### PR TITLE
'Data OUT' Notifications SAR logic and MTU negotiations

### DIFF
--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ble/BleMeshManager.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ble/BleMeshManager.java
@@ -95,7 +95,6 @@ public class BleMeshManager extends BleManager<BleMeshManagerCallbacks> {
         protected Deque<Request> initGatt(final BluetoothGatt gatt) {
             mBluetoothGatt = gatt;
             final LinkedList<Request> requests = new LinkedList<>();
-            requests.push(Request.newMtuRequest(MTU_SIZE_MAX));
             if (isProvisioningComplete) {
                 requests.push(Request.newReadRequest(mMeshProxyDataInCharacteristic));
                 requests.push(Request.newReadRequest(mMeshProxyDataOutCharacteristic));
@@ -105,6 +104,7 @@ public class BleMeshManager extends BleManager<BleMeshManagerCallbacks> {
                 requests.push(Request.newReadRequest(mMeshProvisioningDataOutCharacteristic));
                 requests.push(Request.newEnableNotificationsRequest(mMeshProvisioningDataOutCharacteristic));
             }
+            requests.push(Request.newMtuRequest(MTU_SIZE_MAX));
             return requests;
         }
 


### PR DESCRIPTION
Based on the inputs from the nRF dev ticket "Observation regarding GATT Bearer 'Data OUT' Notifications Re-assembly logic and MTU negotiations", issuing a Pull Request to update the observations/suggestions in the Android-nRF-Mesh-Library. This PR is on behalf of Srikkanth who raised the above mentioned nRF ticket. 