### PR TITLE
Prepare release 0.2

### DIFF
--- a/Example/nrf-mesh/app/build.gradle
+++ b/Example/nrf-mesh/app/build.gradle
@@ -30,7 +30,7 @@ android {
         applicationId "no.nordicsemi.android.nrfmeshprovisioner"
         minSdkVersion 18
         targetSdkVersion 27
-        versionCode 2
+        versionCode 3
         versionName "0.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled true

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ElementConfigurationActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ElementConfigurationActivity.java
@@ -27,12 +27,14 @@ import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.CardView;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.Button;
 
 import javax.inject.Inject;
 
@@ -61,7 +63,8 @@ public class ElementConfigurationActivity extends AppCompatActivity implements I
     ViewModelProvider.Factory mViewModelFactory;
     @BindView(R.id.recycler_view_elements)
     RecyclerView mRecyclerViewElements;
-
+    @BindView(R.id.composition_data_card)
+    CardView mCompostionDataCard;
     private ElementConfigurationViewModel mViewModel;
 
 
@@ -84,20 +87,27 @@ public class ElementConfigurationActivity extends AppCompatActivity implements I
         getSupportActionBar().setTitle(R.string.title_elements);
 
         // Set up views
-        final View infoNoElements = findViewById(R.id.no_elements);
+        final Button getCompostionData = findViewById(R.id.action_get_compostion_data);
+
         mRecyclerViewElements.setLayoutManager(new LinearLayoutManager(this));
         final DividerItemDecoration dividerItemDecoration = new DividerItemDecoration(mRecyclerViewElements.getContext(), DividerItemDecoration.VERTICAL);
         mRecyclerViewElements.addItemDecoration(dividerItemDecoration);
 
-        infoNoElements.findViewById(R.id.action_configure).setOnClickListener(v -> mViewModel.startConfiguration());
-
         mViewModel.getExtendedMeshNode().observe(this, extendedMeshNode -> {
             if(extendedMeshNode.hasElements()){
+                mCompostionDataCard.setVisibility(View.INVISIBLE);
                 final ElementAdapter adapter = new ElementAdapter(this, mViewModel.getExtendedMeshNode());
                 adapter.setOnItemClickListener(this);
                 mRecyclerViewElements.setAdapter(adapter);
                 mRecyclerViewElements.setVisibility(View.VISIBLE);
+            } else {
+                mCompostionDataCard.setVisibility(View.VISIBLE);
+                mRecyclerViewElements.setVisibility(View.INVISIBLE);
             }
+        });
+
+        getCompostionData.setOnClickListener(v -> {
+            mViewModel.sendGetCompositionData();
         });
 
         mViewModel.isConnected().observe(this, isConnected -> {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ElementConfigurationActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ElementConfigurationActivity.java
@@ -81,8 +81,7 @@ public class ElementConfigurationActivity extends AppCompatActivity implements I
         final Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-        getSupportActionBar().setTitle(R.string.title_model_configuration);
-        getSupportActionBar().setSubtitle("Model Configuration");
+        getSupportActionBar().setTitle(R.string.title_elements);
 
         // Set up views
         final View infoNoElements = findViewById(R.id.no_elements);

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/MainActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/MainActivity.java
@@ -154,11 +154,6 @@ public class MainActivity extends AppCompatActivity implements Injectable, HasSu
     }
 
     @Override
-    protected void onStart() {
-        super.onStart();
-    }
-
-    @Override
     public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         if(requestCode == Utils.PROVISIONING_SUCCESS){
@@ -175,13 +170,11 @@ public class MainActivity extends AppCompatActivity implements Injectable, HasSu
     public boolean onNavigationItemSelected(@NonNull MenuItem item) {
         final int id = item.getItemId();
         final FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
-        boolean flag = false;
         switch (id) {
             case R.id.action_network:
                 ft.show(mNetworkFragment).hide(mScannerFragment).hide(mSettingsFragment);
                 break;
             case R.id.action_scanner:
-                flag = true;
                 ft.hide(mNetworkFragment).show(mScannerFragment).hide(mSettingsFragment);
                 break;
             case R.id.action_settings:
@@ -189,13 +182,7 @@ public class MainActivity extends AppCompatActivity implements Injectable, HasSu
                 break;
         }
         ft.commit();
-        if(flag){
-            mScannerFragment.startScanning();
-        } else {
-            mScannerFragment.stopScanning();
-        }
         invalidateOptionsMenu();
-
         return true;
     }
 
@@ -225,7 +212,7 @@ public class MainActivity extends AppCompatActivity implements Injectable, HasSu
 
     @Override
     public void onProvisionedMeshNodeSelected() {
-        mScannerFragment.stopScanning();
+
     }
 
     @Override

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/MainActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/MainActivity.java
@@ -38,6 +38,8 @@ import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 
+import java.util.Map;
+
 import javax.inject.Inject;
 
 import butterknife.BindView;
@@ -45,6 +47,7 @@ import butterknife.ButterKnife;
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
 import dagger.android.support.HasSupportFragmentInjector;
+import no.nordicsemi.android.meshprovisioner.configuration.ProvisionedMeshNode;
 import no.nordicsemi.android.nrfmeshprovisioner.di.Injectable;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentResetNetwork;
 import no.nordicsemi.android.nrfmeshprovisioner.utils.Utils;

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/MeshConfigurationActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/MeshConfigurationActivity.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright (c) 2018, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.android.nrfmeshprovisioner;
+
+import android.app.Activity;
+import android.arch.lifecycle.ViewModelProvider;
+import android.arch.lifecycle.ViewModelProviders;
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.design.widget.CoordinatorLayout;
+import android.support.design.widget.Snackbar;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.Toolbar;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+import java.util.Locale;
+import java.util.Map;
+
+import javax.inject.Inject;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import no.nordicsemi.android.meshprovisioner.configuration.ConfigAppKeyStatus;
+import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
+import no.nordicsemi.android.nrfmeshprovisioner.adapter.ExtendedBluetoothDevice;
+import no.nordicsemi.android.nrfmeshprovisioner.adapter.ProvisioningProgressAdapter;
+import no.nordicsemi.android.nrfmeshprovisioner.di.Injectable;
+import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentAppKeyAddStatus;
+import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentAuthenticationInput;
+import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentFlags;
+import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentIvIndex;
+import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentKeyIndex;
+import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentNetworkKey;
+import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentNodeName;
+import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentProvisioningFailedErrorMessage;
+import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentUnicastAddress;
+import no.nordicsemi.android.nrfmeshprovisioner.livedata.ProvisioningStateLiveData;
+import no.nordicsemi.android.nrfmeshprovisioner.utils.ProvisioningProgress;
+import no.nordicsemi.android.nrfmeshprovisioner.utils.Utils;
+import no.nordicsemi.android.nrfmeshprovisioner.viewmodels.MeshProvisionerViewModel;
+
+public class MeshConfigurationActivity extends AppCompatActivity implements Injectable,
+        DialogFragmentAuthenticationInput.ProvisionerInputFragmentListener,
+        DialogFragmentNodeName.DialogFragmentNodeNameListener,
+        DialogFragmentNetworkKey.DialogFragmentNetworkKeyListener,
+        DialogFragmentKeyIndex.DialogFragmentKeyIndexListener,
+        DialogFragmentFlags.DialogFragmentFlagsListener,
+        DialogFragmentIvIndex.DialogFragmentIvIndexListener,
+        DialogFragmentUnicastAddress.DialogFragmentUnicastAddressListener,
+        DialogFragmentProvisioningFailedErrorMessage.DialogFragmentProvisioningFailedErrorListener,
+        DialogFragmentAppKeyAddStatus.DialogFragmentAppKeyAddStatusListener {
+
+    private static final String DIALOG_FRAGMENT_PROVISIONING_FAILED = "DIALOG_FRAGMENT_PROVISIONING_FAILED";
+    private static final String DIALOG_FRAGMENT_AUTH_INPUT_TAG = "DIALOG_FRAGMENT_AUTH_INPUT_TAG";
+    private static final String DIALOG_FRAGMENT_APP_KEY_STATUS = "DIALOG_FRAGMENT_APP_KEY_STATUS";
+
+    @BindView(R.id.container)
+    CoordinatorLayout mCoordinatorLayout;
+    @BindView(R.id.provisioning_progress_bar)
+    ProgressBar mProvisioningProgressBar;
+    @BindView(R.id.data_container)
+    View content;
+
+    @Inject
+    ViewModelProvider.Factory mViewModelFactory;
+
+    private MeshProvisionerViewModel mViewModel;
+
+    @Override
+    protected void onCreate(final Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_mesh_provisioner);
+        ButterKnife.bind(this);
+
+        final Intent intent = getIntent();
+        final ExtendedBluetoothDevice device = intent.getParcelableExtra(Utils.EXTRA_DEVICE);
+        final String deviceName = device.getName();
+        final String deviceAddress = device.getAddress();
+
+        final Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+        getSupportActionBar().setTitle(deviceName);
+        getSupportActionBar().setSubtitle(deviceAddress);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+
+        mViewModel = ViewModelProviders.of(this, mViewModelFactory).get(MeshProvisionerViewModel.class);
+        mViewModel.connect(device);
+        mViewModel.getProvisioningData().setNodeName(deviceName);
+        // Set up views
+        final LinearLayout connectivityProgressContainer = findViewById(R.id.connectivity_progress_container);
+        final TextView connectionState = findViewById(R.id.connection_state);
+        final Button provisioner = findViewById(R.id.action_provision_device);
+        final View provisioningStatusContainer = findViewById(R.id.info_provisioning_status_container);
+
+        final View containerName = findViewById(R.id.container_name);
+        containerName.findViewById(R.id.image).setBackground(ContextCompat.getDrawable(this, R.drawable.ic_vpn_key_black_alpha_24dp));
+        final TextView nameTitle = containerName.findViewById(R.id.title);
+        nameTitle.setText(R.string.summary_name);
+        final TextView nameView = containerName.findViewById(R.id.text);
+        containerName.setOnClickListener(v -> {
+            final String name = mViewModel.getProvisioningData().getNodeName();
+            final DialogFragmentNodeName dialogFragmentNodeName = DialogFragmentNodeName.newInstance(name);
+            dialogFragmentNodeName.show(getSupportFragmentManager(), null);
+        });
+
+        final View containerUnicastAddress = findViewById(R.id.container_unicast_address);
+        containerUnicastAddress.findViewById(R.id.image).setBackground(ContextCompat.getDrawable(this, R.drawable.ic_lan_black_alpha_24dp));
+        final TextView unicastAddressTitle = containerUnicastAddress.findViewById(R.id.title);
+        unicastAddressTitle.setText(R.string.summary_unicast_address);
+        final TextView unicastAddressView = containerUnicastAddress.findViewById(R.id.text);
+        containerUnicastAddress.setOnClickListener(v -> {
+            final int unicastAddress = mViewModel.getProvisioningData().getUnicastAddress();
+            final DialogFragmentUnicastAddress dialogFragmentFlags = DialogFragmentUnicastAddress.newInstance(unicastAddress);
+            dialogFragmentFlags.show(getSupportFragmentManager(), null);
+        });
+
+        final View containerAppKey = findViewById(R.id.container_app_key);
+        containerAppKey.findViewById(R.id.image).setBackground(ContextCompat.getDrawable(this, R.drawable.ic_vpn_key_black_alpha_24dp));
+        final TextView appKeyTitle = containerAppKey.findViewById(R.id.title);
+        appKeyTitle.setText(R.string.summary_app_keys);
+        final TextView appKeyView = containerAppKey.findViewById(R.id.text);
+        containerAppKey.setOnClickListener(v -> {
+            final Map<Integer, String> appKeys = mViewModel.getProvisioningData().getAppKeys();
+            final Intent manageAppKeys = new Intent(MeshConfigurationActivity.this, ManageAppKeysActivity.class);
+            manageAppKeys.putExtra(ManageAppKeysActivity.APP_KEYS, new ArrayList<>(appKeys.values()));
+            startActivityForResult(manageAppKeys, ManageAppKeysActivity.SELECT_APP_KEY);
+        });
+
+        mViewModel.getConnectionState().observe(this, connectionState::setText);
+
+        mViewModel.isConnected().observe(this, connected -> {
+            if(!connected)
+                finish();
+        });
+
+
+        mViewModel.isDeviceReady().observe(this, deviceReady -> {
+            if(deviceReady) {
+                connectivityProgressContainer.setVisibility(View.GONE);
+                if (mViewModel.isProvisioningComplete()) {
+                    mProvisioningProgressBar.setVisibility(View.VISIBLE);
+                    provisioningStatusContainer.setVisibility(View.VISIBLE);
+                    return;
+                }
+                content.setVisibility(View.VISIBLE);
+            }
+        });
+
+        mViewModel.isReconnecting().observe(this, isReconnecting -> {
+            if(isReconnecting){
+                provisioningStatusContainer.setVisibility(View.GONE);
+                content.setVisibility(View.GONE);
+                mProvisioningProgressBar.setVisibility(View.GONE);
+                connectivityProgressContainer.setVisibility(View.VISIBLE);
+            }
+        });
+
+        mViewModel.getProvisioningData().observe(this, provisioningLiveData -> {
+            nameView.setText(provisioningLiveData.getNodeName());
+            if(provisioningLiveData.getProvisioningSettings() != null) {
+                unicastAddressView.setText(getString(R.string.hex_format, String.format(Locale.US, "%04X", provisioningLiveData.getUnicastAddress())));
+                appKeyView.setText(provisioningLiveData.getSelectedAppKey());
+            }
+        });
+
+        provisioner.setOnClickListener(v -> {
+            mProvisioningProgressBar.setVisibility(View.VISIBLE);
+            final String appKey = appKeyView.getText().toString();
+            final int appKeyIndex = Utils.getKey(mViewModel.getProvisioningData().getAppKeys(), appKey);
+            mViewModel.provisionNode(mViewModel.getProvisioningData().getNodeName());
+        });
+        setupProvisionerStateObservers(provisioningStatusContainer);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(final MenuItem item) {
+        switch (item.getItemId()) {
+            case android.R.id.home:
+                onBackPressed();
+                return true;
+        }
+        return false;
+    }
+
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        //We disconnect from the device if the user presses the back button
+        mViewModel.disconnect();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+    }
+
+    @Override
+    protected void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if(requestCode == ManageAppKeysActivity.SELECT_APP_KEY){
+            if(resultCode == RESULT_OK){
+                final String appKey = data.getStringExtra(ManageAppKeysActivity.RESULT);
+                if(appKey != null){
+                    /*mViewModel.getProvisioningData().setSelectedAppKey(appKey);
+                    mViewModel.getProvisioningData().setSelectedAppKeyIndex(appKeyIndex);*/
+
+                    final int appKeyIndex = Utils.getKey(mViewModel.getProvisioningData().getAppKeys(), appKey);
+                    mViewModel.setSelectedAppKey(appKeyIndex, appKey);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void onPinInputComplete(final String pin) {
+        mViewModel.sendProvisioneePin(pin);
+    }
+
+    @Override
+    public void onPinInputCanceled() {
+        final String message = getString(R.string.provisioning_cancelled);
+        final Snackbar snackbar = Snackbar.make(mCoordinatorLayout, message, Snackbar.LENGTH_LONG);
+        snackbar.show();
+        mViewModel.disconnect();
+    }
+
+    @Override
+    public void onNodeNameUpdated(final String nodeName) {
+        mViewModel.getProvisioningData().setNodeName(nodeName);
+    }
+
+    @Override
+    public void onNetworkKeyGenerated(final String networkKey) {
+        mViewModel.getProvisioningData().setNetworkKey(networkKey);
+    }
+
+    @Override
+    public void onKeyIndexGenerated(final int keyIndex) {
+        mViewModel.getProvisioningData().setKeyIndex(keyIndex);
+    }
+
+    @Override
+    public void onFlagsSelected(final int keyRefreshFlag, final int ivUpdateFlag) {
+        mViewModel.getProvisioningData().setFlags(MeshParserUtils.parseUpdateFlags(keyRefreshFlag, ivUpdateFlag));
+    }
+
+    @Override
+    public void setIvIndex(final int ivIndex) {
+        mViewModel.getProvisioningData().setIvIndex(ivIndex);
+    }
+
+    @Override
+    public void setUnicastAddress(final int unicastAddress) {
+        mViewModel.getProvisioningData().setUnicastAddress(unicastAddress);
+    }
+
+    @Override
+    public void onProvisioningFailed() {
+        //Provisioning failed so now we go back to the scanner page.
+        mViewModel.disconnect();
+        finish();
+    }
+
+    public void setupProvisionerStateObservers(final View provisioningStatusContainer){
+        provisioningStatusContainer.setVisibility(View.VISIBLE);
+
+        final RecyclerView recyclerView = provisioningStatusContainer.findViewById(R.id.recycler_view_provisioning_progress);
+        recyclerView.setLayoutManager(new LinearLayoutManager(this));
+        final ProvisioningProgressAdapter adapter = new ProvisioningProgressAdapter(this, mViewModel.getProvisioningState());
+        recyclerView.setAdapter(adapter);
+
+        mViewModel.getProvisioningState().observe(this, provisioningStateLiveData -> {
+            final ProvisioningProgress provisionerProgress = provisioningStateLiveData.getProvisionerProgress();
+            adapter.refresh(provisioningStateLiveData.getStateList());
+            if(provisionerProgress != null) {
+                final ProvisioningStateLiveData.ProvisioningLiveDataState state = provisionerProgress.getState();
+                switch (state) {
+                    case PROVISIONING_FAILED:
+                        if (getSupportFragmentManager().findFragmentByTag(DIALOG_FRAGMENT_PROVISIONING_FAILED) == null) {
+                            final String statusMessage = ConfigAppKeyStatus.parseStatusMessage(getApplicationContext(), provisionerProgress.getStatusReceived());
+                            DialogFragmentProvisioningFailedErrorMessage message = DialogFragmentProvisioningFailedErrorMessage.newInstance(getString(R.string.title_error_provisioning_failed), statusMessage);
+                            message.show(getSupportFragmentManager(), DIALOG_FRAGMENT_PROVISIONING_FAILED);
+                        }
+                        break;
+                    case PROVISIONING_AUTHENTICATION_INPUT_WAITING:
+                        final android.support.v4.app.Fragment fragment = getSupportFragmentManager().findFragmentByTag(DIALOG_FRAGMENT_AUTH_INPUT_TAG);
+                        if (fragment == null) {
+                            DialogFragmentAuthenticationInput dialogFragmentAuthenticationInput = DialogFragmentAuthenticationInput.newInstance();
+                            dialogFragmentAuthenticationInput.show(getSupportFragmentManager(), DIALOG_FRAGMENT_AUTH_INPUT_TAG);
+                        }
+                        break;
+                    case APP_KEY_STATUS_RECEIVED:
+                        if (getSupportFragmentManager().findFragmentByTag(DIALOG_FRAGMENT_APP_KEY_STATUS) == null) {
+                            final String statusMessage = ConfigAppKeyStatus.parseStatusMessage(getApplicationContext(), provisionerProgress.getStatusReceived());
+                            DialogFragmentAppKeyAddStatus fragmentAppKeyAddStatus = DialogFragmentAppKeyAddStatus.newInstance(getString(R.string.title_configuration_compete), getString(R.string.configuration_complete_summary));
+                            fragmentAppKeyAddStatus.show(getSupportFragmentManager(), DIALOG_FRAGMENT_APP_KEY_STATUS);
+                        }
+                        break;
+                }
+
+            }
+            content.setVisibility(View.GONE);
+        });
+
+    }
+
+    @Override
+    public void onAppKeyAddStatusReceived() {
+        Intent returnIntent = new Intent();
+        returnIntent.putExtra("result", mViewModel.isProvisioningComplete());
+        setResult(Activity.RESULT_OK, returnIntent);
+        finish();
+    }
+}

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/MeshProvisionerActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/MeshProvisionerActivity.java
@@ -186,15 +186,17 @@ public class MeshProvisionerActivity extends AppCompatActivity implements Inject
 
         mViewModel.getProvisioningData().observe(this, provisioningLiveData -> {
             nameView.setText(provisioningLiveData.getNodeName());
-            unicastAddressView.setText(getString(R.string.hex_format, String.format(Locale.US, "%04X", provisioningLiveData.getUnicastAddress())));
-            appKeyView.setText(provisioningLiveData.getSelectedAppKey());
+            if(provisioningLiveData.getProvisioningSettings() != null) {
+                unicastAddressView.setText(getString(R.string.hex_format, String.format(Locale.US, "%04X", provisioningLiveData.getUnicastAddress())));
+                appKeyView.setText(provisioningLiveData.getSelectedAppKey());
+            }
         });
 
         provisioner.setOnClickListener(v -> {
             mProvisioningProgressBar.setVisibility(View.VISIBLE);
             final String appKey = appKeyView.getText().toString();
             final int appKeyIndex = Utils.getKey(mViewModel.getProvisioningData().getAppKeys(), appKey);
-            mViewModel.provisionNode(appKey, appKeyIndex);
+            mViewModel.provisionNode(mViewModel.getProvisioningData().getNodeName());
         });
         setupProvisionerStateObservers(provisioningStatusContainer);
     }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/NetworkFragment.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/NetworkFragment.java
@@ -96,7 +96,7 @@ public class NetworkFragment extends Fragment implements Injectable, NodeAdapter
     @Override
     public void onStart() {
         super.onStart();
-        updateNodeList();
+        mViewModel.getProvisionedNodes();
     }
 
     @Override
@@ -118,7 +118,4 @@ public class NetworkFragment extends Fragment implements Injectable, NodeAdapter
         getActivity().startActivity(meshConfigurationIntent);
     }
 
-    private void updateNodeList(){
-        mViewModel.updateProvisionedNodes();
-    }
 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/NetworkFragment.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/NetworkFragment.java
@@ -96,7 +96,7 @@ public class NetworkFragment extends Fragment implements Injectable, NodeAdapter
     @Override
     public void onStart() {
         super.onStart();
-        mViewModel.getProvisionedNodes();
+        mViewModel.refreshProvisionedNodes();
     }
 
     @Override

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/NodeDetailsActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/NodeDetailsActivity.java
@@ -107,13 +107,20 @@ public class NodeDetailsActivity extends AppCompatActivity implements Injectable
         final TextView features = containerFeatures.findViewById(R.id.text);
         features.setText(CompositionDataParser.formatFeatures(node.getFeatures(), false));
 
+        final TextView view =  findViewById(R.id.no_elements_view);
         mRecyclerView = findViewById(R.id.recycler_view_elements);
-        final LinearLayoutManager linearLayoutManager = new LinearLayoutManager(this);
-        mRecyclerView.setLayoutManager(linearLayoutManager);
-        final ElementAdapterDetails adapter = new ElementAdapterDetails(this, new ArrayList<>(node.getElements().values()));
-        adapter.setOnItemClickListener(this);
-        mRecyclerView.setAdapter(adapter);
-
+        if(node.getElements().isEmpty()){
+            view.setVisibility(View.VISIBLE);
+            mRecyclerView.setVisibility(View.INVISIBLE);
+        } else {
+            view.setVisibility(View.INVISIBLE);
+            mRecyclerView.setVisibility(View.VISIBLE);
+            final LinearLayoutManager linearLayoutManager = new LinearLayoutManager(this);
+            mRecyclerView.setLayoutManager(linearLayoutManager);
+            final ElementAdapterDetails adapter = new ElementAdapterDetails(this, node/*new ArrayList<>(node.getElements().values())*/);
+            adapter.setOnItemClickListener(this);
+            mRecyclerView.setAdapter(adapter);
+        }
     }
 
     @Override

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ProvisionedNodesScannerActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ProvisionedNodesScannerActivity.java
@@ -141,6 +141,7 @@ public class ProvisionedNodesScannerActivity extends AppCompatActivity implement
 
 	@Override
 	public void onItemClick(final ExtendedBluetoothDevice device) {
+		stopScan();
 		final Intent meshProvisionerIntent = new Intent(this, ReconnectActivity.class);
 		meshProvisionerIntent.putExtra(Utils.EXTRA_DEVICE, device);
 		startActivityForResult(meshProvisionerIntent, ReconnectActivity.REQUEST_DEVICE_READY);

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ReconnectActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ReconnectActivity.java
@@ -102,6 +102,12 @@ public class ReconnectActivity extends AppCompatActivity implements Injectable {
     }
 
 	@Override
+	public void onBackPressed() {
+		super.onBackPressed();
+		mReconnectViewModel.disconnect();
+	}
+
+	@Override
 	protected void onStop() {
 		super.onStop();
 	}

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ScannerFragment.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ScannerFragment.java
@@ -123,8 +123,10 @@ public class ScannerFragment extends Fragment implements Injectable, DevicesAdap
     public void onHiddenChanged(final boolean hidden) {
         super.onHiddenChanged(hidden);
         if(hidden){
+            stopScan();
             mScannerFragmentListener.hideProgressBar();
         } else {
+            startScanning();
             if(mSharedViewModel.getScannerRepository().getScannerState().isScanning()){
                 mScannerFragmentListener.showProgressBar();
             } else {
@@ -195,15 +197,11 @@ public class ScannerFragment extends Fragment implements Injectable, DevicesAdap
         startActivity(intent);
     }
 
-    public void startScanning(){
+    private void startScanning(){
         mSharedViewModel.getScannerRepository().getScannerState().startScanning();
         // Create view model containing utility methods for scanning
         mSharedViewModel.getScannerRepository().getScannerState().observe(this, this::startScan);
         Log.v(TAG, "scan started");
-    }
-
-    public void stopScanning() {
-        stopScan();
     }
 
     /**
@@ -220,7 +218,6 @@ public class ScannerFragment extends Fragment implements Injectable, DevicesAdap
                 // We are now OK to start scanning
                 if(state.isScanRequested())
                     if(!state.isScanning()) {
-                        Log.v(TAG, "NOT SCANNING YET..STARTING SCAN");
                         mSharedViewModel.getScannerRepository().startScan(BleMeshManager.MESH_PROVISIONING_UUID);
                     }
 

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ScannerFragment.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ScannerFragment.java
@@ -124,14 +124,8 @@ public class ScannerFragment extends Fragment implements Injectable, DevicesAdap
         super.onHiddenChanged(hidden);
         if(hidden){
             stopScan();
-            mScannerFragmentListener.hideProgressBar();
         } else {
             startScanning();
-            if(mSharedViewModel.getScannerRepository().getScannerState().isScanning()){
-                mScannerFragmentListener.showProgressBar();
-            } else {
-                mScannerFragmentListener.hideProgressBar();
-            }
         }
     }
 

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ScannerFragment.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ScannerFragment.java
@@ -195,7 +195,6 @@ public class ScannerFragment extends Fragment implements Injectable, DevicesAdap
         mSharedViewModel.getScannerRepository().getScannerState().startScanning();
         // Create view model containing utility methods for scanning
         mSharedViewModel.getScannerRepository().getScannerState().observe(this, this::startScan);
-        Log.v(TAG, "scan started");
     }
 
     /**
@@ -212,6 +211,7 @@ public class ScannerFragment extends Fragment implements Injectable, DevicesAdap
                 // We are now OK to start scanning
                 if(state.isScanRequested())
                     if(!state.isScanning()) {
+                        Log.v(TAG, "scan started");
                         mSharedViewModel.getScannerRepository().startScan(BleMeshManager.MESH_PROVISIONING_UUID);
                     }
 
@@ -250,11 +250,9 @@ public class ScannerFragment extends Fragment implements Injectable, DevicesAdap
      * stop scanning for bluetooth devices.
      */
     private void stopScan() {
-        if(mSharedViewModel.getScannerRepository().getScannerState().isScanning()) {
-            mSharedViewModel.getScannerRepository().getScannerState().stopScanning();
-            mSharedViewModel.getScannerRepository().stopScan();
-            mScannerFragmentListener.hideProgressBar();
-            Log.v(TAG, "stopping scan");
-        }
+        mSharedViewModel.getScannerRepository().getScannerState().stopScanning();
+        mSharedViewModel.getScannerRepository().stopScan();
+        mScannerFragmentListener.hideProgressBar();
+        Log.v(TAG, "stopping scan");
     }
 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/SettingsFragment.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/SettingsFragment.java
@@ -171,15 +171,17 @@ public class SettingsFragment extends Fragment implements Injectable,
         });
 
        mViewModel.getProvisioningData().observe(this, provisioningData -> {
-           networkNameView.setText(provisioningData.getNetworkName());
-           globalTtlView.setText(String.valueOf(provisioningData.getGlobalTtl()));
-           keyView.setText(getString(R.string.hex_format, provisioningData.getNetworkKey()));
-           keyIndexView.setText(getString(R.string.hex_format, String.format(Locale.US, "%03X", provisioningData.getKeyIndex())));
-           flagsView.setText(parseFlagsMessage(provisioningData.getFlags()));
-           ivIndexView.setText(getString(R.string.hex_format, String.format(Locale.US, "%08X", provisioningData.getIvIndex())));
-           mViewModel.saveApplicationKeys(provisioningData.getAppKeys());
-           unicastAddressView.setText(getString(R.string.hex_format, String.format(Locale.US, "%04X", provisioningData.getUnicastAddress())));
-           manageAppKeysView.setText(getString(R.string.app_key_count, provisioningData.getAppKeys().size()));
+           if(provisioningData.getProvisioningSettings() != null) {
+               networkNameView.setText(provisioningData.getNetworkName());
+               globalTtlView.setText(String.valueOf(provisioningData.getGlobalTtl()));
+               keyView.setText(getString(R.string.hex_format, provisioningData.getNetworkKey()));
+               keyIndexView.setText(getString(R.string.hex_format, String.format(Locale.US, "%03X", provisioningData.getKeyIndex())));
+               flagsView.setText(parseFlagsMessage(provisioningData.getFlags()));
+               ivIndexView.setText(getString(R.string.hex_format, String.format(Locale.US, "%08X", provisioningData.getIvIndex())));
+               mViewModel.saveApplicationKeys(provisioningData.getAppKeys());
+               unicastAddressView.setText(getString(R.string.hex_format, String.format(Locale.US, "%04X", provisioningData.getUnicastAddress())));
+               manageAppKeysView.setText(getString(R.string.app_key_count, provisioningData.getAppKeys().size()));
+           }
        });
         return rootView;
 
@@ -205,7 +207,7 @@ public class SettingsFragment extends Fragment implements Injectable,
 
     @Override
     public void onNetworkNameEntered(final String networkName) {
-        mViewModel.getProvisioningData().setNetworkName(networkName);
+        mViewModel.getProvisioningData().setNetworkName(getContext(), networkName);
     }
 
     @Override

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/ElementAdapterDetails.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/ElementAdapterDetails.java
@@ -39,6 +39,7 @@ import java.util.List;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import no.nordicsemi.android.meshprovisioner.configuration.MeshModel;
+import no.nordicsemi.android.meshprovisioner.configuration.ProvisionedMeshNode;
 import no.nordicsemi.android.meshprovisioner.models.VendorModel;
 import no.nordicsemi.android.meshprovisioner.utils.CompositionDataParser;
 import no.nordicsemi.android.meshprovisioner.utils.Element;
@@ -47,12 +48,14 @@ import no.nordicsemi.android.nrfmeshprovisioner.R;
 public class ElementAdapterDetails extends RecyclerView.Adapter<ElementAdapterDetails.ViewHolder> {
 
     private final Context mContext;
-    private final List<Element> mElements;
+    private final List<Element> mElements = new ArrayList<>();
     private OnItemClickListener mOnItemClickListener;
 
-    public ElementAdapterDetails(final Context mContext, final List<Element> elements) {
+    public ElementAdapterDetails(final Context mContext, final ProvisionedMeshNode node) {
         this.mContext = mContext;
-        mElements = elements;
+        if(node != null  && node.getElements() != null) {
+            mElements.addAll(new ArrayList<>(node.getElements().values()));
+        }
     }
 
 

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/NodeAdapter.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/NodeAdapter.java
@@ -53,7 +53,7 @@ public class NodeAdapter extends RecyclerView.Adapter<NodeAdapter.ViewHolder>{
         this.mContext = fragmentActivity;
         provisionedNodesLiveData.observe(fragmentActivity, provisionedNodesLiveData1 -> {
             final Map<Integer, ProvisionedMeshNode> nodes = provisionedNodesLiveData1.getProvisionedNodes();
-            if(nodes != null /*&& !nodes.isEmpty()*/){
+            if(nodes != null){
                 mNodes.clear();
                 mNodes.addAll(nodes.values());
             }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/NodeAdapter.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/NodeAdapter.java
@@ -78,11 +78,13 @@ public class NodeAdapter extends RecyclerView.Adapter<NodeAdapter.ViewHolder>{
         holder.unicastAddress.setText(MeshParserUtils.bytesToHex(node.getUnicastAddress(), false));
         final Map<Integer, Element> elements = node.getElements();
         if(elements != null && !elements.isEmpty()) {
+            holder.notConfiguredView.setVisibility(View.GONE);
             holder.companyIdentifier.setText(CompanyIdentifiers.getCompanyName((short) node.getCompanyIdentifier()));
             holder.elements.setText(String.valueOf(elements.size()));
             holder.models.setText(String.valueOf(getModels(elements)));
         } else {
             holder.nodeInfoContainer.setVisibility(View.GONE);
+            holder.notConfiguredView.setVisibility(View.VISIBLE);
         }
     }
 
@@ -126,6 +128,8 @@ public class NodeAdapter extends RecyclerView.Adapter<NodeAdapter.ViewHolder>{
         TextView elements;
         @BindView(R.id.models)
         TextView models;
+        @BindView(R.id.not_configured_view)
+        View notConfiguredView;
         @BindView(R.id.action_configure)
         Button configure;
         @BindView(R.id.action_details)

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/NodeAdapter.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/NodeAdapter.java
@@ -79,6 +79,7 @@ public class NodeAdapter extends RecyclerView.Adapter<NodeAdapter.ViewHolder>{
         final Map<Integer, Element> elements = node.getElements();
         if(elements != null && !elements.isEmpty()) {
             holder.notConfiguredView.setVisibility(View.GONE);
+            holder.nodeInfoContainer.setVisibility(View.VISIBLE);
             holder.companyIdentifier.setText(CompanyIdentifiers.getCompanyName((short) node.getCompanyIdentifier()));
             holder.elements.setText(String.valueOf(elements.size()));
             holder.models.setText(String.valueOf(getModels(elements)));

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/livedata/ProvisionedNodesLiveData.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/livedata/ProvisionedNodesLiveData.java
@@ -24,14 +24,13 @@ package no.nordicsemi.android.nrfmeshprovisioner.livedata;
 
 import android.arch.lifecycle.LiveData;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import no.nordicsemi.android.meshprovisioner.configuration.ProvisionedMeshNode;
-import no.nordicsemi.android.meshprovisioner.utils.AddressUtils;
 
 public class ProvisionedNodesLiveData extends LiveData<ProvisionedNodesLiveData> {
-    private final Map<Integer, ProvisionedMeshNode> mProvisionedNodesMap = new HashMap<>();
+    private final LinkedHashMap<Integer, ProvisionedMeshNode> mProvisionedNodesMap = new LinkedHashMap<>();
 
     public ProvisionedNodesLiveData(){
     }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/livedata/ProvisionedNodesLiveData.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/livedata/ProvisionedNodesLiveData.java
@@ -45,7 +45,6 @@ public class ProvisionedNodesLiveData extends LiveData<ProvisionedNodesLiveData>
 
     public void updateProvisionedNodes(final Map<Integer, ProvisionedMeshNode> provisionedNodes) {
         mProvisionedNodesMap.clear();
-        postValue(this);
         mProvisionedNodesMap.putAll(provisionedNodes);
         postValue(this);
     }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/livedata/ProvisioningLiveData.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/livedata/ProvisioningLiveData.java
@@ -23,6 +23,8 @@
 package no.nordicsemi.android.nrfmeshprovisioner.livedata;
 
 import android.arch.lifecycle.LiveData;
+import android.content.Context;
+import android.content.SharedPreferences;
 
 import java.util.Map;
 
@@ -31,35 +33,51 @@ import no.nordicsemi.android.meshprovisioner.ProvisioningSettings;
 public class ProvisioningLiveData extends LiveData<ProvisioningLiveData>  {
 
     private ProvisioningSettings mProvisioningSettings;
+    protected String networkName = "nRF Mesh Network";
+    private String nodeName = "nRF Mesh Node";
     private String selectedAppKey;
+    private String NETWORK_NAME_PREFS = "NETWORK_NAME_PREFS";
+    private String NETWORK_NAME = "NETWORK_NAME";
 
-    public ProvisioningLiveData(final ProvisioningSettings provisioningSettings){
+    public ProvisioningLiveData(){
+        postValue(this);
+    }
+
+    public ProvisioningSettings getProvisioningSettings() {
+        return mProvisioningSettings;
+    }
+
+    public void loadProvisioningData(final Context context, final ProvisioningSettings provisioningSettings){
         this.mProvisioningSettings = provisioningSettings;
+        loadNetworkName(context);
         postValue(this);
     }
 
     public void refreshProvisioningData(final ProvisioningSettings provisioningSettings) {
         this.mProvisioningSettings = provisioningSettings;
+        networkName = "nRF Mesh Network";
+        nodeName = "nRF Mesh Node";
         postValue(this);
     }
 
     public void setNodeName(final String nodeName) {
         if(nodeName != null && !nodeName.isEmpty()) {
-            mProvisioningSettings.setNodeName(nodeName);
+            this.nodeName = nodeName;
             postValue(this);
         }
     }
 
     public String getNodeName() {
-        return mProvisioningSettings.getNodeName();
+        return nodeName;
     }
 
     public String getNetworkName() {
-        return mProvisioningSettings.getNetworkName();
+        return networkName;
     }
 
-    public void setNetworkName(final String name) {
-        mProvisioningSettings.setNetworkName(name);
+    public void setNetworkName(final Context context, final String name) {
+        this.networkName = name;
+        saveNetworkName(context);
         postValue(this);
     }
 
@@ -134,5 +152,17 @@ public class ProvisioningLiveData extends LiveData<ProvisioningLiveData>  {
     public void setSelectedAppKey(final String appKey){
         this.selectedAppKey = appKey;
         postValue(this);
+    }
+
+    private void loadNetworkName(final Context context) {
+        final SharedPreferences preferences = context.getSharedPreferences(NETWORK_NAME_PREFS, Context.MODE_PRIVATE);
+        networkName = preferences.getString(NETWORK_NAME, networkName);
+    }
+
+    private void saveNetworkName(final Context context) {
+        final SharedPreferences preferences = context.getSharedPreferences(NETWORK_NAME_PREFS, Context.MODE_PRIVATE);
+        final SharedPreferences.Editor editor = preferences.edit();
+        editor.putString(NETWORK_NAME, networkName);
+        editor.apply();
     }
 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/BaseMeshRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/BaseMeshRepository.java
@@ -106,17 +106,18 @@ public abstract class BaseMeshRepository {
     final ConfigModelSubscriptionStatusLiveData mConfigModelSubscriptionStatus = new ConfigModelSubscriptionStatusLiveData();
 
     /** Contains the initial provisioning live data **/
-    ProvisioningLiveData mProvisioningLiveData;
+    final ProvisioningLiveData mProvisioningLiveData = new ProvisioningLiveData();
 
     /** Contains the provisioned nodes **/
     final ProvisionedNodesLiveData mProvisionedNodesLiveData = new ProvisionedNodesLiveData();
 
-    final MeshManagerApi mMeshManagerApi;
+    //final MeshManagerApi mMeshManagerApi;
     final ProvisioningStateLiveData mProvisioningStateLiveData;
     private final Gson mGson;
     private final Handler mHandler;
 
     MeshService.MeshServiceBinder mBinder;
+    protected MeshManagerApi mMeshManagerApi;
     private boolean mIsBound;
 
     private ServiceConnection mServiceConnection = new ServiceConnection() {
@@ -125,6 +126,8 @@ public abstract class BaseMeshRepository {
             mBinder = (MeshService.MeshServiceBinder) service;
             if (mBinder != null) {
                 mIsBound = true;
+                mMeshManagerApi = mBinder.getMeshManagerApi();
+                mProvisioningLiveData.loadProvisioningData(mContext, mBinder.getProvisioningSettings());
                 mProvisionedNodesLiveData.updateProvisionedNodes(mBinder.getProvisionedNodes());
                 if(mExtendedMeshNode != null) {
                     final ProvisionedMeshNode node = mExtendedMeshNode.getMeshNode();
@@ -192,8 +195,8 @@ public abstract class BaseMeshRepository {
         context.bindService(intent, mServiceConnection, 0);
         mContext = context;
         mHandler = new Handler();
-        mMeshManagerApi = MeshManagerApi.getInstance(context);
-        mProvisioningLiveData = new ProvisioningLiveData(mMeshManagerApi.getProvisioningSettings());
+        //mMeshManagerApi = MeshManagerApi.getInstance(context);
+        //mProvisioningLiveData = new ProvisioningLiveData(context, mMeshManagerApi.getProvisioningSettings());
         mProvisioningStateLiveData = new ProvisioningStateLiveData();
         mIsReconnecting.postValue(false);
         final GsonBuilder gsonBuilder = new GsonBuilder();
@@ -310,7 +313,7 @@ public abstract class BaseMeshRepository {
     public void resetMeshNetwork() {
         mBinder.disconnect();
         mBinder.resetMeshNetwork();
-        mProvisioningLiveData.refreshProvisioningData(mMeshManagerApi.getProvisioningSettings());
+        mProvisioningLiveData.refreshProvisioningData(mBinder.getProvisioningSettings());
         mProvisionedNodesLiveData.clearNodes();
         mExtendedMeshNode = null;
     }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/BaseMeshRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/BaseMeshRepository.java
@@ -37,6 +37,8 @@ import android.support.v4.content.LocalBroadcastManager;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import java.util.Map;
+
 import no.nordicsemi.android.meshprovisioner.MeshManagerApi;
 import no.nordicsemi.android.meshprovisioner.configuration.ProvisionedMeshNode;
 import no.nordicsemi.android.meshprovisioner.configuration.MeshModel;
@@ -114,7 +116,6 @@ public abstract class BaseMeshRepository {
     //final MeshManagerApi mMeshManagerApi;
     final ProvisioningStateLiveData mProvisioningStateLiveData;
     protected final Handler mHandler;
-
     MeshService.MeshServiceBinder mBinder;
     protected MeshManagerApi mMeshManagerApi;
     private boolean mIsBound;
@@ -132,7 +133,7 @@ public abstract class BaseMeshRepository {
                     final ProvisionedMeshNode node = mExtendedMeshNode.getMeshNode();
                     final ProvisionedMeshNode meshNode = mBinder.getMeshNode(AddressUtils.getUnicastAddressInt(node.getUnicastAddress()));
                     if (meshNode != null) {
-                        mExtendedMeshNode = new ExtendedMeshNode(meshNode);
+                        mExtendedMeshNode.updateMeshNode(meshNode);
                     }
                 } else {
                     final ProvisionedMeshNode meshNode = mBinder.getMeshNode();

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/BaseMeshRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/BaseMeshRepository.java
@@ -113,8 +113,7 @@ public abstract class BaseMeshRepository {
 
     //final MeshManagerApi mMeshManagerApi;
     final ProvisioningStateLiveData mProvisioningStateLiveData;
-    private final Gson mGson;
-    private final Handler mHandler;
+    protected final Handler mHandler;
 
     MeshService.MeshServiceBinder mBinder;
     protected MeshManagerApi mMeshManagerApi;
@@ -199,11 +198,6 @@ public abstract class BaseMeshRepository {
         //mProvisioningLiveData = new ProvisioningLiveData(context, mMeshManagerApi.getProvisioningSettings());
         mProvisioningStateLiveData = new ProvisioningStateLiveData();
         mIsReconnecting.postValue(false);
-        final GsonBuilder gsonBuilder = new GsonBuilder();
-        gsonBuilder.enableComplexMapKeySerialization();
-        gsonBuilder.registerTypeAdapter(MeshModel.class, new InterfaceAdapter<MeshModel>());
-        gsonBuilder.setPrettyPrinting();
-        mGson = gsonBuilder.create();
     }
 
     public void unbindService(){

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/BaseMeshRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/BaseMeshRepository.java
@@ -219,6 +219,10 @@ public abstract class BaseMeshRepository {
 
     public abstract void onConfigurationStateChanged(final Intent intent);
 
+    public ProvisioningLiveData getProvisioningData(){
+        return mProvisioningLiveData;
+    }
+
     /**
      * Registers a broadcast receiver to receive events from the {@link MeshService}
      */
@@ -319,5 +323,9 @@ public abstract class BaseMeshRepository {
 
     public String getSelectedAppKey() {
         return mBinder.getSelectedAppKey();
+    }
+
+    public void addAppKey(final int appKeyIndex, final String appKey) {
+        mBinder.sendAppKeyAdd(appKeyIndex, appKey);
     }
 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ElementConfigurationRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ElementConfigurationRepository.java
@@ -32,6 +32,15 @@ import no.nordicsemi.android.meshprovisioner.configuration.ProvisionedMeshNode;
 import no.nordicsemi.android.meshprovisioner.configuration.MeshModel;
 import no.nordicsemi.android.nrfmeshprovisioner.livedata.ProvisioningStateLiveData;
 import no.nordicsemi.android.nrfmeshprovisioner.livedata.ExtendedMeshNode;
+import no.nordicsemi.android.nrfmeshprovisioner.viewmodels.MeshNodeStates;
+
+import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_APP_KEY_INDEX;
+import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_CONFIGURATION_STATE;
+import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_ELEMENT_ADDRESS;
+import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_IS_SUCCESS;
+import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_MODEL_ID;
+import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_PUBLISH_ADDRESS;
+import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_STATUS;
 
 public class ElementConfigurationRepository extends BaseMeshRepository {
 
@@ -64,12 +73,11 @@ public class ElementConfigurationRepository extends BaseMeshRepository {
 
     @Override
     public void onProvisioningStateChanged(final Intent intent) {
-
     }
 
     @Override
     public void onConfigurationStateChanged(final Intent intent) {
-
+        handleConfigurationStates(intent);
     }
 
     public LiveData<Boolean> isConnected() {
@@ -108,4 +116,33 @@ public class ElementConfigurationRepository extends BaseMeshRepository {
         mBinder.sendCompositionDataGet(mExtendedMeshNode.getMeshNode());
     }
 
+    private void handleConfigurationStates(final Intent intent){
+        final int state = intent.getExtras().getInt(EXTRA_CONFIGURATION_STATE);
+        final MeshNodeStates.MeshNodeStatus status = MeshNodeStates.MeshNodeStatus.fromStatusCode(state);
+        final ProvisionedMeshNode node = mBinder.getMeshNode();
+        switch (status) {
+            case COMPOSITION_DATA_GET_SENT:
+                mExtendedMeshNode.updateMeshNode(node);
+                break;
+            case COMPOSITION_DATA_STATUS_RECEIVED:
+                mExtendedMeshNode.updateMeshNode(node);
+                break;
+            case SENDING_BLOCK_ACKNOWLEDGEMENT:
+                mExtendedMeshNode.updateMeshNode(node);
+                break;
+            case BLOCK_ACKNOWLEDGEMENT_RECEIVED:
+                mExtendedMeshNode.updateMeshNode(node);
+                break;
+            case SENDING_APP_KEY_ADD:
+                mExtendedMeshNode.updateMeshNode(node);
+                break;
+            case APP_KEY_STATUS_RECEIVED:
+                if(intent.getExtras() != null) {
+                    final int statusCode = intent.getExtras().getInt(EXTRA_STATUS);
+                    mExtendedMeshNode.updateMeshNode(node);
+                    mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state, statusCode);
+                }
+                break;
+        }
+    }
 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/MeshProvisionerRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/MeshProvisionerRepository.java
@@ -94,10 +94,6 @@ public class MeshProvisionerRepository extends BaseMeshRepository {
         return mProvisioningStateLiveData;
     }
 
-    public ProvisioningLiveData getProvisioningData(){
-        return mProvisioningLiveData;
-    }
-
     public ExtendedMeshNode getExtendedMeshNode() {
         return mExtendedMeshNode.getValue();
     }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/MeshProvisionerRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/MeshProvisionerRepository.java
@@ -197,7 +197,7 @@ public class MeshProvisionerRepository extends BaseMeshRepository {
         switch (status) {
             case COMPOSITION_DATA_GET_SENT:
                 mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);
-                mExtendedMeshNode = new ExtendedMeshNode(node);
+                mExtendedMeshNode.updateMeshNode(node);
                 break;
             case COMPOSITION_DATA_STATUS_RECEIVED:
                 mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/MeshProvisionerRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/MeshProvisionerRepository.java
@@ -263,8 +263,8 @@ public class MeshProvisionerRepository extends BaseMeshRepository {
         mContext.startService(intent);
     }
 
-    public void startProvisioning() {
-        mBinder.startProvisioning();
+    public void startProvisioning(final String nodeName) {
+        mBinder.startProvisioning(nodeName);
     }
 
     public void confirmProvisioning(final String pin) {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/MeshRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/MeshRepository.java
@@ -113,7 +113,7 @@ public class MeshRepository extends BaseMeshRepository {
         Utils.saveApplicationKeys(mContext, appKeys);
     }
 
-    public void getProvisionedNodes(){
+    public void refreshProvisionedNodes(){
         if(mBinder != null) {
             Map<Integer, ProvisionedMeshNode> nodes = mBinder.getProvisionedNodes();
             if(!nodes.isEmpty()) {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ProvisionedNodesScannerRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ProvisionedNodesScannerRepository.java
@@ -32,10 +32,12 @@ import android.os.ParcelUuid;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import no.nordicsemi.android.meshprovisioner.configuration.ProvisionedMeshNode;
 import no.nordicsemi.android.nrfmeshprovisioner.ble.BleMeshManager;
 import no.nordicsemi.android.nrfmeshprovisioner.livedata.ScannerLiveData;
 import no.nordicsemi.android.nrfmeshprovisioner.utils.Utils;
@@ -215,9 +217,16 @@ public class ProvisionedNodesScannerRepository extends BaseMeshRepository {
             if (scanRecord != null) {
                 final byte[] serviceData = scanRecord.getServiceData(new ParcelUuid((MESH_PROXY_UUID)));
                 if (serviceData != null) {
-                    if(mMeshManagerApi != null)
-                    if (mMeshManagerApi.networkIdMatches(mNetworkId, serviceData)) {
-                        mScannerLiveData.deviceDiscovered(result);
+                    if (mMeshManagerApi != null) {
+                        if (mMeshManagerApi.isAdvertisingWithNetworkIdentity(serviceData)) {
+                            if(mMeshManagerApi.networkIdMatches(mNetworkId, serviceData)) {
+                                mScannerLiveData.deviceDiscovered(result);
+                            }
+                        } else if (mMeshManagerApi.isAdvertisedWithNodeIdentity(serviceData)) {
+                            if(checkIfNodeIdentityMatches(serviceData)){
+                                mScannerLiveData.deviceDiscovered(result);
+                            }
+                        }
                     }
                 }
             }
@@ -234,4 +243,18 @@ public class ProvisionedNodesScannerRepository extends BaseMeshRepository {
             mScannerLiveData.scanningStopped();
         }
     };
+
+    private boolean checkIfNodeIdentityMatches(final byte[] serviceData){
+        if(mBinder != null) {
+            for(Map.Entry<Integer, ProvisionedMeshNode> node : mProvisionedNodesLiveData.getProvisionedNodes().entrySet()){
+                if(mMeshManagerApi != null) {
+                    if(mMeshManagerApi.nodeIdentityMatches(node.getValue(), serviceData)){
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+
+    }
 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ProvisionedNodesScannerRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ProvisionedNodesScannerRepository.java
@@ -196,10 +196,12 @@ public class ProvisionedNodesScannerRepository extends BaseMeshRepository {
      * stop scanning for bluetooth devices.
      */
     public void stopScanning() {
-        mScannerLiveData.stopScanning();
-        final BluetoothLeScannerCompat scanner = BluetoothLeScannerCompat.getScanner();
-        scanner.stopScan(scanCallbackForProvisionedDevices);
-        mScannerLiveData.scanningStopped();
+        if(mScannerLiveData.isScanning()) {
+            mScannerLiveData.stopScanning();
+            final BluetoothLeScannerCompat scanner = BluetoothLeScannerCompat.getScanner();
+            scanner.stopScan(scanCallbackForProvisionedDevices);
+            mScannerLiveData.scanningStopped();
+        }
     }
 
     private final ScanCallback scanCallbackForProvisionedDevices = new ScanCallback() {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ProvisionedNodesScannerRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ProvisionedNodesScannerRepository.java
@@ -49,7 +49,7 @@ import no.nordicsemi.android.support.v18.scanner.ScanSettings;
 import static no.nordicsemi.android.nrfmeshprovisioner.ble.BleMeshManager.MESH_PROXY_UUID;
 
 @Singleton
-public class ProvisionedNodesScannerRepository extends BaseMeshRepository{
+public class ProvisionedNodesScannerRepository extends BaseMeshRepository {
 
     private final Context mContext;
     private String mNetworkId;
@@ -213,6 +213,7 @@ public class ProvisionedNodesScannerRepository extends BaseMeshRepository{
             if (scanRecord != null) {
                 final byte[] serviceData = scanRecord.getServiceData(new ParcelUuid((MESH_PROXY_UUID)));
                 if (serviceData != null) {
+                    if(mMeshManagerApi != null)
                     if (mMeshManagerApi.networkIdMatches(mNetworkId, serviceData)) {
                         mScannerLiveData.deviceDiscovered(result);
                     }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ReconnectRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ReconnectRepository.java
@@ -142,4 +142,10 @@ public class ReconnectRepository {
         intent.putExtra(EXTRA_DEVICE, device);
         mContext.startService(intent);
     }
+
+    public void disconnect() {
+        if(mBinder != null) {
+            mBinder.disconnect();
+        }
+    }
 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ScannerRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ScannerRepository.java
@@ -30,6 +30,7 @@ import android.content.IntentFilter;
 import android.location.LocationManager;
 import android.os.Handler;
 import android.os.ParcelUuid;
+import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,6 +48,7 @@ import no.nordicsemi.android.support.v18.scanner.ScanSettings;
 
 public class ScannerRepository {
 
+    private static final String TAG = ScannerRepository.class.getSimpleName();
     private final Context mContext;
     private Handler mHandler;
 
@@ -74,8 +76,12 @@ public class ScannerRepository {
 
         @Override
         public void onScanFailed(final int errorCode) {
-            // TODO This should be handled
-            mScannerLiveData.scanningStopped();
+            try {
+                // TODO This should be handled
+                mScannerLiveData.scanningStopped();
+            } catch (Exception ex) {
+                Log.v(TAG, ex.getMessage() + " : Error code: " + errorCode);
+            }
         }
     };
 
@@ -158,6 +164,7 @@ public class ScannerRepository {
             return;
         }
 
+        mScannerLiveData.scanningStarted();
         // Scanning settings
         final ScanSettings settings = new ScanSettings.Builder()
                 .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
@@ -175,7 +182,6 @@ public class ScannerRepository {
 
         final BluetoothLeScannerCompat scanner = BluetoothLeScannerCompat.getScanner();
         scanner.startScan(filters, settings, mScanCallbacks);
-        mScannerLiveData.scanningStarted();
     }
 
     /**

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/service/MeshService.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/service/MeshService.java
@@ -158,7 +158,7 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
     public void onCreate() {
         AndroidInjection.inject(this);
         super.onCreate();
-        mMeshManagerApi = MeshManagerApi.getInstance(this);
+        mMeshManagerApi = new MeshManagerApi(this);
         mMeshManagerApi.setProvisionerManagerTransportCallbacks(this);
         mMeshManagerApi.setProvisioningStatusCallbacks(this);
         mMeshManagerApi.setConfigurationCallbacks(this);
@@ -742,6 +742,10 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
 
     public class MeshServiceBinder extends Binder {
 
+        public MeshManagerApi getMeshManagerApi(){
+            return mMeshManagerApi;
+        }
+
         /**
          * Connect to peripheral
          * @param device bluetooth device
@@ -824,10 +828,9 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
 
         }
 
-        public void startProvisioning() {
+        public void startProvisioning(final String nodeName) {
             mIsProvisioningComplete = false;
             mIsConfigurationComplete = false;
-            final String nodeName =  mProvisioningSettings.getNodeName();
             final String networkKey = mProvisioningSettings.getNetworkKey();
             final int keyIndex = mProvisioningSettings.getKeyIndex();
             final int flags = mProvisioningSettings.getFlags();
@@ -906,6 +909,10 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
 
         public String getSelectedAppKey() {
             return mAppKey;
+        }
+
+        public ProvisioningSettings getProvisioningSettings() {
+            return mMeshManagerApi.getProvisioningSettings();
         }
     }
 

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/service/MeshService.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/service/MeshService.java
@@ -884,6 +884,12 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
             mMeshManagerApi.getCompositionData(node);
         }
 
+        public void sendAppKeyAdd(final int appKeyIndex, final String appKey){
+            mAppKeyIndex = appKeyIndex;
+            mAppKey = appKey;
+            mMeshManagerApi.addAppKey(mMeshNode, appKeyIndex, appKey);
+        }
+
         /**
          * Binds appkey to model
          * @param meshNode corresponding mesh node

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/ElementConfigurationViewModel.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/ElementConfigurationViewModel.java
@@ -75,7 +75,7 @@ public class ElementConfigurationViewModel extends ViewModel {
         return mElementConfigurationRepository;
     }
 
-    public void startConfiguration() {
+    public void sendGetCompositionData() {
         mElementConfigurationRepository.sendGetCompositionData();
     }
 

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/ElementConfigurationViewModel.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/ElementConfigurationViewModel.java
@@ -27,8 +27,10 @@ import android.arch.lifecycle.ViewModel;
 
 import javax.inject.Inject;
 
+import no.nordicsemi.android.meshprovisioner.ProvisioningSettings;
 import no.nordicsemi.android.meshprovisioner.configuration.ProvisionedMeshNode;
 import no.nordicsemi.android.nrfmeshprovisioner.livedata.ExtendedMeshNode;
+import no.nordicsemi.android.nrfmeshprovisioner.livedata.ProvisioningLiveData;
 import no.nordicsemi.android.nrfmeshprovisioner.livedata.ProvisioningStateLiveData;
 import no.nordicsemi.android.nrfmeshprovisioner.repository.ElementConfigurationRepository;
 
@@ -79,4 +81,15 @@ public class ElementConfigurationViewModel extends ViewModel {
         mElementConfigurationRepository.sendGetCompositionData();
     }
 
+    public ProvisioningLiveData getProvisioningData() {
+        return mElementConfigurationRepository.getProvisioningData();
+    }
+
+    public void setSelectedAppKey(final int appKeyIndex, final String appkey) {
+        mElementConfigurationRepository.setSelectedAppKey(appKeyIndex, appkey);
+    }
+
+    public void sendAppKeyAdd(final int appKeyIndex, final String appKey) {
+        mElementConfigurationRepository.addAppKey(appKeyIndex, appKey);
+    }
 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/MeshProvisionerViewModel.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/MeshProvisionerViewModel.java
@@ -88,8 +88,8 @@ public class MeshProvisionerViewModel extends ViewModel {
         mMeshProvisionerRepository.unbindService();
     }
 
-    public void provisionNode(final String appKey, final int appKeyIndex) {
-        mMeshProvisionerRepository.startProvisioning();
+    public void provisionNode(final String nodeName) {
+        mMeshProvisionerRepository.startProvisioning(nodeName);
     }
 
     public void sendProvisioneePin(final String pin) {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/ReconnectViewModel.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/ReconnectViewModel.java
@@ -61,4 +61,8 @@ public class ReconnectViewModel extends ViewModel {
     public void connect(final ExtendedBluetoothDevice device) {
         mReconnectRepository.connect(device);
     }
+
+    public void disconnect() {
+        mReconnectRepository.disconnect();
+    }
 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/SharedViewModel.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/SharedViewModel.java
@@ -96,7 +96,7 @@ public class SharedViewModel extends ViewModel {
         return mMeshRepository.isConnectedToMesh();
     }
 
-    public void updateProvisionedNodes() {
+    public void getProvisionedNodes() {
         mMeshRepository.getProvisionedNodes();
     }
 

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/SharedViewModel.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/SharedViewModel.java
@@ -96,8 +96,8 @@ public class SharedViewModel extends ViewModel {
         return mMeshRepository.isConnectedToMesh();
     }
 
-    public void getProvisionedNodes() {
-        mMeshRepository.getProvisionedNodes();
+    public void refreshProvisionedNodes() {
+        mMeshRepository.refreshProvisionedNodes();
     }
 
     public void setMeshNode(final ProvisionedMeshNode meshNode) {

--- a/Example/nrf-mesh/app/src/main/res/drawable/ic_widgets_black_24dp_alpha.xml
+++ b/Example/nrf-mesh/app/src/main/res/drawable/ic_widgets_black_24dp_alpha.xml
@@ -1,0 +1,5 @@
+<vector android:alpha="0.6" android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M13,13v8h8v-8h-8zM3,21h8v-8L3,13v8zM3,3v8h8L11,3L3,3zM16.66,1.69L11,7.34 16.66,13l5.66,-5.66 -5.66,-5.65z"/>
+</vector>

--- a/Example/nrf-mesh/app/src/main/res/layout/activity_mesh_configurator.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/activity_mesh_configurator.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018, Nordic Semiconductor
+  ~ All rights reserved.
+  ~
+  ~ Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+  ~
+  ~ 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  ~
+  ~ 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+  ~ documentation and/or other materials provided with the distribution.
+  ~
+  ~ 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+  ~ software without specific prior written permission.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+  ~ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<android.support.design.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MeshProvisionerActivity"
+    tools:ignore="ContentDescription">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <android.support.design.widget.AppBarLayout
+            android:id="@+id/appbar_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:theme="@style/AppTheme.AppBarOverlay">
+
+            <android.support.v7.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/colorPrimary"
+                app:popupTheme="@style/AppTheme.PopupOverlay"/>
+
+            <ProgressBar
+                android:id="@+id/provisioning_progress_bar"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="-7dp"
+                android:layout_marginTop="-8dp"
+                android:indeterminate="true"
+                android:indeterminateTint="@android:color/white"
+                android:visibility="invisible"/>
+
+        </android.support.design.widget.AppBarLayout>
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentBottom="true"
+            android:layout_centerHorizontal="true"
+            android:layout_marginBottom="8dp"
+            android:src="@drawable/background_title"/>
+
+        <ScrollView
+            android:id="@+id/data_container"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_below="@+id/appbar_layout"
+            android:visibility="gone">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <android.support.v7.widget.CardView
+                    android:id="@+id/network_key_card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/activity_horizontal_margin"
+                    android:layout_marginTop="@dimen/activity_horizontal_margin"
+                    android:background="@android:color/white"
+                    app:cardElevation="1dp">
+
+                    <android.support.constraint.ConstraintLayout
+                        android:id="@+id/provisioning_data_container"
+                        android:layout_width="match_parent"
+                        android:layout_height="match_parent">
+
+                        <android.support.v7.widget.Toolbar
+                            android:id="@+id/network_key_tool_bar"
+                            android:layout_width="0dp"
+                            android:layout_height="?actionBarSize"
+                            app:layout_constraintLeft_toLeftOf="parent"
+                            app:layout_constraintRight_toRightOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:logo="@drawable/ic_certificate"
+                            app:title="Provisioning Data"
+                            app:titleMarginStart="@dimen/toolbar_title_margin"/>
+
+                        <include
+                            android:id="@+id/container_name"
+                            layout="@layout/layout_container"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            app:layout_constraintLeft_toLeftOf="parent"
+                            app:layout_constraintRight_toRightOf="parent"
+                            app:layout_constraintTop_toBottomOf="@+id/network_key_tool_bar"/>
+
+                        <include
+                            android:id="@+id/container_unicast_address"
+                            layout="@layout/layout_container"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            app:layout_constraintLeft_toLeftOf="parent"
+                            app:layout_constraintRight_toRightOf="parent"
+                            app:layout_constraintTop_toBottomOf="@+id/container_name"/>
+
+                        <include
+                            android:id="@+id/container_app_key"
+                            layout="@layout/layout_container"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            app:layout_constraintLeft_toLeftOf="parent"
+                            app:layout_constraintRight_toRightOf="parent"
+                            app:layout_constraintTop_toBottomOf="@+id/container_unicast_address"/>
+
+                        <View
+                            android:id="@+id/div1"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:background="@drawable/divider"
+                            app:layout_constraintLeft_toLeftOf="parent"
+                            app:layout_constraintRight_toRightOf="parent"
+                            app:layout_constraintTop_toBottomOf="@+id/container_app_key"/>
+
+                        <Button
+                            android:id="@+id/action_provision_device"
+                            style="@style/Widget.AppCompat.Button.Borderless.Colored"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_horizontal"
+                            android:layout_marginEnd="8dp"
+                            android:layout_marginStart="8dp"
+                            android:padding="@dimen/activity_horizontal_margin"
+                            android:text="@string/provision_action"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintRight_toRightOf="parent"
+                            app:layout_constraintTop_toBottomOf="@+id/div1"/>
+                    </android.support.constraint.ConstraintLayout>
+                </android.support.v7.widget.CardView>
+            </LinearLayout>
+        </ScrollView>
+
+        <include
+            android:id="@+id/info_provisioning_status_container"
+            layout="@layout/info_live_provisioning_status"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            android:layout_below="@+id/appbar_layout"
+            android:layout_marginTop="@dimen/activity_vertical_margin"/>
+
+        <LinearLayout
+            android:id="@+id/connectivity_progress_container"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:gravity="center_horizontal"
+            android:orientation="vertical"
+            android:padding="@dimen/activity_horizontal_margin"
+            android:visibility="visible">
+
+            <TextView
+                android:id="@+id/connection_state"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center_horizontal"
+                android:textSize="16sp"
+                tools:text="@string/state_connecting"/>
+
+            <ProgressBar
+                android:id="@+id/progress_bar"
+                style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+                android:layout_width="250dp"
+                android:layout_height="wrap_content"
+                android:indeterminate="true"/>
+        </LinearLayout>
+
+    </RelativeLayout>
+</android.support.design.widget.CoordinatorLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/activity_mesh_element_configuration.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/activity_mesh_element_configuration.xml
@@ -28,7 +28,6 @@
     android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MeshProvisionerActivity"
     tools:ignore="ContentDescription">
 
     <android.support.constraint.ConstraintLayout
@@ -50,6 +49,17 @@
                 android:layout_height="?actionBarSize"
                 android:background="?attr/colorPrimary"
                 app:popupTheme="@style/AppTheme.PopupOverlay"/>
+
+            <ProgressBar
+                android:id="@+id/provisioning_progress_bar"
+                style="?android:attr/progressBarStyleHorizontal"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="-7dp"
+                android:layout_marginTop="-8dp"
+                android:indeterminate="true"
+                android:indeterminateTint="@android:color/white"
+                android:visibility="invisible"/>
 
         </android.support.design.widget.AppBarLayout>
 
@@ -77,60 +87,71 @@
             app:layout_constraintTop_toBottomOf="@id/appbar_layout"
             android:visibility="visible"/>
 
-        <include
-            android:id="@+id/no_elements"
-            layout="@layout/info_no_elements"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/appbar_layout"/>
 
-        <include
-            android:id="@+id/no_devices"
-            layout="@layout/info_no_devices"
-            android:layout_width="0dp"
+        <android.support.v7.widget.CardView
+            android:id="@+id/composition_data_card"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/appbar_layout"/>
+            android:layout_marginBottom="@dimen/activity_horizontal_margin"
+            android:layout_marginTop="@dimen/activity_horizontal_margin"
+            android:background="@android:color/white"
+            app:cardElevation="1dp"
+            app:layout_constraintTop_toBottomOf="@id/appbar_layout"
+            android:visibility="invisible"
+            tools:visibility="visible">
 
-        <include
-            android:id="@+id/bluetooth_off"
-            layout="@layout/info_no_bluetooth"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/appbar_layout"/>
+            <android.support.constraint.ConstraintLayout
+                android:id="@+id/composition_data_container"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
 
-        <include
-            android:id="@+id/no_location_permission"
-            layout="@layout/info_no_permission"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/appbar_layout"/>
+                <android.support.v7.widget.Toolbar
+                    android:id="@+id/composition_data_tool_bar"
+                    android:layout_width="0dp"
+                    android:layout_height="?actionBarSize"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:logo="@drawable/ic_widgets_black_24dp_alpha"
+                    app:title="@string/title_elements"
+                    app:titleMarginStart="@dimen/toolbar_title_margin"/>
 
-        <include
-            android:id="@+id/connectivity_progress_container"
-            layout="@layout/info_connectivity_progress_container"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:visibility="gone"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toEndOf="parent" />
+                <TextView
+                    android:id="@+id/no_elements"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:text="@string/no_elements_guide_composition_data"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/composition_data_tool_bar"
+                    android:paddingStart="@dimen/activity_horizontal_margin"
+                    android:paddingEnd="@dimen/activity_horizontal_margin"
+                    android:paddingBottom="@dimen/activity_vertical_margin"/>
+
+                <View
+                    android:id="@+id/div1"
+                    android:layout_width="0dp"
+                    android:layout_height="1dp"
+                    android:background="@drawable/divider"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/no_elements"/>
+
+                <Button
+                    android:id="@+id/action_get_compostion_data"
+                    style="@style/Widget.AppCompat.Button.Borderless.Colored"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginEnd="8dp"
+                    android:layout_marginStart="8dp"
+                    android:padding="@dimen/activity_horizontal_margin"
+                    android:text="@string/action_composition_data"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/div1"/>
+            </android.support.constraint.ConstraintLayout>
+        </android.support.v7.widget.CardView>
 
     </android.support.constraint.ConstraintLayout>
 </android.support.design.widget.CoordinatorLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/activity_node_details.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/activity_node_details.xml
@@ -67,7 +67,7 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:clipToPadding="false"
-            android:paddingBottom="@dimen/activity_vertical_margin"
+            android:paddingBottom="@dimen/item_padding_bottom"
             android:scrollbars="none"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
@@ -197,11 +197,12 @@
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/activity_vertical_margin"
-                    android:layout_marginBottom="@dimen/activity_vertical_margin"
+                    android:layout_marginBottom="@dimen/item_padding_bottom"
                     android:background="@android:color/white"
                     app:cardElevation="1dp"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/node_details_card">
 
                     <android.support.constraint.ConstraintLayout
@@ -219,6 +220,23 @@
                             app:logo="@drawable/ic_info_outline_black_alpha"
                             app:title="@string/title_node_element_details"
                             app:titleMarginStart="@dimen/toolbar_title_margin"/>
+
+                        <TextView
+                            android:id="@+id/no_elements_view"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:text="@string/no_elements_guide_info"
+                            android:textColor="@android:color/black"
+                            android:textSize="14sp"
+                            android:paddingTop="@dimen/item_padding_top"
+                            android:paddingBottom="@dimen/activity_vertical_margin"
+                            android:paddingEnd="@dimen/activity_horizontal_margin"
+                            android:paddingStart="@dimen/activity_horizontal_margin"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toBottomOf="@id/elements_tool_bar"
+                            android:visibility="gone"
+                            tools:visibility="visible"/>
 
                         <android.support.v7.widget.RecyclerView
                             android:id="@+id/recycler_view_elements"

--- a/Example/nrf-mesh/app/src/main/res/layout/info_no_elements.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/info_no_elements.xml
@@ -22,34 +22,14 @@
   -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:orientation="vertical"
-    android:paddingEnd="@dimen/activity_horizontal_margin"
-    android:paddingStart="@dimen/activity_horizontal_margin"
-    tools:ignore="ContentDescription">
-
-    <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:padding="@dimen/activity_horizontal_margin"
-        app:srcCompat="@drawable/ic_mesh_model_nordic_black"/>
-
-    <TextView
-        style="@style/Widget.ScannerSubtitle"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:gravity="center_horizontal"
-        android:text="@string/no_elements_found"/>
-
-    <TextView
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/activity_vertical_margin"
-        android:text="@string/no_elements_guide_info"/>
+              xmlns:tools="http://schemas.android.com/tools"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
+              android:orientation="vertical"
+              android:paddingEnd="@dimen/activity_horizontal_margin"
+              android:paddingStart="@dimen/activity_horizontal_margin"
+              tools:ignore="ContentDescription">
 
     <Button
         android:id="@+id/action_configure"

--- a/Example/nrf-mesh/app/src/main/res/layout/network_item.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/network_item.xml
@@ -72,9 +72,9 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:paddingBottom="@dimen/item_padding_bottom"
+                app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@id/icon"
-                app:layout_constraintTop_toBottomOf="@id/node_name"
-                app:layout_constraintEnd_toEndOf="parent">
+                app:layout_constraintTop_toBottomOf="@id/node_name">
 
                 <TextView
                     android:id="@+id/unicast_title"
@@ -90,8 +90,9 @@
                     android:id="@+id/unicast"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/item_padding_start"
+                    android:layout_marginStart="16dp"
                     android:ellipsize="end"
+                    android:maxLines="1"
                     android:text="0x0001"
                     android:textSize="14sp"
                     app:layout_constraintEnd_toEndOf="parent"
@@ -103,64 +104,59 @@
                     android:id="@+id/company_identifier_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/item_padding_start"
                     android:text="@string/company"
                     android:textSize="14sp"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/unicast_title"/>
+                    app:layout_constraintStart_toStartOf="@+id/unicast_title"
+                    app:layout_constraintTop_toBottomOf="@+id/unicast"/>
 
                 <TextView
                     android:id="@+id/company_identifier"
                     android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/item_padding_start"
-                    android:ellipsize="marquee"
+                    android:ellipsize="end"
+                    android:maxLines="1"
                     android:text="@string/nordic_semiconductor_asa"
                     android:textSize="14sp"
                     app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/company_identifier_title"
-                    app:layout_constraintTop_toBottomOf="@id/unicast_title"/>
+                    app:layout_constraintStart_toStartOf="@+id/unicast"
+                    app:layout_constraintTop_toBottomOf="@+id/unicast"/>
 
                 <TextView
                     android:id="@+id/elements_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/item_padding_start"
                     android:text="@string/elements"
                     android:textSize="14sp"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/company_identifier_title"/>
+                    app:layout_constraintStart_toStartOf="@+id/unicast_title"
+                    app:layout_constraintTop_toBottomOf="@+id/company_identifier"/>
 
                 <TextView
                     android:id="@+id/elements"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/item_padding_start"
                     android:text="4"
                     android:textSize="14sp"
-                    app:layout_constraintStart_toEndOf="@id/elements_title"
-                    app:layout_constraintTop_toBottomOf="@id/company_identifier_title"
+                    app:layout_constraintStart_toStartOf="@+id/unicast"
+                    app:layout_constraintTop_toBottomOf="@+id/company_identifier"
                     tools:ignore="HardcodedText"/>
 
                 <TextView
                     android:id="@+id/models_title"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/item_padding_start"
                     android:text="@string/models"
                     android:textSize="14sp"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toBottomOf="@id/elements_title"/>
+                    app:layout_constraintStart_toStartOf="@+id/unicast_title"
+                    app:layout_constraintTop_toBottomOf="@+id/elements"/>
 
                 <TextView
                     android:id="@+id/models"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/item_padding_start"
                     android:text="29"
                     android:textSize="14sp"
-                    app:layout_constraintStart_toEndOf="@id/models_title"
-                    app:layout_constraintTop_toBottomOf="@id/elements_title"
+                    app:layout_constraintStart_toStartOf="@+id/unicast"
+                    app:layout_constraintTop_toBottomOf="@+id/elements"
                     tools:ignore="HardcodedText"/>
 
             </android.support.constraint.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/network_item.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/network_item.xml
@@ -74,7 +74,9 @@
                 android:paddingBottom="@dimen/item_padding_bottom"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@id/icon"
-                app:layout_constraintTop_toBottomOf="@id/node_name">
+                app:layout_constraintTop_toBottomOf="@id/node_name"
+                android:visibility="visible"
+                tools:visibility="invisible">
 
                 <TextView
                     android:id="@+id/unicast_title"
@@ -161,6 +163,19 @@
 
             </android.support.constraint.ConstraintLayout>
 
+            <TextView
+                android:id="@+id/not_configured_view"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:textSize="14sp"
+                android:text="@string/provisioned_not_configured"
+                android:layout_marginStart="@dimen/item_padding_start"
+                android:paddingBottom="@dimen/item_padding_bottom"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@id/icon"
+                app:layout_constraintTop_toBottomOf="@id/node_name"
+                android:visibility="gone"
+                tools:visibility="visible"/>
             <View
                 android:id="@+id/divider"
                 android:layout_width="0dp"

--- a/Example/nrf-mesh/app/src/main/res/menu/app_key_add.xml
+++ b/Example/nrf-mesh/app/src/main/res/menu/app_key_add.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018, Nordic Semiconductor
+  ~ All rights reserved.
+  ~
+  ~ Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+  ~
+  ~ 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  ~
+  ~ 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+  ~ documentation and/or other materials provided with the distribution.
+  ~
+  ~ 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+  ~ software without specific prior written permission.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+  ~ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_app_key_add"
+        android:enabled="true"
+        android:title="@string/action_add_app_key"
+        app:showAsAction="always"/>
+</menu>

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -253,7 +253,7 @@
     <string name="title_bound_app_keys">Bound App Keys</string>
 
     <string name="no_elements_found">NO ELEMENTS FOUND</string>
-    <string name="no_elements_guide_info">Try configuring the node again to see what elements are available on this node</string>
+    <string name="no_elements_guide_info">No elements were found! \n\nTry configuring the node again to see what elements are available on this node. You may do this by going back to the main screen and connecting to the node</string>
     <string name="action_connect">CONNECT</string>
     <string name="action_disconnect">Disconnect</string>
 
@@ -271,7 +271,7 @@
     <string name="action_reset_network">Reset Network</string>
     <string name="title_reset_network">Reset Mesh Network</string>
     <string name="message_reset_network">This will clear all the data stored related to this network and will not be recoverable. Would you like to continue?</string>
-    <string name="not_subscribed_to_groups">Not subscribed to to any group addresses.</string>
+    <string name="not_subscribed_to_groups">Not subscribed to any group addresses.</string>
     <string name="title_group_address">Group Address</string>
     <string name="dialog_summary_group_address">Group address this model should subscribe.</string>
     <string name="title_configuration_compete">Confguration Complete</string>

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -118,6 +118,7 @@
     <string name="node_replay_protection_count">Replay Protection Count</string>
     <string name="node_features">Node Features</string>
 
+    <string name="title_elements">Elements</string>
     <string name="title_node_element_details">Element Details</string>
 
     <string name="title_node_app_keys">Application Keys</string>

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -277,4 +277,6 @@
     <string name="title_configuration_compete">Confguration Complete</string>
     <string name="configuration_complete_summary">Mesh node has been successfully configured.</string>
     <string name="action_composition_data">GET COMPOSITION DATA</string>
+
+    <string name="action_add_app_key">ADD APP KEY</string>
 </resources>

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -201,15 +201,14 @@
     <string name="app_key_count">%d keys</string>
     <string name="hint_app_key">App key</string>
     <string name="no_app_keys_title">NO ADDED APP KEYS</string>
-    <string name="no_app_keys_rationale">App keys are required in order to configure a mUnprovisionedMeshNode after provisioning has been completed. Please click on the add button to add an app key </string>
+    <string name="no_app_keys_rationale">App keys are required in order to configure a UnprovisionedMeshNode after provisioning has been completed. Please click on the add button to add an app key </string>
     <string name="app_key_deleted">App key deleted.</string>
     <string name="undo">Undo</string>
     <string name="title_error_provisioning_failed">Provisioning Failed</string>
     <string name="provisioning_cancelled">Provisioning canceled!</string>
     <string name="details">Details</string>
     <string name="node_status">Node status:</string>
-    <string name="provisioned_not_configured">Provisioned, not configured</string>
-    <string name="provisioned_and_configured">Provisioned and Configured</string>
+    <string name="provisioned_not_configured">Provisioned, not configured.</string>
     <string name="configuration_state">Configuration status:</string>
     <string name="configured">Configured</string>
 
@@ -253,7 +252,8 @@
     <string name="title_bound_app_keys">Bound App Keys</string>
 
     <string name="no_elements_found">NO ELEMENTS FOUND</string>
-    <string name="no_elements_guide_info">No elements were found! \n\nTry configuring the node again to see what elements are available on this node. You may do this by going back to the main screen and connecting to the node</string>
+    <string name="no_elements_guide_info">No elements were found! \n\nTry configuring the node again to see what elements are available on this node. You may do this by going back to the main screen and connecting to the node.</string>
+    <string name="no_elements_guide_composition_data">No elements were found! \nGet composition data to see what elements are on this node.</string>
     <string name="action_connect">CONNECT</string>
     <string name="action_disconnect">Disconnect</string>
 
@@ -276,4 +276,5 @@
     <string name="dialog_summary_group_address">Group address this model should subscribe.</string>
     <string name="title_configuration_compete">Confguration Complete</string>
     <string name="configuration_complete_summary">Mesh node has been successfully configured.</string>
+    <string name="action_composition_data">GET COMPOSITION DATA</string>
 </resources>

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNode.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNode.java
@@ -5,6 +5,7 @@ import android.text.TextUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -47,14 +48,14 @@ public abstract class BaseMeshNode implements Parcelable {
     protected boolean proxyFeatureSupported;
     protected boolean friendFeatureSupported;
     protected boolean lowPowerFeatureSupported;
-    protected Map<Integer, Element> mElements;
+    protected final Map<Integer, Element> mElements = new LinkedHashMap<>();
     protected List<Integer> mAddedAppKeyIndexes = new ArrayList<>();
     protected Map<Integer, String> mAddedAppKeys = new HashMap<>(); //Map containing the key as the app key index and the app key as the value
     protected byte[] generatedNetworkId;
     private String bluetoothDeviceAddress;
     protected long mTimeStampInMillis;
 
-    public BaseMeshNode() {
+    protected BaseMeshNode() {
 
     }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
@@ -16,9 +16,9 @@ import java.util.Map;
 import java.util.UUID;
 
 import no.nordicsemi.android.meshprovisioner.configuration.ConfigMessage;
+import no.nordicsemi.android.meshprovisioner.configuration.MeshModel;
 import no.nordicsemi.android.meshprovisioner.configuration.ProvisionedMeshNode;
 import no.nordicsemi.android.meshprovisioner.configuration.SequenceNumber;
-import no.nordicsemi.android.meshprovisioner.configuration.MeshModel;
 import no.nordicsemi.android.meshprovisioner.utils.AddressUtils;
 import no.nordicsemi.android.meshprovisioner.utils.InterfaceAdapter;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
@@ -209,7 +209,7 @@ public class MeshManagerApi implements InternalTransportCallbacks, InternalMeshM
         final SharedPreferences preferences = mContext.getSharedPreferences(PROVISIONED_NODES_FILE, Context.MODE_PRIVATE);
         final SharedPreferences.Editor editor = preferences.edit();
         editor.clear();
-        editor.apply();
+        editor.commit();
     }
 
     @Override
@@ -490,10 +490,7 @@ public class MeshManagerApi implements InternalTransportCallbacks, InternalMeshM
      * @param serviceData advertised service data
      * @return true if the hashes match or false otherwise
      */
-    public boolean hashMatches(final ProvisionedMeshNode meshNode, final byte[] serviceData) {
-        if (!isAdvertisedWithNodeIdentity(serviceData))
-            return false;
-
+    public boolean nodeIdentityMatches(final ProvisionedMeshNode meshNode, final byte[] serviceData) {
         final byte[] advertisedHash = getAdvertisedHash(serviceData);
         //If there is no advertised hash return false as this is used to match against the generated hash
         if (advertisedHash == null) {
@@ -525,7 +522,7 @@ public class MeshManagerApi implements InternalTransportCallbacks, InternalMeshM
      * @param serviceData advertised service data
      * @return returns true if the node is advertising with Node Identity or false otherwise
      */
-    private boolean isAdvertisedWithNodeIdentity(final byte[] serviceData) {
+    public boolean isAdvertisedWithNodeIdentity(final byte[] serviceData) {
         return serviceData != null &&
                 serviceData[ADVERTISED_HASH_OFFSET - 1] == ADVERTISEMENT_TYPE_NODE_IDENTITY;
     }
@@ -566,9 +563,6 @@ public class MeshManagerApi implements InternalTransportCallbacks, InternalMeshM
      * @return returns true if the network ids match or false otherwise
      */
     public boolean networkIdMatches(final String networkId, final byte[] serviceData) {
-        if (!isAdvertisingWithNetworkIdentity(serviceData))
-            return false;
-
         final byte[] advertisedNetworkId = getAdvertisedNetworkId(serviceData);
         return advertisedNetworkId != null && networkId.equals(MeshParserUtils.bytesToHex(advertisedNetworkId, false).toUpperCase());
     }
@@ -579,7 +573,7 @@ public class MeshManagerApi implements InternalTransportCallbacks, InternalMeshM
      * @param serviceData advertised service data
      * @return returns the advertised hash
      */
-    private boolean isAdvertisingWithNetworkIdentity(final byte[] serviceData) {
+    public boolean isAdvertisingWithNetworkIdentity(final byte[] serviceData) {
         return serviceData != null && serviceData[ADVERTISED_NETWWORK_ID_OFFSET - 1] == ADVERTISEMENT_TYPE_NETWORK_ID;
     }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
@@ -50,7 +50,7 @@ public class MeshManagerApi implements InternalTransportCallbacks, InternalMeshM
     /**
      * Length of the random number required to calculate the hash containing the node id
      */
-    private final static int HASH_RANDOM_NUMBER_LENGTH = 64; //in btis
+    private final static int HASH_RANDOM_NUMBER_LENGTH = 64; //in bits
     private static final int ADVERTISEMENT_TYPE_NETWORK_ID = 0x00;
     private static final int ADVERTISEMENT_TYPE_NODE_IDENTITY = 0x01;
     /**
@@ -77,10 +77,9 @@ public class MeshManagerApi implements InternalTransportCallbacks, InternalMeshM
      * Length of the network id contained in the advertisement service data
      */
     private final static int ADVERTISED_NETWWORK_ID_LENGTH = 8;
-    private static MeshManagerApi mInstance;
     private final Map<Integer, ProvisionedMeshNode> mProvisionedNodes = new HashMap<>();
     private final ProvisioningSettings mProvisioningSettings;
-    private final Context mContext;
+    private Context mContext;
     private Gson mGson;
     private int mGlobalTtl = 7;
     private MeshManagerTransportCallbacks mTransportCallbacks;
@@ -91,19 +90,13 @@ public class MeshManagerApi implements InternalTransportCallbacks, InternalMeshM
     private byte[] mOutgoingBuffer;
     private int mOutgoingBufferOffset;
 
-    private MeshManagerApi(final Context context) {
+    public MeshManagerApi(final Context context) {
         this.mContext = context;
         this.mProvisioningSettings = new ProvisioningSettings(context);
         initGson();
         initProvisionedNodes();
         mMeshProvisioningHandler = new MeshProvisioningHandler(context, this, this);
         mMeshConfigurationHandler = new MeshConfigurationHandler(context, this, this);
-    }
-
-    public static MeshManagerApi getInstance(final Context context) {
-        if (mInstance == null)
-            mInstance = new MeshManagerApi(context);
-        return mInstance;
     }
 
     public void setProvisionerManagerTransportCallbacks(final MeshManagerTransportCallbacks transportCallbacks) {
@@ -437,6 +430,13 @@ public class MeshManagerApi implements InternalTransportCallbacks, InternalMeshM
      * Starts the provisioning process
      */
     public void startProvisioning(@NonNull final String address, final String nodeName, @NonNull final String networkKeyValue, final int keyIndex, final int flags, final int ivIndex, final int unicastAddress, final int globalTtl) throws IllegalArgumentException {
+        //We must save all the provisioning data here so that they could be reused when provisioning the next devices
+        mProvisioningSettings.setNetworkKey(networkKeyValue);
+        mProvisioningSettings.setKeyIndex(keyIndex);
+        mProvisioningSettings.setFlags(flags);
+        mProvisioningSettings.setIvIndex(ivIndex);
+        mProvisioningSettings.setUnicastAddress(unicastAddress);
+        mProvisioningSettings.setGlobalTtl(globalTtl);
         mMeshProvisioningHandler.startProvisioning(address ,nodeName, networkKeyValue, keyIndex, flags, ivIndex, unicastAddress, globalTtl);
     }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/ProvisioningSettings.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/ProvisioningSettings.java
@@ -13,7 +13,6 @@ public class ProvisioningSettings extends NetworkSettings {
     private static final String APPLICATION_KEYS = "APPLICATION_KEYS";
     private static final String PROVISIONING_DATA = "PROVISIONING_DATA";
     private static final String NETWORK_NAME = "NETWORK_NAME";
-    private static final String NODE_NAME = "NODE_NAME";
     private static final String NETWORK_KEY = "NETWORK_KEY";
     private static final String UNICAST_ADDRESS = "UNICAST_ADDRESS";
     private static final String KEY_INDEX = "KEY_INDEX";
@@ -21,7 +20,6 @@ public class ProvisioningSettings extends NetworkSettings {
     private static final String FLAGS = "FLAGS";
     private static final String GLOBAL_TTL = "GLOBAL_TTL";
     private final Context mContext;
-    private String nodeName = "nRF Mesh Node";
     private String selectedAppkey;
 
     ProvisioningSettings(final Context context) {
@@ -35,8 +33,6 @@ public class ProvisioningSettings extends NetworkSettings {
      */
     protected void generateProvisioningData() {
         final SharedPreferences preferences = mContext.getSharedPreferences(PROVISIONING_DATA, Context.MODE_PRIVATE);
-        networkName = preferences.getString(NETWORK_NAME, "nRF Mesh Network");
-        nodeName = preferences.getString(NODE_NAME, "nRF Mesh Node");
         networkKey = preferences.getString(NETWORK_KEY, SecureUtils.generateRandomNetworkKey());
         unicastAddress = preferences.getInt(UNICAST_ADDRESS, 1);
         keyIndex = preferences.getInt(KEY_INDEX, 0);
@@ -68,24 +64,6 @@ public class ProvisioningSettings extends NetworkSettings {
             appKeys.put(2, "63964771734fbd76e3b40519d1d94a50".toUpperCase());
         }
         saveApplicationKeys();
-    }
-
-    public String getNetworkName() {
-        return networkName;
-    }
-
-    public void setNetworkName(final String networkName) {
-        this.networkName = networkName;
-        saveNetworkName();
-    }
-
-    public String getNodeName() {
-        return nodeName;
-    }
-
-    public void setNodeName(final String nodeName) {
-        this.nodeName = nodeName;
-        saveNodeName();
     }
 
     public String getNetworkKey() {
@@ -146,21 +124,6 @@ public class ProvisioningSettings extends NetworkSettings {
         this.globalTtl = globalTtl;
         saveGlobalTtl();
     }
-
-    private void saveNetworkName() {
-        final SharedPreferences preferences = mContext.getSharedPreferences(PROVISIONING_DATA, Context.MODE_PRIVATE);
-        final SharedPreferences.Editor editor = preferences.edit();
-        editor.putString(NETWORK_NAME, networkName);
-        editor.apply();
-    }
-
-    private void saveNodeName() {
-        final SharedPreferences preferences = mContext.getSharedPreferences(PROVISIONING_DATA, Context.MODE_PRIVATE);
-        final SharedPreferences.Editor editor = preferences.edit();
-        editor.putString(NODE_NAME, nodeName);
-        editor.apply();
-    }
-
     private void saveNetowrkKey() {
         final SharedPreferences preferences = mContext.getSharedPreferences(PROVISIONING_DATA, Context.MODE_PRIVATE);
         final SharedPreferences.Editor editor = preferences.edit();

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/ConfigCompositionDataStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/ConfigCompositionDataStatus.java
@@ -6,6 +6,7 @@ import android.util.Log;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 
@@ -38,7 +39,7 @@ public final class ConfigCompositionDataStatus extends ConfigMessage {
     private boolean lowPowerFeatureSupported;
     private int mUnicastAddress;
 
-    private Map<Integer, Element> mElements = new HashMap<>();
+    private Map<Integer, Element> mElements = new LinkedHashMap<>();
 
 
     public ConfigCompositionDataStatus(final Context context, final ProvisionedMeshNode unprovisionedMeshNode,
@@ -143,7 +144,7 @@ public final class ConfigCompositionDataStatus extends ConfigMessage {
         int counter = 0;
         byte[] elementAddress = null;
         while (tempOffset < accessPayload.length) {
-            final Map<Integer, MeshModel> models = new HashMap<>();
+            final Map<Integer, MeshModel> models = new LinkedHashMap<>();
             final int locationDescriptor = accessPayload[tempOffset + 1] << 8 | accessPayload[tempOffset];
             Log.v(TAG, "Location identifier: " + String.format(Locale.US, "%04X", locationDescriptor));
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/ProvisionedMeshNode.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/ProvisionedMeshNode.java
@@ -14,7 +14,7 @@ import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
 
 public class ProvisionedMeshNode extends BaseMeshNode {
 
-    protected SecureUtils.K2Output k2Output;
+    private SecureUtils.K2Output k2Output;
 
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
     public ProvisionedMeshNode(){
@@ -63,7 +63,7 @@ public class ProvisionedMeshNode extends BaseMeshNode {
         friendFeatureSupported = in.readByte() != 0;
         lowPowerFeatureSupported = in.readByte() != 0;
         generatedNetworkId = in.createByteArray();
-        mElements = in.readHashMap(Element.class.getClassLoader());
+        mElements.putAll(in.readHashMap(Element.class.getClassLoader()));
         mAddedAppKeys = in.readHashMap(String.class.getClassLoader());
         mAddedAppKeyIndexes = in.readArrayList(Integer.class.getClassLoader());
         mTimeStampInMillis = in.readLong();
@@ -239,7 +239,7 @@ public class ProvisionedMeshNode extends BaseMeshNode {
             proxyFeatureSupported = configCompositionDataStatus.isProxyFeatureSupported();
             friendFeatureSupported = configCompositionDataStatus.isFriendFeatureSupported();
             lowPowerFeatureSupported = configCompositionDataStatus.isLowPowerFeatureSupported();
-            mElements = configCompositionDataStatus.getElements();
+            mElements.putAll(configCompositionDataStatus.getElements());
         }
     }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/Element.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/Element.java
@@ -6,6 +6,7 @@ import android.os.Parcelable;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -15,17 +16,6 @@ import no.nordicsemi.android.meshprovisioner.models.VendorModel;
 
 public class Element implements Parcelable {
 
-    public static final Creator<Element> CREATOR = new Creator<Element>() {
-        @Override
-        public Element createFromParcel(Parcel in) {
-            return new Element(in);
-        }
-
-        @Override
-        public Element[] newArray(int size) {
-            return new Element[size];
-        }
-    };
     private final byte[] elementAddress;
     private final int locationDescriptor;
     private final int sigModelCount;
@@ -57,6 +47,18 @@ public class Element implements Parcelable {
         dest.writeMap(meshModels);
     }
 
+    public static final Creator<Element> CREATOR = new Creator<Element>() {
+        @Override
+        public Element createFromParcel(Parcel in) {
+            return new Element(in);
+        }
+
+        @Override
+        public Element[] newArray(int size) {
+            return new Element[size];
+        }
+    };
+
     @Override
     public int describeContents() {
         return 0;
@@ -78,38 +80,12 @@ public class Element implements Parcelable {
         return vendorModelCount;
     }
 
-    public Map<Integer, MeshModel> getMeshModels() {
-        return meshModels;
-    }
-
-
     /**
      * Returns a list of sig models avaialable in this element
      * @return List containing sig models
      */
-    public List<SigModel> getSigModels() {
-        final List<SigModel> sigModels = new ArrayList<>();
-        for(Map.Entry<Integer, MeshModel> entry : meshModels.entrySet()) {
-            if(entry.getValue() instanceof SigModel){
-                sigModels.add((SigModel) entry.getValue());
-            }
-        }
-
-        return sigModels;
-    }
-
-    /**
-     * Returns a list of vendor models avaialable in this element
-     * @return List containing vendor models
-     */
-    public List<VendorModel> getVendorModels() {
-        final List<VendorModel> vendorModels = new ArrayList<>();
-        for(Map.Entry<Integer, MeshModel> entry : meshModels.entrySet()) {
-            if(entry.getValue() instanceof VendorModel){
-                vendorModels.add((VendorModel) entry.getValue());
-            }
-        }
-        return vendorModels;
+    public Map<Integer, MeshModel> getMeshModels() {
+        return Collections.unmodifiableMap(meshModels);
     }
 
     public int getElementAddressInt() {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/NetworkSettings.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/NetworkSettings.java
@@ -1,15 +1,12 @@
 package no.nordicsemi.android.meshprovisioner.utils;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
 public abstract class NetworkSettings {
 
-    protected String networkName = "nRF Mesh Network";
     protected String networkKey;
     protected Map<Integer, String> appKeys = new HashMap<>();
-    protected ArrayList<Integer> selectedAppKeyIndexes = new ArrayList<>();
     protected int keyIndex = 0;
     protected int ivIndex = 0;
     protected int unicastAddress = 1;
@@ -20,5 +17,5 @@ public abstract class NetworkSettings {
 
     }
 
-    public abstract void setNetworkName(final String networkName);
+    protected abstract void generateProvisioningData();
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/SigModelParser.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/SigModelParser.java
@@ -12,6 +12,8 @@ import no.nordicsemi.android.meshprovisioner.models.GenericBatteryServer;
 import no.nordicsemi.android.meshprovisioner.models.GenericClientPropertyServer;
 import no.nordicsemi.android.meshprovisioner.models.GenericDefaultTransitionTimeClient;
 import no.nordicsemi.android.meshprovisioner.models.GenericDefaultTransitionTimeServer;
+import no.nordicsemi.android.meshprovisioner.models.GenericLevelClientModel;
+import no.nordicsemi.android.meshprovisioner.models.GenericLevelServerModel;
 import no.nordicsemi.android.meshprovisioner.models.GenericLocationClient;
 import no.nordicsemi.android.meshprovisioner.models.GenericLocationServer;
 import no.nordicsemi.android.meshprovisioner.models.GenericLocationSetupServer;
@@ -61,15 +63,15 @@ import no.nordicsemi.android.meshprovisioner.models.TimeSetupServer;
 public class SigModelParser {
     private static final String TAG = SigModelParser.class.getSimpleName();
 
-    private static final short CONFIGURATION_SERVER_MODEL = 0x0000;
-    private static final short CONFIGURATION_CLIENT_MODEL = 0x0001;
+    private static final short CONFIGURATION_SERVER = 0x0000;
+    private static final short CONFIGURATION_CLIENT = 0x0001;
     private static final short HEALTH_SERVER_MODEL = 0x0002;
     private static final short HEALTH_CLIENT_MODEL = 0x0003;
 
-    private static final short GENERIC_ON_OFF_SERVER_MODEL = 0x1000;
-    private static final short GENERIC_ON_OFF_CLIENT_MODEL = 0x1001;
-    private static final short GENERIC_LEVEL_SERVER_MODEL = 0x1002;
-    private static final short GENERIC_LEVEL_CLIENT_MODEL = 0x1003;
+    private static final short GENERIC_ON_OFF_SERVER = 0x1000;
+    private static final short GENERIC_ON_OFF_CLIENT = 0x1001;
+    private static final short GENERIC_LEVEL_SERVER = 0x1002;
+    private static final short GENERIC_LEVEL_CLIENT = 0x1003;
 
     private static final short GENERIC_DEFAULT_TRANSITION_TIME_SERVER = 0x1004;
     private static final short GENERIC_DEFAULT_TRANSITION_TIME_CLIENT = 0x1005;
@@ -134,22 +136,22 @@ public class SigModelParser {
      */
     public static SigModel getSigModel(final int sigModelId) {
         switch (sigModelId) {
-            case CONFIGURATION_SERVER_MODEL:
+            case CONFIGURATION_SERVER:
                 return new ConfigurationServerModel(sigModelId);
-            case CONFIGURATION_CLIENT_MODEL:
+            case CONFIGURATION_CLIENT:
                 return new ConfigurationClientModel(sigModelId);
             case HEALTH_SERVER_MODEL:
                 return new HealthServerModel(sigModelId);
             case HEALTH_CLIENT_MODEL:
                 return new HealthClientModel(sigModelId);
-            case GENERIC_ON_OFF_SERVER_MODEL:
+            case GENERIC_ON_OFF_SERVER:
                 return new GenericOnOffServerModel(sigModelId);
-            case GENERIC_ON_OFF_CLIENT_MODEL:
+            case GENERIC_ON_OFF_CLIENT:
                 return new GenericOnOffClientModel(sigModelId);
-            case GENERIC_LEVEL_SERVER_MODEL:
-                return new GenericOnOffServerModel(sigModelId);
-            case GENERIC_LEVEL_CLIENT_MODEL:
-                return new GenericOnOffClientModel(sigModelId);
+            case GENERIC_LEVEL_SERVER:
+                return new GenericLevelServerModel(sigModelId);
+            case GENERIC_LEVEL_CLIENT:
+                return new GenericLevelClientModel(sigModelId);
             case GENERIC_DEFAULT_TRANSITION_TIME_SERVER:
                 return new GenericDefaultTransitionTimeServer(sigModelId);
             case GENERIC_DEFAULT_TRANSITION_TIME_CLIENT:
@@ -248,36 +250,6 @@ public class SigModelParser {
                 return new LightLightnessClient(sigModelId);
             default:
                 Log.v(TAG, "Model ID: " + String.format(Locale.US, "%04X", sigModelId));
-        }
-        return null;
-    }
-
-    /**
-     * Returns the Bluetooth sig model based on the model id.
-     *
-     * @param model bluetooth sig model id
-     * @return SigModel
-     */
-    public static SigModel getModelType(final MeshModel model) {
-        switch (model.getModelId()) {
-            case CONFIGURATION_SERVER_MODEL:
-                return (ConfigurationServerModel) model;
-            case CONFIGURATION_CLIENT_MODEL:
-                return (ConfigurationClientModel) model;
-            case HEALTH_SERVER_MODEL:
-                return (HealthServerModel) model;
-            case HEALTH_CLIENT_MODEL:
-                return (HealthClientModel) model;
-            case GENERIC_ON_OFF_SERVER_MODEL:
-                return (GenericOnOffServerModel) model;
-            case GENERIC_ON_OFF_CLIENT_MODEL:
-                return (GenericOnOffClientModel) model;
-            case GENERIC_LEVEL_SERVER_MODEL:
-                return (GenericOnOffServerModel) model;
-            case GENERIC_LEVEL_CLIENT_MODEL:
-                return (GenericOnOffClientModel) model;
-            default:
-                Log.v(TAG, "Model ID: " + String.format(Locale.US, "%04X", model.getModelId()));
         }
         return null;
     }


### PR DESCRIPTION
This contains fixes related to
* Major bug fix related to the SDK entry point holding on to a context reference.
* Invalid naming convention for Generic Level Client and Generic Level Server
* Maintaining provisioned order of nodes/elements and models
* ScannerFragment is more robust when starting and stopping scan
* Bug fix related to continuous scanning where scanning wasn't being stopped if the provisioned device was not found to connect and continue configuration.
* Added a 20 second scanner timeout in case the provisioned device was not found during the configuration steps.
* Added improvements to continue configuration in case the app failed to reconnect once the provisioning has completed. This includes getting composition data and adding app keys
* Added improvements for the user to continue adding more than one app key to a node and this will also allow the user to bind more app keys