### PR TITLE
Improvements/display device key in node details

### DIFF
--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/NodeDetailsActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/NodeDetailsActivity.java
@@ -22,30 +22,29 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner;
 
+import android.content.ClipData;
+import android.content.ClipboardManager;
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import java.text.DateFormat;
-import java.util.ArrayList;
 
 import butterknife.ButterKnife;
 import no.nordicsemi.android.meshprovisioner.configuration.ProvisionedMeshNode;
 import no.nordicsemi.android.meshprovisioner.utils.CompanyIdentifiers;
 import no.nordicsemi.android.meshprovisioner.utils.CompositionDataParser;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
-import no.nordicsemi.android.nrfmeshprovisioner.adapter.ElementAdapter;
 import no.nordicsemi.android.nrfmeshprovisioner.adapter.ElementAdapterDetails;
 import no.nordicsemi.android.nrfmeshprovisioner.di.Injectable;
-import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentGlobalTtl;
 import no.nordicsemi.android.nrfmeshprovisioner.utils.Utils;
 
 public class NodeDetailsActivity extends AppCompatActivity implements Injectable, ElementAdapterDetails.OnItemClickListener {
@@ -64,46 +63,70 @@ public class NodeDetailsActivity extends AppCompatActivity implements Injectable
         if(node == null)
             finish();
 
+        final ClipboardManager clipboard = (ClipboardManager) getSystemService(Context.CLIPBOARD_SERVICE);
+
         final Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setTitle(node.getNodeName());
 
         final View containerNodeName = findViewById(R.id.container_name);
+        containerNodeName.setClickable(false);
         final TextView nodeName = containerNodeName.findViewById(R.id.text);
         nodeName.setText(node.getNodeName());
 
         final View containerProvisioningTimeStamp = findViewById(R.id.container_timestamp);
+        containerProvisioningTimeStamp.setClickable(false);
         final TextView timestamp = containerProvisioningTimeStamp.findViewById(R.id.text);
         final String format = DateFormat.getDateTimeInstance(DateFormat.LONG, DateFormat.LONG).format(node.getTimeStamp());
         timestamp.setText(format);
 
         final View containerNodeIdentifier = findViewById(R.id.container_identifier);
+        containerNodeIdentifier.setClickable(false);
         final TextView nodeIdentifier = containerNodeIdentifier.findViewById(R.id.text);
         nodeIdentifier.setText(node.getNodeIdentifier());
 
         final View containerUnicastAddress = findViewById(R.id.container_unicast_address);
+        containerUnicastAddress.setClickable(false);
         final TextView unicastAddress = containerUnicastAddress.findViewById(R.id.text);
         unicastAddress.setText(MeshParserUtils.bytesToHex(node.getUnicastAddress(), false));
 
+        final View containerDeviceKey = findViewById(R.id.container_device_key);
+        containerDeviceKey.setClickable(false);
+        final TextView deviceKey = containerDeviceKey.findViewById(R.id.text);
+        deviceKey.setText(MeshParserUtils.bytesToHex(node.getDeviceKey(), false));
+
+        final View copyDeviceKey = findViewById(R.id.copy);
+        copyDeviceKey.setOnClickListener(v -> {
+            if(clipboard != null) {
+                final ClipData clipDeviceKey = ClipData.newPlainText("Device Key", MeshParserUtils.bytesToHex(node.getDeviceKey(), false));
+                clipboard.setPrimaryClip(clipDeviceKey);
+                Toast.makeText(NodeDetailsActivity.this, R.string.device_key_clipboard_copied, Toast.LENGTH_SHORT).show();
+            }
+        });
+
         final View containerCompanyIdentifier = findViewById(R.id.container_company_identifier);
+        containerCompanyIdentifier.setClickable(false);
         final TextView companyIdentifier = containerCompanyIdentifier.findViewById(R.id.text);
         companyIdentifier.setText(CompanyIdentifiers.getCompanyName((short) node.getCompanyIdentifier()));
 
         final View containerProductIdentifier = findViewById(R.id.container_product_identifier);
+        containerProductIdentifier.setClickable(false);
         final TextView productIdentifier = containerProductIdentifier.findViewById(R.id.text);
         productIdentifier.setText(CompositionDataParser.formatProductIdentifier(node.getProductIdentifier(), false));
 
         final View containerProductVersion = findViewById(R.id.container_product_version);
+        containerProductVersion.setClickable(false);
         final TextView productVersion = containerProductVersion.findViewById(R.id.text);
         productVersion.setText(CompositionDataParser.formatVersionIdentifier(node.getVersionIdentifier(), false));
 
-        node.getVersionIdentifier();
         final View containerCrpl = findViewById(R.id.container_crpl);
+        containerCrpl.setClickable(false);
         final TextView crpl = containerCrpl.findViewById(R.id.text);
         crpl.setText(CompositionDataParser.formatReplayProtectionCount(node.getCrpl(), false));
 
         final View containerFeatures = findViewById(R.id.container_features);
+        containerFeatures.setClickable(false);
         final TextView features = containerFeatures.findViewById(R.id.text);
         features.setText(CompositionDataParser.formatFeatures(node.getFeatures(), false));
 

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/NodeDetailsActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/NodeDetailsActivity.java
@@ -108,27 +108,47 @@ public class NodeDetailsActivity extends AppCompatActivity implements Injectable
         final View containerCompanyIdentifier = findViewById(R.id.container_company_identifier);
         containerCompanyIdentifier.setClickable(false);
         final TextView companyIdentifier = containerCompanyIdentifier.findViewById(R.id.text);
-        companyIdentifier.setText(CompanyIdentifiers.getCompanyName((short) node.getCompanyIdentifier()));
+        if(node.getCompanyIdentifier() != null) {
+            companyIdentifier.setText(CompanyIdentifiers.getCompanyName(node.getCompanyIdentifier().shortValue()));
+        } else {
+            companyIdentifier.setText(R.string.unavailable);
+        }
 
         final View containerProductIdentifier = findViewById(R.id.container_product_identifier);
         containerProductIdentifier.setClickable(false);
         final TextView productIdentifier = containerProductIdentifier.findViewById(R.id.text);
-        productIdentifier.setText(CompositionDataParser.formatProductIdentifier(node.getProductIdentifier(), false));
+        if(node.getProductIdentifier() != null) {
+            productIdentifier.setText(CompositionDataParser.formatProductIdentifier(node.getProductIdentifier().shortValue(), false));
+        } else {
+            productIdentifier.setText(R.string.unavailable);
+        }
 
         final View containerProductVersion = findViewById(R.id.container_product_version);
         containerProductVersion.setClickable(false);
         final TextView productVersion = containerProductVersion.findViewById(R.id.text);
-        productVersion.setText(CompositionDataParser.formatVersionIdentifier(node.getVersionIdentifier(), false));
+        if(node.getVersionIdentifier() != null) {
+            productVersion.setText(CompositionDataParser.formatVersionIdentifier(node.getVersionIdentifier().shortValue(), false));
+        } else {
+            productVersion.setText(R.string.unavailable);
+        }
 
         final View containerCrpl = findViewById(R.id.container_crpl);
         containerCrpl.setClickable(false);
         final TextView crpl = containerCrpl.findViewById(R.id.text);
-        crpl.setText(CompositionDataParser.formatReplayProtectionCount(node.getCrpl(), false));
+        if(node.getCrpl() != null) {
+            crpl.setText(CompositionDataParser.formatReplayProtectionCount(node.getCrpl().shortValue(), false));
+        } else {
+            crpl.setText(R.string.unavailable);
+        }
 
         final View containerFeatures = findViewById(R.id.container_features);
         containerFeatures.setClickable(false);
         final TextView features = containerFeatures.findViewById(R.id.text);
-        features.setText(CompositionDataParser.formatFeatures(node.getFeatures(), false));
+        if(node.getFeatures() != null) {
+            features.setText(CompositionDataParser.formatFeatures(node.getFeatures().shortValue(), false));
+        } else {
+            features.setText(R.string.unavailable);
+        }
 
         final TextView view =  findViewById(R.id.no_elements_view);
         mRecyclerView = findViewById(R.id.recycler_view_elements);

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/NodeAdapter.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/NodeAdapter.java
@@ -80,7 +80,7 @@ public class NodeAdapter extends RecyclerView.Adapter<NodeAdapter.ViewHolder>{
         if(elements != null && !elements.isEmpty()) {
             holder.notConfiguredView.setVisibility(View.GONE);
             holder.nodeInfoContainer.setVisibility(View.VISIBLE);
-            holder.companyIdentifier.setText(CompanyIdentifiers.getCompanyName((short) node.getCompanyIdentifier()));
+            holder.companyIdentifier.setText(CompanyIdentifiers.getCompanyName(node.getCompanyIdentifier().shortValue()));
             holder.elements.setText(String.valueOf(elements.size()));
             holder.models.setText(String.valueOf(getModels(elements)));
         } else {

--- a/Example/nrf-mesh/app/src/main/res/drawable/ic_content_copy_black_24dp_alpha.xml
+++ b/Example/nrf-mesh/app/src/main/res/drawable/ic_content_copy_black_24dp_alpha.xml
@@ -1,0 +1,5 @@
+<vector android:alpha="0.6" android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M16,1L4,1c-1.1,0 -2,0.9 -2,2v14h2L4,3h12L16,1zM19,5L8,5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h11c1.1,0 2,-0.9 2,-2L21,7c0,-1.1 -0.9,-2 -2,-2zM19,21L8,21L8,7h11v14z"/>
+</vector>

--- a/Example/nrf-mesh/app/src/main/res/layout/activity_node_details.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/activity_node_details.xml
@@ -145,13 +145,36 @@
                             app:layout_constraintTop_toBottomOf="@+id/container_identifier"/>
 
                         <include
+                            android:id="@+id/container_device_key"
+                            layout="@layout/info_node_device_key"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintEnd_toStartOf="@id/copy"
+                            app:layout_constraintTop_toBottomOf="@+id/container_unicast_address"/>
+
+                        <ImageView
+                            android:id="@+id/copy"
+                            android:layout_width="wrap_content"
+                            android:layout_height="0dp"
+                            android:paddingStart="@dimen/activity_horizontal_margin"
+                            android:paddingEnd="@dimen/activity_horizontal_margin"
+                            android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                            android:background="?selectableItemBackground"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toEndOf="@id/container_device_key"
+                            app:layout_constraintTop_toTopOf="@id/container_device_key"
+                            app:layout_constraintBottom_toBottomOf="@id/container_device_key"
+                            app:srcCompat="@drawable/ic_content_copy_black_24dp_alpha"/>
+
+                        <include
                             android:id="@+id/container_company_identifier"
                             layout="@layout/info_node_company_identifier"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
                             app:layout_constraintLeft_toLeftOf="parent"
                             app:layout_constraintRight_toRightOf="parent"
-                            app:layout_constraintTop_toBottomOf="@+id/container_unicast_address"/>
+                            app:layout_constraintTop_toBottomOf="@+id/container_device_key"/>
 
                         <include
                             android:id="@+id/container_product_identifier"

--- a/Example/nrf-mesh/app/src/main/res/layout/info_node_device_key.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/info_node_device_key.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018, Nordic Semiconductor
+  ~ All rights reserved.
+  ~
+  ~ Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+  ~
+  ~ 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  ~
+  ~ 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+  ~ documentation and/or other materials provided with the distribution.
+  ~
+  ~ 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+  ~ software without specific prior written permission.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+  ~ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?selectableItemBackground"
+    android:clickable="true"
+    android:padding="@dimen/activity_horizontal_margin"
+    android:focusable="true">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:textColor="@android:color/black"
+        android:textSize="16sp"
+        android:text="@string/node_device_key"
+        app:layout_constraintLeft_toRightOf="@id/image"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="RtlSymmetry"/>
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:textSize="12sp"
+        app:layout_constraintLeft_toRightOf="@id/image"
+        app:layout_constraintTop_toBottomOf="@id/title"
+        tools:ignore="RtlSymmetry"/>
+
+    <ImageView
+        android:id="@+id/image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="@+id/text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/title"
+        app:srcCompat="@drawable/ic_vpn_key_black_alpha_24dp"
+        tools:ignore="ContentDescription,VectorDrawableCompat"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -310,4 +310,5 @@
         state. Any stored data related to the node will be deleted from the app. Do you wish to continue?</string>
     <string name="node_device_key">Device Key</string>
     <string name="device_key_clipboard_copied">Device key copied to clipboard</string>
+    <string name="unavailable">Unavailable</string>
 </resources>

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -308,4 +308,6 @@
     <string name="reset_node_rationale">Resetting this node will change its provisioned state back to un-provisioned state.</string>
     <string name="reset_node_rationale_summary">Resetting this node will change its provisioned state back to un-provisioned
         state. Any stored data related to the node will be deleted from the app. Do you wish to continue?</string>
+    <string name="node_device_key">Device Key</string>
+    <string name="device_key_clipboard_copied">Device key copied to clipboard</string>
 </resources>

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNode.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNode.java
@@ -62,11 +62,11 @@ public abstract class BaseMeshNode implements Parcelable {
     protected int mReceivedSequenceNumber;
     protected String bluetoothAddress;
     protected String nodeIdentifier;
-    protected int companyIdentifier;
-    protected int productIdentifier;
-    protected int versionIdentifier;
-    protected int crpl;
-    protected int features;
+    protected Integer companyIdentifier = null;
+    protected Integer productIdentifier = null;
+    protected Integer versionIdentifier = null;
+    protected Integer crpl = null;
+    protected Integer features = null;
     protected boolean relayFeatureSupported;
     protected boolean proxyFeatureSupported;
     protected boolean friendFeatureSupported;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/MeshModel.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/MeshModel.java
@@ -89,10 +89,7 @@ public abstract class MeshModel implements Parcelable {
     private void sortAppKeys(final HashMap<Integer, String> unorderedBoundAppKeys){
         final Set<Integer> unorderedKeys =  unorderedBoundAppKeys.keySet();
 
-        final List<Integer> orderedKeys = new ArrayList<>();
-        for(int key : unorderedKeys) {
-            orderedKeys.add(key);
-        }
+        final List<Integer> orderedKeys = new ArrayList<>(unorderedKeys);
         Collections.sort(orderedKeys);
         for(int key : orderedKeys) {
             mBoundAppKeys.put(key, unorderedBoundAppKeys.get(key));

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/ProvisionedMeshNode.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/ProvisionedMeshNode.java
@@ -78,11 +78,11 @@ public class ProvisionedMeshNode extends BaseMeshNode {
         bluetoothAddress = in.readString();
         k2Output = in.readParcelable(SecureUtils.K2Output.class.getClassLoader());
         nodeIdentifier = in.readString();
-        companyIdentifier = in.readInt();
-        productIdentifier = in.readInt();
-        versionIdentifier = in.readInt();
-        crpl = in.readInt();
-        features = in.readInt();
+        companyIdentifier = (Integer) in.readValue(Integer.class.getClassLoader());
+        productIdentifier = (Integer) in.readValue(Integer.class.getClassLoader());
+        versionIdentifier = (Integer) in.readValue(Integer.class.getClassLoader());
+        crpl = (Integer) in.readValue(Integer.class.getClassLoader());
+        features = (Integer) in.readValue(Integer.class.getClassLoader());
         relayFeatureSupported = in.readByte() != 0;
         proxyFeatureSupported = in.readByte() != 0;
         friendFeatureSupported = in.readByte() != 0;
@@ -111,11 +111,11 @@ public class ProvisionedMeshNode extends BaseMeshNode {
         dest.writeString(bluetoothAddress);
         dest.writeParcelable(k2Output, flags);
         dest.writeString(nodeIdentifier);
-        dest.writeInt(companyIdentifier);
-        dest.writeInt(productIdentifier);
-        dest.writeInt(versionIdentifier);
-        dest.writeInt(crpl);
-        dest.writeInt(features);
+        dest.writeValue(companyIdentifier);
+        dest.writeValue(productIdentifier);
+        dest.writeValue(versionIdentifier);
+        dest.writeValue(crpl);
+        dest.writeValue(features);
         dest.writeByte((byte) (relayFeatureSupported ? 1 : 0));
         dest.writeByte((byte) (proxyFeatureSupported ? 1 : 0));
         dest.writeByte((byte) (friendFeatureSupported ? 1 : 0));
@@ -181,23 +181,23 @@ public class ProvisionedMeshNode extends BaseMeshNode {
         this.k2Output = k2Output;
     }
 
-    public final int getCompanyIdentifier() {
+    public final Integer getCompanyIdentifier() {
         return companyIdentifier;
     }
 
-    public final int getProductIdentifier() {
+    public final Integer getProductIdentifier() {
         return productIdentifier;
     }
 
-    public final int getVersionIdentifier() {
+    public final Integer getVersionIdentifier() {
         return versionIdentifier;
     }
 
-    public final int getCrpl() {
+    public final Integer getCrpl() {
         return crpl;
     }
 
-    public final int getFeatures() {
+    public final Integer getFeatures() {
         return features;
     }
 
@@ -288,10 +288,7 @@ public class ProvisionedMeshNode extends BaseMeshNode {
     private void sortElements(final HashMap<Integer, Element> unorderedElements){
         final Set<Integer> unorderedKeys =  unorderedElements.keySet();
 
-        final List<Integer> orderedKeys = new ArrayList<>();
-        for(int key : unorderedKeys) {
-            orderedKeys.add(key);
-        }
+        final List<Integer> orderedKeys = new ArrayList<>(unorderedKeys);
         Collections.sort(orderedKeys);
         for(int key : orderedKeys) {
             mElements.put(key, unorderedElements.get(key));

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/CompanyIdentifiers.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/CompanyIdentifiers.java
@@ -1606,6 +1606,7 @@ public class CompanyIdentifiers {
      * @return company name;
      */
     public static String getCompanyName(final short companyIdentifier) {
-        return vendorModels.get(companyIdentifier);
+        final String companyName = vendorModels.get(companyIdentifier);
+        return companyName == null ? "Company ID unavailable" : companyName;
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/Element.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/Element.java
@@ -75,10 +75,7 @@ public class Element implements Parcelable {
     private void sortModels(final HashMap<Integer, MeshModel> unorderedElements){
         final Set<Integer> unorderedKeys =  unorderedElements.keySet();
 
-        final List<Integer> orderedKeys = new ArrayList<>();
-        for(int key : unorderedKeys) {
-            orderedKeys.add(key);
-        }
+        final List<Integer> orderedKeys = new ArrayList<>(unorderedKeys);
         Collections.sort(orderedKeys);
         for(int key : orderedKeys) {
             meshModels.put(key, unorderedElements.get(key));


### PR DESCRIPTION
* added an improvement to display the device key on node details with the ability to copy to clipboard.
* bug fix: NodeDetailsActivity was showing wrong composition data for nodes that has not been configured All non-configured nodes had a wrong company identifier being set to a default int value. Now the library handles this properly by using an Integer instead and returning an unknown company ID.