### PR TITLE
Bugfix/invalid state on generic on off set on android 6

### DIFF
--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ble/BleMeshManager.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ble/BleMeshManager.java
@@ -149,7 +149,7 @@ public class BleMeshManager extends BleManager<BleMeshManagerCallbacks> {
             mMeshProvisioningDataInCharacteristic = null;
             mMeshProvisioningDataOutCharacteristic = null;
             mMeshProxyDataInCharacteristic = null;
-            mMeshProxyDataOutCharacteristic = mMeshProvisioningDataOutCharacteristic;
+            mMeshProxyDataOutCharacteristic = null;
         }
 
         @Override
@@ -166,6 +166,7 @@ public class BleMeshManager extends BleManager<BleMeshManagerCallbacks> {
         @Override
         public void onCharacteristicNotified(final BluetoothGatt gatt, final BluetoothGattCharacteristic characteristic) {
             final byte[] data = characteristic.getValue();
+            Log.v(TAG, "Characteristic notified: " + MeshParserUtils.bytesToHex(data, true));
             mCallbacks.onDataReceived(gatt.getDevice(), mtuSize, data);
         }
 

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ble/BleMeshManager.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ble/BleMeshManager.java
@@ -145,6 +145,7 @@ public class BleMeshManager extends BleManager<BleMeshManagerCallbacks> {
 
         @Override
         protected void onDeviceDisconnected() {
+            isProvisioningComplete = false;
             mMeshProvisioningDataInCharacteristic = null;
             mMeshProvisioningDataOutCharacteristic = null;
             mMeshProxyDataInCharacteristic = null;
@@ -158,7 +159,7 @@ public class BleMeshManager extends BleManager<BleMeshManagerCallbacks> {
         @Override
         public void onCharacteristicWrite(final BluetoothGatt gatt, final BluetoothGattCharacteristic characteristic) {
             final byte[] data = characteristic.getValue();
-            Log.v(TAG, "Data written: " + MeshParserUtils.bytesToHex(data, true));
+            Log.v(TAG, "Data written to characteristic: " + MeshParserUtils.bytesToHex(data, true));
             mCallbacks.onDataSent(gatt.getDevice(), mtuSize, data);
         }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshConfigurationHandler.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshConfigurationHandler.java
@@ -187,8 +187,8 @@ class MeshConfigurationHandler {
         final ConfigCompositionDataGet compositionDataGet = new ConfigCompositionDataGet(mContext,
                 meshNode, aszmic, mInternalTransportCallbacks, mStatusCallbacks);
         configMessage = compositionDataGet;
-        compositionDataGet.executeSend();
         configMessage = new ConfigCompositionDataStatus(mContext, meshNode, mInternalTransportCallbacks, mStatusCallbacks);
+        compositionDataGet.executeSend();
     }
 
     /**
@@ -283,8 +283,8 @@ class MeshConfigurationHandler {
         final ConfigModelSubscriptionAdd configModelSubscriptionAdd = new ConfigModelSubscriptionAdd(mContext, meshNode, aszmic, elementAddress, subscriptionAddress, modelIdentifier);
         configModelSubscriptionAdd.setTransportCallbacks(mInternalTransportCallbacks);
         configModelSubscriptionAdd.setConfigurationStatusCallbacks(mStatusCallbacks);
-        configModelSubscriptionAdd.executeSend();
         configMessage = new ConfigModelSubscriptionStatus(mContext, meshNode, ConfigMessageOpCodes.CONFIG_MODEL_SUBSCRIPTION_ADD, mInternalTransportCallbacks, mStatusCallbacks);
+        configModelSubscriptionAdd.executeSend();
     }
 
     /**
@@ -309,11 +309,11 @@ class MeshConfigurationHandler {
      * @param appKeyIndex          index of the app key to encrypt the message with
      */
     public void getGenericOnOff(final ProvisionedMeshNode node, final MeshModel model, final byte[] address, final boolean aszmic, final int appKeyIndex) {
-        final GenericOnOffGet genericOnOffSet = new GenericOnOffGet(mContext, node, model, aszmic, address, appKeyIndex);
-        genericOnOffSet.setTransportCallbacks(mInternalTransportCallbacks);
-        genericOnOffSet.setConfigurationStatusCallbacks(mStatusCallbacks);
-        genericOnOffSet.executeSend();
-        configMessage = genericOnOffSet;
+        final GenericOnOffGet genericOnOffGet = new GenericOnOffGet(mContext, node, model, aszmic, address, appKeyIndex);
+        genericOnOffGet.setTransportCallbacks(mInternalTransportCallbacks);
+        genericOnOffGet.setConfigurationStatusCallbacks(mStatusCallbacks);
+        configMessage = genericOnOffGet;
+        genericOnOffGet.executeSend();
     }
 
     /**
@@ -333,8 +333,8 @@ class MeshConfigurationHandler {
         final GenericOnOffSet genericOnOffSet = new GenericOnOffSet(mContext, node, model, aszmic, address, appKeyIndex, transitionSteps, transitionResolution, delay, state);
         genericOnOffSet.setTransportCallbacks(mInternalTransportCallbacks);
         genericOnOffSet.setConfigurationStatusCallbacks(mStatusCallbacks);
-        genericOnOffSet.executeSend();
         configMessage = genericOnOffSet;
+        genericOnOffSet.executeSend();
     }
 
     /**
@@ -351,11 +351,11 @@ class MeshConfigurationHandler {
      * @param state                on off state
      */
     public void setGenericOnOffUnacknowledged(final ProvisionedMeshNode node, final MeshModel model, final byte[] address, final boolean aszmic, final int appKeyIndex, final Integer transitionSteps, final Integer transitionResolution, final Integer delay, final boolean state) {
-        final GenericOnOffSetUnacknowledged genericOnOffSet = new GenericOnOffSetUnacknowledged(mContext, node, model, aszmic, address, appKeyIndex, transitionSteps, transitionResolution, delay, state);
-        genericOnOffSet.setTransportCallbacks(mInternalTransportCallbacks);
-        genericOnOffSet.setConfigurationStatusCallbacks(mStatusCallbacks);
-        genericOnOffSet.executeSend();
-        configMessage = genericOnOffSet;
+        final GenericOnOffSetUnacknowledged genericOnOffSetUnAcked = new GenericOnOffSetUnacknowledged(mContext, node, model, aszmic, address, appKeyIndex, transitionSteps, transitionResolution, delay, state);
+        genericOnOffSetUnAcked.setTransportCallbacks(mInternalTransportCallbacks);
+        genericOnOffSetUnAcked.setConfigurationStatusCallbacks(mStatusCallbacks);
+        configMessage = genericOnOffSetUnAcked;
+        genericOnOffSetUnAcked.executeSend();
     }
 
 
@@ -366,7 +366,7 @@ class MeshConfigurationHandler {
      */
     public void resetMeshNode(final ProvisionedMeshNode provisionedMeshNode) {
         final ConfigNodeReset configNodeReset = new ConfigNodeReset(mContext, provisionedMeshNode, false, mInternalTransportCallbacks, mStatusCallbacks);
-        configNodeReset.executeSend();
         configMessage = configNodeReset;
+        configNodeReset.executeSend();
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/GenericOnOffSet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/GenericOnOffSet.java
@@ -93,6 +93,7 @@ public class GenericOnOffSet extends ConfigMessage implements LowerTransportLaye
     public void executeSend() {
         if (!mPayloads.isEmpty()) {
             for (int i = 0; i < mPayloads.size(); i++) {
+                Log.v(TAG, "Sending Generic OnOff set: " + (mState ? "ON" : "OFF"));
                 mInternalTransportCallbacks.sendPdu(mProvisionedMeshNode, mPayloads.get(i));
             }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/MeshTransport.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/MeshTransport.java
@@ -25,6 +25,7 @@ package no.nordicsemi.android.meshprovisioner.configuration;
 import android.content.Context;
 import android.os.Handler;
 import android.support.annotation.VisibleForTesting;
+import android.util.Log;
 
 import no.nordicsemi.android.meshprovisioner.messages.AccessMessage;
 import no.nordicsemi.android.meshprovisioner.messages.ControlMessage;
@@ -106,6 +107,16 @@ final class MeshTransport extends NetworkLayer {
         final int sequenceNumber = incrementSequenceNumber();
         final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(sequenceNumber);
 
+        Log.v(TAG, "Src address: " + MeshParserUtils.bytesToHex(src, false));
+        Log.v(TAG, "Dst address: " + MeshParserUtils.bytesToHex(provisionedMeshNode.getUnicastAddress(), false));
+        Log.v(TAG, "Key: " + MeshParserUtils.bytesToHex(key, false));
+        Log.v(TAG, "akf: " + akf);
+        Log.v(TAG, "aid: " + aid);
+        Log.v(TAG, "aszmic: " + aszmic);
+        Log.v(TAG, "Access message opcode: " + accessOpCode);
+        Log.v(TAG, "Access message parameters: " + MeshParserUtils.bytesToHex(accessMessageParameters, false));
+
+
         final AccessMessage message = new AccessMessage();
         message.setSrc(src);
         message.setDst(provisionedMeshNode.getUnicastAddress());
@@ -146,6 +157,15 @@ final class MeshTransport extends NetworkLayer {
 
         final int sequenceNumber = incrementSequenceNumber();
         final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(sequenceNumber);
+
+        Log.v(TAG, "Src address: " + MeshParserUtils.bytesToHex(src, false));
+        Log.v(TAG, "Dst address: " + MeshParserUtils.bytesToHex(dst, false));
+        Log.v(TAG, "Key: " + MeshParserUtils.bytesToHex(key, false));
+        Log.v(TAG, "akf: " + akf);
+        Log.v(TAG, "aid: " + aid);
+        Log.v(TAG, "aszmic: " + aszmic);
+        Log.v(TAG, "Access message opcode: " + accessOpCode);
+        Log.v(TAG, "Access message parameters: " + MeshParserUtils.bytesToHex(accessMessageParameters, false));
 
         final AccessMessage message = new AccessMessage();
         message.setSrc(src);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/MeshTransport.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/MeshTransport.java
@@ -164,7 +164,7 @@ final class MeshTransport extends NetworkLayer {
         Log.v(TAG, "akf: " + akf);
         Log.v(TAG, "aid: " + aid);
         Log.v(TAG, "aszmic: " + aszmic);
-        Log.v(TAG, "Access message opcode: " + accessOpCode);
+        Log.v(TAG, "Access message opcode: " + Integer.toHexString(accessOpCode));
         Log.v(TAG, "Access message parameters: " + MeshParserUtils.bytesToHex(accessMessageParameters, false));
 
         final AccessMessage message = new AccessMessage();

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/models/VendorModel.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/models/VendorModel.java
@@ -24,6 +24,7 @@ package no.nordicsemi.android.meshprovisioner.models;
 
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.util.Log;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -33,6 +34,7 @@ import no.nordicsemi.android.meshprovisioner.utils.CompanyIdentifiers;
 
 public class VendorModel extends MeshModel {
 
+    private static final String TAG = VendorModel.class.getSimpleName();
     private final short companyIdentifier;
     private final String companyName;
 
@@ -52,17 +54,16 @@ public class VendorModel extends MeshModel {
         super(modelIdentifier);
         final ByteBuffer buffer = ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN);
         buffer.putInt(modelIdentifier);
-        buffer.position(2);
-        this.companyIdentifier = buffer.getShort();
+        this.companyIdentifier = buffer.getShort(0);
         this.companyName = CompanyIdentifiers.getCompanyName(companyIdentifier);
+        Log.v(TAG, "Company name: " + companyName);
     }
 
     private VendorModel(final Parcel source) {
         super(source);
         final ByteBuffer buffer = ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN);
         buffer.putInt(mModelId);
-        buffer.position(2);
-        this.companyIdentifier = buffer.getShort();
+        this.companyIdentifier = buffer.getShort(0);
         this.companyName = CompanyIdentifiers.getCompanyName(companyIdentifier);
     }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/AccessLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/AccessLayer.java
@@ -72,7 +72,7 @@ public abstract class AccessLayer {
         }
         final byte [] accessPdu = accessMessageBuffer.array();
 
-        Log.v(TAG, "Access PDU " + MeshParserUtils.bytesToHex(accessPdu, false));
+        Log.v(TAG, "Created Access PDU " + MeshParserUtils.bytesToHex(accessPdu, false));
         accessMessage.setAccessPdu(accessMessageBuffer.array());
     }
 
@@ -110,6 +110,6 @@ public abstract class AccessLayer {
         final ByteBuffer paramsBuffer = ByteBuffer.allocate(length).order(ByteOrder.BIG_ENDIAN);
         paramsBuffer.put(accessPayload, opCodeLength, length);
         message.setParameters(paramsBuffer.array());
-        Log.v("AccessLayer", "Access PDU " + MeshParserUtils.bytesToHex(accessPayload, false));
+        Log.v(TAG, "Received Access PDU " + MeshParserUtils.bytesToHex(accessPayload, false));
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/AccessLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/AccessLayer.java
@@ -37,6 +37,7 @@ import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 
 public abstract class AccessLayer {
 
+    private static final String TAG = AccessLayer.class.getSimpleName();
     protected Context mContext;
     protected ProvisionedMeshNode mMeshNode;
     protected int sequenceNumber;
@@ -69,6 +70,9 @@ public abstract class AccessLayer {
             accessMessageBuffer = ByteBuffer.allocate(opCodes.length);
             accessMessageBuffer.put(opCodes);
         }
+        final byte [] accessPdu = accessMessageBuffer.array();
+
+        Log.v(TAG, "Access PDU " + MeshParserUtils.bytesToHex(accessPdu, false));
         accessMessage.setAccessPdu(accessMessageBuffer.array());
     }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LowerTransportLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LowerTransportLayer.java
@@ -219,7 +219,9 @@ public abstract class LowerTransportLayer extends UpperTransportLayer {
         final ByteBuffer lowerTransportBuffer = ByteBuffer.allocate(1 + encryptedUpperTransportPDU.length).order(ByteOrder.BIG_ENDIAN);
         lowerTransportBuffer.put(header);
         lowerTransportBuffer.put(encryptedUpperTransportPDU);
-        return lowerTransportBuffer.array();
+        final byte [] lowerTransportPDU = lowerTransportBuffer.array();
+        Log.v(TAG, "Unsegmented Lower transport access PDU " + MeshParserUtils.bytesToHex(lowerTransportPDU, false));
+        return lowerTransportPDU;
     }
 
     /**
@@ -250,7 +252,9 @@ public abstract class LowerTransportLayer extends UpperTransportLayer {
             offset += MAX_SEGMENTED_ACCESS_PAYLOAD_LENGTH;
             length = encryptedUpperTransportPDU.length - offset;
 
-            lowerTransportPduMap.put(segO, lowerTransportBuffer.array());
+            final byte [] lowerTransportPDU = lowerTransportBuffer.array();
+            Log.v(TAG, "Segmented Lower transport access PDU: " + MeshParserUtils.bytesToHex(lowerTransportPDU, false) + " " + segO + " of " + numberOfSegments);
+            lowerTransportPduMap.put(segO, lowerTransportPDU);
         }
         return lowerTransportPduMap;
     }


### PR DESCRIPTION
This was mainly due to having the current state set after the message being sent. This was intermittently causing the current state of the mesh configuration handler to be in an invalid state.