### PR TITLE
Feature/unbind app key

### DIFF
--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/BindAppKeysActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/BindAppKeysActivity.java
@@ -23,39 +23,27 @@
 package no.nordicsemi.android.nrfmeshprovisioner;
 
 import android.app.Activity;
-import android.content.ComponentName;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.design.widget.FloatingActionButton;
-import android.support.design.widget.Snackbar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.DefaultItemAnimator;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
-import android.support.v7.widget.helper.ItemTouchHelper;
 import android.util.SparseArray;
 import android.view.MenuItem;
 import android.view.View;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Set;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import no.nordicsemi.android.nrfmeshprovisioner.adapter.AppKeyAdapter;
-import no.nordicsemi.android.nrfmeshprovisioner.adapter.BoundAppKeyAdapter;
-import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentAddAppKey;
-import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentEditAppKey;
-import no.nordicsemi.android.nrfmeshprovisioner.widgets.ItemTouchHelperAdapter;
-import no.nordicsemi.android.nrfmeshprovisioner.widgets.RemovableItemTouchHelperCallback;
-import no.nordicsemi.android.nrfmeshprovisioner.widgets.RemovableViewHolder;
+import no.nordicsemi.android.nrfmeshprovisioner.adapter.BindAppKeyAdapter;
 
-public class BindAppKeysActivity extends AppCompatActivity implements BoundAppKeyAdapter.OnItemClickListener {
+public class BindAppKeysActivity extends AppCompatActivity implements BindAppKeyAdapter.OnItemClickListener {
 
     public static final String RESULT_APP_KEY = "RESULT_APP_KEY";
     public static final String RESULT_APP_KEY_INDEX = "RESULT_APP_KEY_INDEX";
@@ -68,7 +56,7 @@ public class BindAppKeysActivity extends AppCompatActivity implements BoundAppKe
     View container;
 
     private SparseArray<String> mAppKeysMap = new SparseArray<>();
-    private BoundAppKeyAdapter mAdapter;
+    private BindAppKeyAdapter mAdapter;
 
     @Override
     protected void onCreate(@Nullable final Bundle savedInstanceState) {
@@ -90,7 +78,7 @@ public class BindAppKeysActivity extends AppCompatActivity implements BoundAppKe
         final DividerItemDecoration dividerItemDecoration = new DividerItemDecoration(appKeysRecyclerView.getContext(), DividerItemDecoration.VERTICAL);
         appKeysRecyclerView.addItemDecoration(dividerItemDecoration);
         appKeysRecyclerView.setItemAnimator(new DefaultItemAnimator());
-        mAdapter = new BoundAppKeyAdapter(this, mAppKeysMap);
+        mAdapter = new BindAppKeyAdapter(this, mAppKeysMap);
         mAdapter.setOnItemClickListener(this);
         appKeysRecyclerView.setAdapter(mAdapter);
 

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/AddressAdapter.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/AddressAdapter.java
@@ -98,7 +98,7 @@ public class AddressAdapter extends RecyclerView.Adapter<AddressAdapter.ViewHold
         void onItemClick(final int position, final byte[] address);
     }
 
-    final class ViewHolder extends RemovableViewHolder {
+    public final class ViewHolder extends RemovableViewHolder {
 
         @BindView(R.id.address)
         TextView address;

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/BindAppKeyAdapter.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/BindAppKeyAdapter.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2018, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.android.nrfmeshprovisioner.adapter;
+
+import android.content.Context;
+import android.support.v7.widget.RecyclerView;
+import android.util.SparseArray;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import no.nordicsemi.android.nrfmeshprovisioner.R;
+import no.nordicsemi.android.nrfmeshprovisioner.widgets.RemovableViewHolder;
+
+public class BindAppKeyAdapter extends RecyclerView.Adapter<BindAppKeyAdapter.ViewHolder> {
+
+    private final SparseArray<String> appKeys;
+    private final Context mContext;
+    private OnItemClickListener mOnItemClickListener;
+
+    public BindAppKeyAdapter(final Context context, final SparseArray<String> appKeys) {
+        this.mContext = context;
+        this.appKeys = appKeys;
+    }
+
+    public void setOnItemClickListener(final BindAppKeyAdapter.OnItemClickListener listener) {
+        mOnItemClickListener = listener;
+    }
+
+    @Override
+    public BindAppKeyAdapter.ViewHolder onCreateViewHolder(final ViewGroup parent, final int viewType) {
+        final View layoutView = LayoutInflater.from(mContext).inflate(R.layout.app_key_item, parent, false);
+        return new BindAppKeyAdapter.ViewHolder(layoutView);
+    }
+
+    @Override
+    public void onBindViewHolder(final BindAppKeyAdapter.ViewHolder holder, final int position) {
+        if(appKeys.size() > 0) {
+            holder.appKeyId.setText(mContext.getString(R.string.app_key_item , position + 1));
+            final String appKey = appKeys.get(appKeys.keyAt(position));
+            holder.appKey.setText(appKey.toUpperCase());
+        }
+    }
+
+    @Override
+    public long getItemId(final int position) {
+        return position;
+    }
+
+    @Override
+    public int getItemCount() {
+        return appKeys.size();
+    }
+
+    public boolean isEmpty() {
+        return getItemCount() == 0;
+    }
+
+    @FunctionalInterface
+    public interface OnItemClickListener {
+        void onItemClick(final int position, final String appKey);
+    }
+
+    final class ViewHolder extends RemovableViewHolder {
+
+        @BindView(R.id.app_key_id)
+        TextView appKeyId;
+        @BindView(R.id.app_key)
+        TextView appKey;
+
+        private ViewHolder(final View view) {
+            super(view);
+            ButterKnife.bind(this, view);
+            view.findViewById(R.id.removable).setOnClickListener(v -> {
+                if (mOnItemClickListener != null) {
+                    final int key = appKeys.keyAt(getAdapterPosition());
+                    mOnItemClickListener.onItemClick(key, appKeys.get(key));
+                }
+            });
+        }
+    }
+}

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/ManageAppKeyAdapter.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/ManageAppKeyAdapter.java
@@ -53,7 +53,6 @@ public class ManageAppKeyAdapter extends RecyclerView.Adapter<ManageAppKeyAdapte
             if(provisioningSettings != null){
                 appKeys.clear();
                 appKeys.addAll(provisioningSettings.getAppKeys());
-                //populateAppKeysMap(provisioningSettings.getAppKeys());
             }
             notifyDataSetChanged();
         });
@@ -62,16 +61,6 @@ public class ManageAppKeyAdapter extends RecyclerView.Adapter<ManageAppKeyAdapte
     public void setOnItemClickListener(final ManageAppKeyAdapter.OnItemClickListener listener) {
         mOnItemClickListener = listener;
     }
-
-    /*private void populateAppKeysMap(final Map<Integer, String> tempAppKeys){
-        appKeys.clear();
-
-        for (Map.Entry<Integer, String> entry : tempAppKeys.entrySet()) {
-            int key = entry.getKey();
-            String value = entry.getValue();
-            appKeys.put(key,value);
-        }
-    }*/
 
     @Override
     public ManageAppKeyAdapter.ViewHolder onCreateViewHolder(final ViewGroup parent, final int viewType) {
@@ -101,15 +90,6 @@ public class ManageAppKeyAdapter extends RecyclerView.Adapter<ManageAppKeyAdapte
     public boolean isEmpty() {
         return getItemCount() == 0;
     }
-
-    /*public int getLastKey() {
-        if(appKeys.size() == 0) {
-            return 0;
-        } else {
-            final int count = getItemCount();
-            return appKeys.keyAt(count - 1);
-        }
-    }*/
 
     @FunctionalInterface
     public interface OnItemClickListener {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ModelConfigurationRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ModelConfigurationRepository.java
@@ -147,6 +147,7 @@ public class ModelConfigurationRepository extends BaseMeshRepository {
                     final int appKeyIndex = intent.getExtras().getInt(EXTRA_APP_KEY_INDEX);
                     final int modelId = intent.getExtras().getInt(EXTRA_MODEL_ID);
                     mExtendedMeshNode.updateMeshNode(node);
+                    mMeshModel.postValue(model);
                     mAppKeyBindStatus.onStatusChanged(success, statusCode, elementAddress, appKeyIndex, modelId);
                 }
                 break;
@@ -208,8 +209,17 @@ public class ModelConfigurationRepository extends BaseMeshRepository {
      *
      * @param appKeyIndex index of the application key that has already been added to the mesh node
      */
-    public void bindAppKey(final int appKeyIndex) {
+    public void sendBindAppKey(final int appKeyIndex) {
         mBinder.sendBindAppKey(mExtendedMeshNode.getMeshNode(), mElement.getValue().getElementAddress(), mMeshModel.getValue(), appKeyIndex);
+    }
+
+    /**
+     * Unbbinds appkey to model
+     *
+     * @param appKeyIndex index of the application key that has already been added to the mesh node
+     */
+    public void sendUnbindAppKey(final int appKeyIndex) {
+        mBinder.sendUnbindAppKey(mExtendedMeshNode.getMeshNode(), mElement.getValue().getElementAddress(), mMeshModel.getValue(), appKeyIndex);
     }
 
     public void sendConfigModelPublishAddressSet(final byte[] publishAddress) {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/service/MeshService.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/service/MeshService.java
@@ -982,6 +982,10 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
             mMeshManagerApi.bindAppKey(meshNode, elementAddress, meshModel, appKeyIndex);
         }
 
+        public void sendUnbindAppKey(final ProvisionedMeshNode meshNode, final byte[] elementAddress, final MeshModel meshModel, final int appKeyIndex) {
+            mMeshManagerApi.unbindAppKey(meshNode, elementAddress, meshModel, appKeyIndex);
+        }
+
         public void sendConfigModelPublishAddressSet(final ProvisionedMeshNode node, final Element element, final MeshModel meshModel, final int appKeyIndex, final byte[] publishAddress) {
             mMeshManagerApi.setConfigModelPublishAddress(node,
                     element.getElementAddress(), publishAddress, appKeyIndex, meshModel.getModelId(), 0, 0xFF, 0, 0, 0);

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/ModelConfigurationViewModel.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/ModelConfigurationViewModel.java
@@ -78,8 +78,12 @@ public class ModelConfigurationViewModel extends ViewModel {
         return mModelConfigurationRepository.getExtendedMeshNode();
     }
 
-    public void bindAppKey(final int appKeyIndex) {
-        mModelConfigurationRepository.bindAppKey(appKeyIndex);
+    public void sendBindAppKey(final int appKeyIndex) {
+        mModelConfigurationRepository.sendBindAppKey(appKeyIndex);
+    }
+
+    public void sendUnbindAppKey(final int appKeyIndex) {
+        mModelConfigurationRepository.sendUnbindAppKey(appKeyIndex);
     }
 
     public LiveData<AppKeyBindStatusLiveData> getAppKeyBindStatusLiveData() {

--- a/Example/nrf-mesh/app/src/main/res/layout/activity_model_configuration.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/activity_model_configuration.xml
@@ -108,54 +108,46 @@
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent"
-                        app:logo="@drawable/ic_vpn_key_black_alpha_24dp"
-                        app:title="@string/title_app_key"
+                        app:logo="@drawable/ic_folder_key_black_24dp_alpha"
+                        app:title="@string/title_bound_app_keys"
                         app:titleMarginStart="@dimen/toolbar_title_margin"/>
+
 
                     <android.support.constraint.ConstraintLayout
                         android:id="@+id/container_app_key_bind"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:background="?selectableItemBackground"
-                        android:paddingBottom="@dimen/item_padding_bottom"
-                        android:paddingEnd="@dimen/activity_horizontal_margin"
-                        android:paddingStart="@dimen/activity_horizontal_margin"
-                        android:paddingTop="@dimen/item_padding_top"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/app_key_tool_bar">
+                        app:layout_constraintLeft_toLeftOf="parent"
+                        app:layout_constraintRight_toRightOf="parent"
+                        app:layout_constraintTop_toBottomOf="@+id/app_key_tool_bar">
 
                         <TextView
-                            android:id="@+id/app_key_title"
+                            android:id="@+id/bound_keys"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:paddingStart="@dimen/activity_horizontal_margin"
-                            android:text="@string/title_bound_app_keys"
+                            android:text="@string/no_app_keys_bound"
                             android:textColor="@android:color/black"
-                            android:textSize="16sp"
+                            android:textSize="14sp"
+                            android:paddingTop="@dimen/item_padding_top"
+                            android:paddingBottom="@dimen/item_padding_bottom"
+                            android:paddingEnd="@dimen/activity_horizontal_margin"
+                            android:paddingStart="@dimen/activity_horizontal_margin"
                             app:layout_constraintEnd_toEndOf="parent"
-                            app:layout_constraintStart_toEndOf="@id/image"
+                            app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toTopOf="parent"/>
 
-                        <TextView
-                            android:id="@+id/app_key_index"
+                        <android.support.v7.widget.RecyclerView
+                            android:id="@+id/recycler_view_bound_keys"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
-                            android:paddingStart="@dimen/activity_horizontal_margin"
-                            android:text="None"
-                            android:textSize="12sp"
+                            android:clipToPadding="false"
+                            android:scrollbars="none"
+                            android:visibility="gone"
+                            app:layout_constraintBottom_toBottomOf="parent"
                             app:layout_constraintEnd_toEndOf="parent"
-                            app:layout_constraintStart_toEndOf="@id/image"
-                            app:layout_constraintTop_toBottomOf="@id/app_key_title"/>
-
-                        <ImageView
-                            android:id="@+id/image"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            app:layout_constraintBottom_toBottomOf="@+id/app_key_index"
                             app:layout_constraintStart_toStartOf="parent"
-                            app:layout_constraintTop_toTopOf="@+id/app_key_title"
-                            app:srcCompat="@drawable/ic_index"/>
+                            app:layout_constraintTop_toTopOf="parent"/>
 
                     </android.support.constraint.ConstraintLayout>
 
@@ -167,6 +159,19 @@
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintStart_toEndOf="@id/icon"
                         app:layout_constraintTop_toBottomOf="@id/container_app_key_bind"/>
+
+                    <TextView
+                        android:id="@+id/unbind_hint"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="@dimen/item_padding_end"
+                        android:padding="@dimen/activity_horizontal_margin"
+                        android:text="@string/hint_unbind"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/div1"
+                        android:visibility="invisible"
+                        tools:visibility="visible"/>
 
                     <Button
                         android:id="@+id/action_bind_app_key"

--- a/Example/nrf-mesh/app/src/main/res/layout/bound_app_key_item.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/bound_app_key_item.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018, Nordic Semiconductor
+  ~ All rights reserved.
+  ~
+  ~ Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+  ~
+  ~ 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  ~
+  ~ 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+  ~ documentation and/or other materials provided with the distribution.
+  ~
+  ~ 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+  ~ software without specific prior written permission.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+  ~ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             xmlns:tools="http://schemas.android.com/tools"
+             android:layout_width="match_parent"
+             android:layout_height="wrap_content"
+             xmlns:app="http://schemas.android.com/apk/res-auto"
+             android:background="@color/background_swipe_delete"
+             tools:ignore="ContentDescription">
+
+    <android.support.v7.widget.AppCompatImageView
+        android:id="@+id/icon_delete"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:srcCompat="@drawable/ic_delete_white"
+        android:layout_gravity="center_vertical"
+        android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:layout_marginEnd="@dimen/activity_horizontal_margin"/>
+
+    <LinearLayout
+        android:id="@+id/removable"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:background="@android:color/white"
+        android:paddingBottom="@dimen/item_padding_bottom"
+        android:paddingEnd="@dimen/activity_horizontal_margin"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/item_padding_top"
+        tools:ignore="ContentDescription">
+
+        <android.support.v7.widget.AppCompatImageView
+            android:id="@+id/icon"
+            android:layout_width="wrap_content"
+            android:layout_height="match_parent"
+            android:scaleType="center"
+            android:alpha="0.8"
+            app:srcCompat="@drawable/ic_vpn_key_black_alpha_24dp"/>
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="match_parent"
+            android:orientation="vertical">
+            <TextView
+                android:id="@+id/app_key_id"
+                android:text="AppKey 0"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                android:layout_marginStart="@dimen/activity_horizontal_margin"
+                android:ellipsize="end"
+                android:singleLine="true"
+                android:textSize="16sp"
+                android:textColor="@android:color/black"/>
+
+            <TextView
+                android:id="@+id/app_key"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                android:layout_marginStart="@dimen/activity_horizontal_margin"
+                android:ellipsize="end"
+                android:singleLine="true"
+                android:textSize="12sp"
+                android:textColor="@color/textColorSecondary"/>
+        </LinearLayout>
+    </LinearLayout>
+</FrameLayout>

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -226,6 +226,7 @@
     <string name="get_composition_data_action">Get Composition Data</string>
     <string name="title_appkey_status">AppKey Status</string>
     <string name="app_key_item">App key %d</string>
+    <string name="app_key_index_item">Key Index: %d</string>
     <string name="error_node_name">Node name cannot be empty!</string>
     <string name="element_address">Element : %s</string>
     <string name="model_count">%d Models</string>
@@ -236,9 +237,9 @@
     <string name="model_id_type_vendor">Vendor Model ID:</string>
 
     <string name="title_publish_address">Publish Address</string>
-    <string name="title_subscription_addresseses">Subscription Addresses</string>
+    <string name="title_subscription_addresses">Subscription Addresses</string>
     <string name="none">None</string>
-    <string name="no_app_keys_bound">0 app keys bound</string>
+    <string name="no_app_keys_bound">No app keys are bound to this model.</string>
     <string name="app_keys_bound">%d app keys bound</string>
     <string name="no_publish_addresses">Publish address not set</string>
     <string name="no_subscription_addresses">No subscription address</string>
@@ -316,4 +317,5 @@
     <string name="node_device_key">Device Key</string>
     <string name="device_key_clipboard_copied">Device key copied to clipboard</string>
     <string name="unavailable">Unavailable</string>
+    <string name="hint_unbind">Hint: Swipe key to unbind.</string>
 </resources>

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshConfigurationHandler.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshConfigurationHandler.java
@@ -31,6 +31,7 @@ import no.nordicsemi.android.meshprovisioner.configuration.ConfigCompositionData
 import no.nordicsemi.android.meshprovisioner.configuration.ConfigMessage;
 import no.nordicsemi.android.meshprovisioner.configuration.ConfigModelAppBind;
 import no.nordicsemi.android.meshprovisioner.configuration.ConfigModelAppStatus;
+import no.nordicsemi.android.meshprovisioner.configuration.ConfigModelAppUnbind;
 import no.nordicsemi.android.meshprovisioner.configuration.ConfigModelPublicationSet;
 import no.nordicsemi.android.meshprovisioner.configuration.ConfigModelPublicationStatus;
 import no.nordicsemi.android.meshprovisioner.configuration.ConfigModelSubscriptionAdd;
@@ -80,7 +81,10 @@ class MeshConfigurationHandler {
                 //Block ack for app key status sent
                 break;
             case CONFIG_MODEL_APP_BIND:
-                configMessage = new ConfigModelAppStatus(mContext, meshNode, mInternalTransportCallbacks, mStatusCallbacks);
+                configMessage = new ConfigModelAppStatus(mContext, meshNode, configMessage.getState().getState(), mInternalTransportCallbacks, mStatusCallbacks);
+                break;
+            case CONFIG_MODEL_APP_UNBIND:
+                configMessage = new ConfigModelAppStatus(mContext, meshNode, configMessage.getState().getState(), mInternalTransportCallbacks, mStatusCallbacks);
                 break;
             case CONFIG_MODEL_APP_STATUS:
                 break;
@@ -127,10 +131,12 @@ class MeshConfigurationHandler {
                 ((ConfigAppKeyStatus) configMessage).parseData(pdu);
                 break;
             case CONFIG_MODEL_APP_BIND:
-                final ConfigModelAppBind configModelAppBind = ((ConfigModelAppBind) configMessage);
+                /*final ConfigModelAppBind configModelAppBind = ((ConfigModelAppBind) configMessage);
                 configModelAppBind.parseData(pdu);
                 //publication set block ack received, switch to next state.
-                configMessage = new ConfigModelAppStatus(mContext, meshNode, mInternalTransportCallbacks, mStatusCallbacks);
+                configMessage = new ConfigModelAppStatus(mContext, meshNode, configMessage.getMessageType(), mInternalTransportCallbacks, mStatusCallbacks);*/
+            case CONFIG_MODEL_APP_UNBIND:
+                break;
             case CONFIG_MODEL_APP_STATUS:
                 ((ConfigModelAppStatus) configMessage).parseData(pdu);
                 break;
@@ -208,6 +214,25 @@ class MeshConfigurationHandler {
     public void bindAppKey(final ProvisionedMeshNode meshNode, final int aszmic,
                            final byte[] elementAddress, final int modelIdentifier, final int appKeyIndex) {
         final ConfigModelAppBind configModelAppBind = new ConfigModelAppBind(mContext, meshNode, aszmic,
+                elementAddress, modelIdentifier, appKeyIndex);
+        configModelAppBind.setTransportCallbacks(mInternalTransportCallbacks);
+        configModelAppBind.setConfigurationStatusCallbacks(mStatusCallbacks);
+        configMessage = configModelAppBind;
+        configModelAppBind.executeSend();
+    }
+
+    /**
+     * Unbinds a previously bound app key from a specified model
+     *
+     * @param meshNode        mesh node containing the model
+     * @param aszmic          application mic size, if 0 uses 32-bit encryption and 64-bit otherwise
+     * @param elementAddress  address of the element containing the model
+     * @param modelIdentifier identifier of the model. This could be 16-bit SIG Model or a 32-bit Vendor model identifier
+     * @param appKeyIndex     application key index
+     */
+    public void unbindAppKey(final ProvisionedMeshNode meshNode, final int aszmic,
+                             final byte[] elementAddress, final int modelIdentifier, final int appKeyIndex) {
+        final ConfigModelAppUnbind configModelAppBind = new ConfigModelAppUnbind(mContext, meshNode, aszmic,
                 elementAddress, modelIdentifier, appKeyIndex);
         configModelAppBind.setTransportCallbacks(mInternalTransportCallbacks);
         configModelAppBind.setConfigurationStatusCallbacks(mStatusCallbacks);
@@ -340,8 +365,8 @@ class MeshConfigurationHandler {
      * @param provisionedMeshNode mesh node to be reset
      */
     public void resetMeshNode(final ProvisionedMeshNode provisionedMeshNode) {
-       final ConfigNodeReset configNodeReset = new ConfigNodeReset(mContext, provisionedMeshNode, false, mInternalTransportCallbacks, mStatusCallbacks);
-       configNodeReset.executeSend();
-       configMessage = configNodeReset;
+        final ConfigNodeReset configNodeReset = new ConfigNodeReset(mContext, provisionedMeshNode, false, mInternalTransportCallbacks, mStatusCallbacks);
+        configNodeReset.executeSend();
+        configMessage = configNodeReset;
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
@@ -752,6 +752,18 @@ public class MeshManagerApi implements InternalTransportCallbacks, InternalMeshM
     }
 
     /**
+     * Unbinds a previously bound the app key.
+     *
+     * @param meshNode       corresponding mesh node
+     * @param elementAddress elementAddress
+     * @param model          16-bit SIG Model Identifier or 32-bit Vendor Model identifier
+     * @param appKeyIndex    index of the app key
+     */
+    public void unbindAppKey(final ProvisionedMeshNode meshNode, final byte[] elementAddress, final MeshModel model, final int appKeyIndex) {
+        mMeshConfigurationHandler.unbindAppKey(meshNode, 0, elementAddress, model.getModelId(), appKeyIndex);
+    }
+
+    /**
      * Set a publish address for configuration model
      *
      * @param provisionedMeshNode            Mesh node containing the model

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/ConfigMessage.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/ConfigMessage.java
@@ -49,6 +49,7 @@ public abstract class ConfigMessage implements LowerTransportLayerCallbacks {
     MeshConfigurationStatusCallbacks mConfigStatusCallbacks;
     protected MeshModel mMeshModel;
     protected int mAppKeyIndex;
+    protected int messageType;
 
     public ConfigMessage(final Context context, final ProvisionedMeshNode provisionedMeshNode) {
         this.mContext = context;
@@ -92,6 +93,10 @@ public abstract class ConfigMessage implements LowerTransportLayerCallbacks {
         return mAppKeyIndex;
     }
 
+    public int getMessageType() {
+        return messageType;
+    }
+
     public enum MessageState {
         //Configuration message states
         COMPOSITION_DATA_GET(ConfigMessageOpCodes.CONFIG_COMPOSITION_DATA_GET),
@@ -99,6 +104,7 @@ public abstract class ConfigMessage implements LowerTransportLayerCallbacks {
         APP_KEY_ADD(ConfigMessageOpCodes.CONFIG_APPKEY_ADD),
         APP_KEY_STATUS(ConfigMessageOpCodes.CONFIG_APPKEY_STATUS),
         CONFIG_MODEL_APP_BIND(ConfigMessageOpCodes.CONFIG_MODEL_APP_BIND),
+        CONFIG_MODEL_APP_UNBIND(ConfigMessageOpCodes.CONFIG_MODEL_APP_UNBIND),
         CONFIG_MODEL_APP_STATUS(ConfigMessageOpCodes.CONFIG_MODEL_APP_STATUS),
         CONFIG_MODEL_PUBLICATION_SET(ConfigMessageOpCodes.CONFIG_MODEL_PUBLICATION_SET),
         CONFIG_MODEL_PUBLICATION_STATUS(ConfigMessageOpCodes.CONFIG_MODEL_PUBLICATION_STATUS),

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/ConfigModelAppStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/ConfigModelAppStatus.java
@@ -150,20 +150,28 @@ public final class ConfigModelAppStatus extends ConfigMessage {
                     statusMessage = parseStatusMessage(mContext, status);
                     parseStatus(status);
                     Log.v(TAG, "Status: " + isSuccessful);
-                    Log.v(TAG, "Status message: " + statusMessage);
-                    Log.v(TAG, "App key index: " + MeshParserUtils.bytesToHex(appKeyIndex, false));
-                    Log.v(TAG, "Model Identifier: " + MeshParserUtils.bytesToHex(modelIdentifier, false));
 
                     if(previiousMessageType == ConfigMessageOpCodes.CONFIG_MODEL_APP_BIND) {
-                        mProvisionedMeshNode.setAppKeyBindStatus(this);
+                        if(isSuccessful) {
+                            mProvisionedMeshNode.setAppKeyBindStatus(this);
+                            statusMessage = "App key was successfully bound";
+                            Log.v(TAG, "Status message: " + statusMessage);
+                        }
                     } else {
-                        mProvisionedMeshNode.setAppKeyUnbindStatus(this);
+                        if(isSuccessful) {
+                            mProvisionedMeshNode.setAppKeyUnbindStatus(this);
+                            statusMessage = "App key was successfully unbound";
+                            Log.v(TAG, "Status message: " + statusMessage);
+                        }
                     }
+                    Log.v(TAG, "App key index: " + MeshParserUtils.bytesToHex(appKeyIndex, false));
+                    Log.v(TAG, "Model Identifier: " + MeshParserUtils.bytesToHex(modelIdentifier, false));
 
                     mConfigStatusCallbacks.onAppKeyBindStatusReceived(mProvisionedMeshNode, isSuccessful, status,
                             AddressUtils.getUnicastAddressInt(elementAddress), getAppKeyIndexInt(), getModelIdentifierInt());
                     mInternalTransportCallbacks.updateMeshNode(mProvisionedMeshNode);
                 } else {
+                    Log.v(TAG, "Unknown pdu received!");
                     mConfigStatusCallbacks.onUnknownPduReceived(mProvisionedMeshNode);
                 }
             } else {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/ConfigModelAppStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/ConfigModelAppStatus.java
@@ -52,12 +52,16 @@ public final class ConfigModelAppStatus extends ConfigMessage {
     private byte[] modelIdentifier; //16-bit SIG Model or 32-bit Vendor Model identifier
     private boolean isSuccessful;
     private String statusMessage;
+    private final int previiousMessageType;
 
     public ConfigModelAppStatus(Context context,
                                 final ProvisionedMeshNode unprovisionedMeshNode,
+                                final int previousMessageType,
                                 final InternalTransportCallbacks internalTransportCallbacks,
                                 final MeshConfigurationStatusCallbacks meshConfigurationStatusCallbacks) {
         super(context, unprovisionedMeshNode);
+        this.messageType = previousMessageType;
+        this.previiousMessageType = previousMessageType;
         this.mInternalTransportCallbacks = internalTransportCallbacks;
         this.mConfigStatusCallbacks = meshConfigurationStatusCallbacks;
     }
@@ -150,7 +154,12 @@ public final class ConfigModelAppStatus extends ConfigMessage {
                     Log.v(TAG, "App key index: " + MeshParserUtils.bytesToHex(appKeyIndex, false));
                     Log.v(TAG, "Model Identifier: " + MeshParserUtils.bytesToHex(modelIdentifier, false));
 
-                    mProvisionedMeshNode.setConfigModelAppStatus(this);
+                    if(previiousMessageType == ConfigMessageOpCodes.CONFIG_MODEL_APP_BIND) {
+                        mProvisionedMeshNode.setAppKeyBindStatus(this);
+                    } else {
+                        mProvisionedMeshNode.setAppKeyUnbindStatus(this);
+                    }
+
                     mConfigStatusCallbacks.onAppKeyBindStatusReceived(mProvisionedMeshNode, isSuccessful, status,
                             AddressUtils.getUnicastAddressInt(elementAddress), getAppKeyIndexInt(), getModelIdentifierInt());
                     mInternalTransportCallbacks.updateMeshNode(mProvisionedMeshNode);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/ConfigModelAppUnbind.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/ConfigModelAppUnbind.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2018, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.android.meshprovisioner.configuration;
+
+import android.content.Context;
+import android.util.Log;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import no.nordicsemi.android.meshprovisioner.InternalTransportCallbacks;
+import no.nordicsemi.android.meshprovisioner.MeshConfigurationStatusCallbacks;
+import no.nordicsemi.android.meshprovisioner.messages.AccessMessage;
+import no.nordicsemi.android.meshprovisioner.messages.ControlMessage;
+import no.nordicsemi.android.meshprovisioner.messages.Message;
+import no.nordicsemi.android.meshprovisioner.opcodes.ConfigMessageOpCodes;
+import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
+
+/**
+ * This class handles binding application keys to a specific model where the mode could be,
+ * a 16-bit Bluetooth SigModel or a 32-bit Vendor Model
+ */
+public final class ConfigModelAppUnbind extends ConfigMessage {
+
+    private static final String TAG = ConfigModelAppUnbind.class.getSimpleName();
+
+    private static final int SIG_MODEL_APP_KEY_BIND_PARAMS_LENGTH = 6;
+    private static final int VENDOR_MODEL_APP_KEY_BIND_PARAMS_LENGTH = 8;
+
+    private final int akf = 0;
+    private final int aid = 0;
+
+    private final int mAszmic;
+    private final byte[] mElementAddress;
+    private final int mModelIdentifier;
+    private final int mAppKeyIndex;
+
+    public ConfigModelAppUnbind(final Context context,
+                                final ProvisionedMeshNode meshNode,
+                                final int aszmic,
+                                final byte[] elementAddress, final int modelIdentifier,
+                                final int appKeyIndex) {
+        super(context, meshNode);
+        this.mAszmic = aszmic == 1 ? 1 : 0;
+        this.mElementAddress = elementAddress;
+        this.mModelIdentifier = modelIdentifier;
+        this.mAppKeyIndex = appKeyIndex;
+        createAccessMessage();
+    }
+
+    public void setTransportCallbacks(final InternalTransportCallbacks callbacks) {
+        this.mInternalTransportCallbacks = callbacks;
+    }
+
+    public void setConfigurationStatusCallbacks(final MeshConfigurationStatusCallbacks callbacks) {
+        this.mConfigStatusCallbacks = callbacks;
+    }
+
+    @Override
+    public MessageState getState() {
+        return MessageState.CONFIG_MODEL_APP_UNBIND;
+    }
+
+    /**
+     * Creates the access message to be sent to the node
+     */
+    private void createAccessMessage() {
+        ByteBuffer paramsBuffer;
+        byte[] parameters;
+        final byte[] applicationKeyIndex = MeshParserUtils.addKeyIndexPadding(mAppKeyIndex);
+        //We check if the model identifier value is within the range of a 16-bit value here. If it is then it is a sigmodel
+        if (mModelIdentifier >= Short.MIN_VALUE && mModelIdentifier <= Short.MAX_VALUE) {
+            paramsBuffer = ByteBuffer.allocate(SIG_MODEL_APP_KEY_BIND_PARAMS_LENGTH).order(ByteOrder.LITTLE_ENDIAN);
+            paramsBuffer.put(mElementAddress[1]);
+            paramsBuffer.put(mElementAddress[0]);
+            paramsBuffer.put(applicationKeyIndex[1]);
+            paramsBuffer.put(applicationKeyIndex[0]);
+            paramsBuffer.putShort((short) mModelIdentifier);
+            parameters = paramsBuffer.array();
+        } else {
+            paramsBuffer = ByteBuffer.allocate(VENDOR_MODEL_APP_KEY_BIND_PARAMS_LENGTH).order(ByteOrder.LITTLE_ENDIAN);
+            paramsBuffer.put(mElementAddress[1]);
+            paramsBuffer.put(mElementAddress[0]);
+            paramsBuffer.put(applicationKeyIndex[1]);
+            paramsBuffer.put(applicationKeyIndex[0]);
+            final byte[] modelIdentifier = new byte[]{(byte) ((mModelIdentifier >> 24) & 0xFF), (byte) ((mModelIdentifier >> 16) & 0xFF), (byte) ((mModelIdentifier >> 8) & 0xFF), (byte) (mModelIdentifier & 0xFF)};
+            paramsBuffer.put(modelIdentifier[1]);
+            paramsBuffer.put(modelIdentifier[0]);
+            paramsBuffer.put(modelIdentifier[3]);
+            paramsBuffer.put(modelIdentifier[2]);
+            parameters = paramsBuffer.array();
+        }
+        messageType = ConfigMessageOpCodes.CONFIG_MODEL_APP_UNBIND;
+        final byte[] key = mProvisionedMeshNode.getDeviceKey();
+        final AccessMessage accessMessage = mMeshTransport.createMeshMessage(mProvisionedMeshNode, mSrc, key, akf, aid, mAszmic, messageType, parameters);
+        mPayloads.putAll(accessMessage.getNetworkPdu());
+    }
+
+    /**
+     * Starts sending the mesh pdu
+     */
+    public void executeSend() {
+        if (!mPayloads.isEmpty()) {
+            for (int i = 0; i < mPayloads.size(); i++) {
+                if (mInternalTransportCallbacks != null) {
+                    mInternalTransportCallbacks.sendPdu(mProvisionedMeshNode, mPayloads.get(i));
+                }
+            }
+
+            if (mConfigStatusCallbacks != null)
+                mConfigStatusCallbacks.onAppKeyBindSent(mProvisionedMeshNode);
+        }
+    }
+
+    public void parseData(final byte[] pdu) {
+        parseMessage(pdu);
+    }
+
+    private void parseMessage(final byte[] pdu) {
+        final Message message = mMeshTransport.parsePdu(mSrc, pdu);
+        if (message != null) {
+            if (message instanceof AccessMessage) {
+                final byte[] accessPayload = ((AccessMessage) message).getAccessPdu();
+                Log.v(TAG, "Unexpected access message received: " + MeshParserUtils.bytesToHex(accessPayload, false));
+            } else {
+                final ControlMessage controlMessage = (ControlMessage) message;
+                Log.v(TAG, "Control message received: " + MeshParserUtils.bytesToHex(pdu, false));
+                parseControlMessage(controlMessage);
+            }
+        } else {
+            Log.v(TAG, "Message reassembly may not be complete yet");
+        }
+    }
+
+    @Override
+    public void sendSegmentAcknowledgementMessage(final ControlMessage controlMessage) {
+        final ControlMessage message = mMeshTransport.createSegmentBlockAcknowledgementMessage(controlMessage);
+        Log.v(TAG, "Sending acknowledgement: " + MeshParserUtils.bytesToHex(message.getNetworkPdu().get(0), false));
+        mInternalTransportCallbacks.sendPdu(mProvisionedMeshNode, message.getNetworkPdu().get(0));
+        mConfigStatusCallbacks.onBlockAcknowledgementSent(mProvisionedMeshNode);
+    }
+
+    /**
+     * Returns the source address of the message i.e. where it originated from
+     *
+     * @return source address
+     */
+    public byte[] getSrc() {
+        return mSrc;
+    }
+}

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/MeshModel.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/MeshModel.java
@@ -124,8 +124,10 @@ public abstract class MeshModel implements Parcelable {
     }
 
     protected void removeBoundAppKey(final int appKeyIndex, final String appKey) {
-        if (mBoundAppKeyIndexes.contains(appKeyIndex))
-            mBoundAppKeyIndexes.remove(appKeyIndex);
+        if (mBoundAppKeyIndexes.contains(appKeyIndex)) {
+            final int position = mBoundAppKeyIndexes.indexOf(appKeyIndex);
+            mBoundAppKeyIndexes.remove(position);
+        }
         mBoundAppKeys.remove(appKeyIndex);
     }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/MeshModel.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/MeshModel.java
@@ -123,6 +123,12 @@ public abstract class MeshModel implements Parcelable {
         mBoundAppKeys.put(appKeyIndex, appKey);
     }
 
+    protected void removeBoundAppKey(final int appKeyIndex, final String appKey) {
+        if (mBoundAppKeyIndexes.contains(appKeyIndex))
+            mBoundAppKeyIndexes.remove(appKeyIndex);
+        mBoundAppKeys.remove(appKeyIndex);
+    }
+
     /**
      * Returns an unmodifiable map of bound app keys for this model.
      * @return LinkedHashMap containing the bound app keys for this model

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/ProvisionedMeshNode.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/ProvisionedMeshNode.java
@@ -130,6 +130,16 @@ public class ProvisionedMeshNode extends BaseMeshNode {
         dest.writeByteArray(mConfigurationSrc);
     }
 
+    private void sortElements(final HashMap<Integer, Element> unorderedElements){
+        final Set<Integer> unorderedKeys =  unorderedElements.keySet();
+
+        final List<Integer> orderedKeys = new ArrayList<>(unorderedKeys);
+        Collections.sort(orderedKeys);
+        for(int key : orderedKeys) {
+            mElements.put(key, unorderedElements.get(key));
+        }
+    }
+
 
     public static final Creator<ProvisionedMeshNode> CREATOR = new Creator<ProvisionedMeshNode>() {
         @Override
@@ -268,10 +278,10 @@ public class ProvisionedMeshNode extends BaseMeshNode {
     }
 
     /**
-     * Sets the data from the {@link ConfigModelAppStatus}
-     * @param configModelAppStatus Composition data status object
+     * Sets the bound app key data from the {@link ConfigModelAppStatus}
+     * @param configModelAppStatus ConfigModelAppStatus contaiing the bound app key information
      */
-    protected final void setConfigModelAppStatus(final ConfigModelAppStatus configModelAppStatus) {
+    protected final void setAppKeyBindStatus(final ConfigModelAppStatus configModelAppStatus) {
         if (configModelAppStatus != null) {
             if (configModelAppStatus.isSuccessful()) {
                 final Element element = mElements.get(configModelAppStatus.getElementAddressInt());
@@ -284,13 +294,21 @@ public class ProvisionedMeshNode extends BaseMeshNode {
         }
     }
 
-    private void sortElements(final HashMap<Integer, Element> unorderedElements){
-        final Set<Integer> unorderedKeys =  unorderedElements.keySet();
+    /**
+     * Sets the unbind app key data from the {@link ConfigModelAppStatus}
+     * @param configModelAppStatus ConfigModelAppStatus containing the unbound app key information
+     */
+    protected final void setAppKeyUnbindStatus(final ConfigModelAppStatus configModelAppStatus) {
+        if (configModelAppStatus != null) {
+            if (configModelAppStatus.isSuccessful()) {
+                final Element element = mElements.get(configModelAppStatus.getElementAddressInt());
+                final int modelIdentifier = configModelAppStatus.getModelIdentifierInt();
+                final MeshModel model = element.getMeshModels().get(modelIdentifier);
+                final int appKeyIndex = configModelAppStatus.getAppKeyIndexInt();
+                final String appKey = mAddedAppKeys.get(appKeyIndex);
+                model.removeBoundAppKey(appKeyIndex, appKey);
+            }
 
-        final List<Integer> orderedKeys = new ArrayList<>(unorderedKeys);
-        Collections.sort(orderedKeys);
-        for(int key : orderedKeys) {
-            mElements.put(key, unorderedElements.get(key));
         }
     }
 }


### PR DESCRIPTION
This contains a missing feature that would allow the user to unbind previously unbind app key. Previously the user would have to reset the node and start all over if they had bound the wrong app key to a specific model.