### PR TITLE
Feature/identify node before provisioning #39

### DIFF
--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/MeshProvisionerActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/MeshProvisionerActivity.java
@@ -49,7 +49,7 @@ import javax.inject.Inject;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import no.nordicsemi.android.meshprovisioner.states.ProvisioningFailed;
+import no.nordicsemi.android.meshprovisioner.states.ProvisioningFailedState;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 import no.nordicsemi.android.nrfmeshprovisioner.adapter.ExtendedBluetoothDevice;
 import no.nordicsemi.android.nrfmeshprovisioner.adapter.ProvisioningProgressAdapter;
@@ -119,9 +119,10 @@ public class MeshProvisionerActivity extends AppCompatActivity implements Inject
         final LinearLayout connectivityProgressContainer = findViewById(R.id.connectivity_progress_container);
         final TextView connectionState = findViewById(R.id.connection_state);
         final Button provisioner = findViewById(R.id.action_provision_device);
+        final Button identify = findViewById(R.id.action_identify_device);
         final View provisioningStatusContainer = findViewById(R.id.info_provisioning_status_container);
 
-        final View containerName = findViewById(R.id.container_name);
+        final View containerName = findViewById(R.id.container_element_count);
         containerName.findViewById(R.id.image).setBackground(ContextCompat.getDrawable(this, R.drawable.ic_vpn_key_black_alpha_24dp));
         final TextView nameTitle = containerName.findViewById(R.id.title);
         nameTitle.setText(R.string.summary_name);
@@ -132,7 +133,7 @@ public class MeshProvisionerActivity extends AppCompatActivity implements Inject
             dialogFragmentNodeName.show(getSupportFragmentManager(), null);
         });
 
-        final View containerUnicastAddress = findViewById(R.id.container_unicast_address);
+        final View containerUnicastAddress = findViewById(R.id.container_algorithm);
         containerUnicastAddress.findViewById(R.id.image).setBackground(ContextCompat.getDrawable(this, R.drawable.ic_lan_black_alpha_24dp));
         final TextView unicastAddressTitle = containerUnicastAddress.findViewById(R.id.title);
         unicastAddressTitle.setText(R.string.summary_unicast_address);
@@ -143,7 +144,7 @@ public class MeshProvisionerActivity extends AppCompatActivity implements Inject
             dialogFragmentFlags.show(getSupportFragmentManager(), null);
         });
 
-        final View containerAppKey = findViewById(R.id.container_app_key);
+        final View containerAppKey = findViewById(R.id.container_public_key_type);
         containerAppKey.findViewById(R.id.image).setBackground(ContextCompat.getDrawable(this, R.drawable.ic_vpn_key_black_alpha_24dp));
         final TextView appKeyTitle = containerAppKey.findViewById(R.id.title);
         appKeyTitle.setText(R.string.summary_app_keys);
@@ -192,11 +193,13 @@ public class MeshProvisionerActivity extends AppCompatActivity implements Inject
             }
         });
 
+        identify.setOnClickListener(v -> mViewModel.identifyNode());
+
         provisioner.setOnClickListener(v -> {
             mProvisioningProgressBar.setVisibility(View.VISIBLE);
+            setupProvisionerStateObservers(provisioningStatusContainer);
             mViewModel.provisionNode(mViewModel.getProvisioningData().getNodeName());
         });
-        setupProvisionerStateObservers(provisioningStatusContainer);
     }
 
     @Override
@@ -301,7 +304,7 @@ public class MeshProvisionerActivity extends AppCompatActivity implements Inject
                 switch (state) {
                     case PROVISIONING_FAILED:
                         if (getSupportFragmentManager().findFragmentByTag(DIALOG_FRAGMENT_PROVISIONING_FAILED) == null) {
-                            final String statusMessage = ProvisioningFailed.parseProvisioningFailure(getApplicationContext(), provisionerProgress.getStatusReceived());
+                            final String statusMessage = ProvisioningFailedState.parseProvisioningFailure(getApplicationContext(), provisionerProgress.getStatusReceived());
                             DialogFragmentProvisioningFailedErrorMessage message = DialogFragmentProvisioningFailedErrorMessage.newInstance(getString(R.string.title_error_provisioning_failed), statusMessage);
                             message.show(getSupportFragmentManager(), DIALOG_FRAGMENT_PROVISIONING_FAILED);
                         }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/MeshProvisionerActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/MeshProvisionerActivity.java
@@ -72,6 +72,7 @@ import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentNetworkKey;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentNodeName;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentProvisioningFailedErrorMessage;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentUnicastAddress;
+import no.nordicsemi.android.nrfmeshprovisioner.livedata.ExtendedMeshNode;
 import no.nordicsemi.android.nrfmeshprovisioner.livedata.ProvisioningStateLiveData;
 import no.nordicsemi.android.nrfmeshprovisioner.utils.ProvisioningProgress;
 import no.nordicsemi.android.nrfmeshprovisioner.utils.Utils;
@@ -130,7 +131,6 @@ public class MeshProvisionerActivity extends AppCompatActivity implements Inject
         final LinearLayout connectivityProgressContainer = findViewById(R.id.connectivity_progress_container);
         final TextView connectionState = findViewById(R.id.connection_state);
         final Button provisioner = findViewById(R.id.action_provision_device);
-        final Button identify = findViewById(R.id.action_identify_device);
         final View provisioningStatusContainer = findViewById(R.id.info_provisioning_status_container);
 
         final View containerName = findViewById(R.id.container_element_count);
@@ -209,21 +209,21 @@ public class MeshProvisionerActivity extends AppCompatActivity implements Inject
                 final UnprovisionedMeshNode node = (UnprovisionedMeshNode) extendedMeshNode.getMeshNode();
                 if (node.getProvisioningCapabilities() != null) {
                     mProvisioningProgressBar.setVisibility(View.INVISIBLE);
-                    identify.setVisibility(View.GONE);
+                    provisioner.setText(R.string.provision_action);
                     updateCapabilitiesUi(node.getProvisioningCapabilities());
                 }
             }
         });
 
-        identify.setOnClickListener(v -> {
-            mProvisioningProgressBar.setVisibility(View.VISIBLE);
-            mViewModel.identifyNode();
-        });
-
         provisioner.setOnClickListener(v -> {
-            mProvisioningProgressBar.setVisibility(View.VISIBLE);
-            setupProvisionerStateObservers(provisioningStatusContainer);
-            mViewModel.startProvisioning(mViewModel.getProvisioningData().getNodeName());
+            final ExtendedMeshNode meshNode = mViewModel.getMeshNode();
+            if(meshNode != null && meshNode.getMeshNode().getProvisioningCapabilities() != null) {
+                setupProvisionerStateObservers(provisioningStatusContainer);
+                mProvisioningProgressBar.setVisibility(View.VISIBLE);
+                mViewModel.startProvisioning();
+            } else {
+                mViewModel.identifyNode(mViewModel.getProvisioningData().getNodeName());
+            }
         });
     }
 

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ModelConfigurationActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ModelConfigurationActivity.java
@@ -163,7 +163,8 @@ public class ModelConfigurationActivity extends AppCompatActivity implements Inj
 
         mActionBindAppKey.setOnClickListener(v -> {
             final Intent bindAppKeysIntent = new Intent(ModelConfigurationActivity.this, BindAppKeysActivity.class);
-            bindAppKeysIntent.putExtra(ManageAppKeysActivity.APP_KEYS, (Parcelable) ((ProvisionedMeshNode)mViewModel.getExtendedMeshNode().getMeshNode()).getAddedAppKeys());
+            final ProvisionedMeshNode node = ((ProvisionedMeshNode)mViewModel.getExtendedMeshNode().getMeshNode());
+            bindAppKeysIntent.putExtra(ManageAppKeysActivity.APP_KEYS, (Serializable) node.getAddedAppKeys());
             startActivityForResult(bindAppKeysIntent, ManageAppKeysActivity.SELECT_APP_KEY);
         });
 

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ModelConfigurationActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ModelConfigurationActivity.java
@@ -27,6 +27,7 @@ import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Parcelable;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.LinearLayoutManager;
@@ -162,7 +163,7 @@ public class ModelConfigurationActivity extends AppCompatActivity implements Inj
 
         mActionBindAppKey.setOnClickListener(v -> {
             final Intent bindAppKeysIntent = new Intent(ModelConfigurationActivity.this, BindAppKeysActivity.class);
-            bindAppKeysIntent.putExtra(ManageAppKeysActivity.APP_KEYS, (Serializable) mViewModel.getExtendedMeshNode().getMeshNode().getAddedAppKeys());
+            bindAppKeysIntent.putExtra(ManageAppKeysActivity.APP_KEYS, (Parcelable) ((ProvisionedMeshNode)mViewModel.getExtendedMeshNode().getMeshNode()).getAddedAppKeys());
             startActivityForResult(bindAppKeysIntent, ManageAppKeysActivity.SELECT_APP_KEY);
         });
 
@@ -229,7 +230,7 @@ public class ModelConfigurationActivity extends AppCompatActivity implements Inj
             } else {
                 final int elementAdd = configModelPublicationStatusLiveData.getElementAddressInt();
                 final int modelIdentifier = configModelPublicationStatusLiveData.getModelIdentifier();
-                final Element element = mViewModel.getExtendedMeshNode().getMeshNode().getElements().get(elementAdd);
+                final Element element = ((ProvisionedMeshNode)mViewModel.getExtendedMeshNode().getMeshNode()).getElements().get(elementAdd);
                 final MeshModel model = element.getMeshModels().get(modelIdentifier);
                 final byte[] publishAddress = model.getPublishAddress();
                 mPublishAddressView.setText(MeshParserUtils.bytesToHex(publishAddress, true));
@@ -403,7 +404,7 @@ public class ModelConfigurationActivity extends AppCompatActivity implements Inj
                 mActionRead = nodeControlsContainer.findViewById(R.id.action_read);
                 mActionOnOff.setOnClickListener(v -> {
                     try {
-                        final ProvisionedMeshNode node = mViewModel.getExtendedMeshNode().getMeshNode();
+                        final ProvisionedMeshNode node = (ProvisionedMeshNode) mViewModel.getExtendedMeshNode().getMeshNode();
                         if(mActionOnOff.getText().toString().equals(getString(R.string.action_generic_on))){
                             /*mActionOnOff.setText(R.string.action_generic_off);
                             onOffState.setText(R.string.generic_state_on);*/
@@ -423,7 +424,7 @@ public class ModelConfigurationActivity extends AppCompatActivity implements Inj
                 });
 
                 mActionRead.setOnClickListener(v -> {
-                    final ProvisionedMeshNode node = mViewModel.getExtendedMeshNode().getMeshNode();
+                    final ProvisionedMeshNode node = (ProvisionedMeshNode) mViewModel.getExtendedMeshNode().getMeshNode();
                     mViewModel.sendGenericOnOffGet(node);
                     //mActionRead.setEnabled(false);
                     showProgressbar();

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/NodeConfigurationActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/NodeConfigurationActivity.java
@@ -167,7 +167,7 @@ public class NodeConfigurationActivity extends AppCompatActivity implements Inje
             }
 
             if (extendedMeshNode.hasAddedAppKeys()) {
-                final Map<Integer, String> appKeys = extendedMeshNode.getMeshNode().getAddedAppKeys();
+                final Map<Integer, String> appKeys = ((ProvisionedMeshNode)extendedMeshNode.getMeshNode()).getAddedAppKeys();
                 if (!appKeys.isEmpty()) {
                     noAppKeysFound.setVisibility(View.GONE);
                     recyclerViewAppKeys.setVisibility(View.VISIBLE);
@@ -307,7 +307,7 @@ public class NodeConfigurationActivity extends AppCompatActivity implements Inje
 
     @Override
     public void onNodeReset() {
-        final ProvisionedMeshNode provisionedMeshNode = mViewModel.getExtendedMeshNode().getMeshNode();
+        final ProvisionedMeshNode provisionedMeshNode = (ProvisionedMeshNode) mViewModel.getExtendedMeshNode().getMeshNode();
         mViewModel.resetNode(provisionedMeshNode);
     }
 

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/NodeDetailsActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/NodeDetailsActivity.java
@@ -86,7 +86,7 @@ public class NodeDetailsActivity extends AppCompatActivity implements Injectable
         final TextView nodeIdentifier = containerNodeIdentifier.findViewById(R.id.text);
         nodeIdentifier.setText(node.getNodeIdentifier());
 
-        final View containerUnicastAddress = findViewById(R.id.container_algorithm);
+        final View containerUnicastAddress = findViewById(R.id.container_supported_algorithm);
         containerUnicastAddress.setClickable(false);
         final TextView unicastAddress = containerUnicastAddress.findViewById(R.id.text);
         unicastAddress.setText(MeshParserUtils.bytesToHex(node.getUnicastAddress(), false));

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/NodeDetailsActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/NodeDetailsActivity.java
@@ -70,7 +70,7 @@ public class NodeDetailsActivity extends AppCompatActivity implements Injectable
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setTitle(node.getNodeName());
 
-        final View containerNodeName = findViewById(R.id.container_name);
+        final View containerNodeName = findViewById(R.id.container_element_count);
         containerNodeName.setClickable(false);
         final TextView nodeName = containerNodeName.findViewById(R.id.text);
         nodeName.setText(node.getNodeName());
@@ -86,7 +86,7 @@ public class NodeDetailsActivity extends AppCompatActivity implements Injectable
         final TextView nodeIdentifier = containerNodeIdentifier.findViewById(R.id.text);
         nodeIdentifier.setText(node.getNodeIdentifier());
 
-        final View containerUnicastAddress = findViewById(R.id.container_unicast_address);
+        final View containerUnicastAddress = findViewById(R.id.container_algorithm);
         containerUnicastAddress.setClickable(false);
         final TextView unicastAddress = containerUnicastAddress.findViewById(R.id.text);
         unicastAddress.setText(MeshParserUtils.bytesToHex(node.getUnicastAddress(), false));

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/SettingsFragment.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/SettingsFragment.java
@@ -164,7 +164,7 @@ public class SettingsFragment extends Fragment implements Injectable,
             dialogFragmentFlags.show(getChildFragmentManager(), null);
         });
 
-        final View containerUnicastAddress = rootView.findViewById(R.id.container_algorithm);
+        final View containerUnicastAddress = rootView.findViewById(R.id.container_supported_algorithm);
         containerUnicastAddress.findViewById(R.id.image).setBackground(ContextCompat.getDrawable(getContext(), R.drawable.ic_lan_black_alpha_24dp));
         final TextView unicastAddressTitle = containerUnicastAddress.findViewById(R.id.title);
         unicastAddressTitle.setText(R.string.summary_unicast_address);

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/SettingsFragment.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/SettingsFragment.java
@@ -164,7 +164,7 @@ public class SettingsFragment extends Fragment implements Injectable,
             dialogFragmentFlags.show(getChildFragmentManager(), null);
         });
 
-        final View containerUnicastAddress = rootView.findViewById(R.id.container_unicast_address);
+        final View containerUnicastAddress = rootView.findViewById(R.id.container_algorithm);
         containerUnicastAddress.findViewById(R.id.image).setBackground(ContextCompat.getDrawable(getContext(), R.drawable.ic_lan_black_alpha_24dp));
         final TextView unicastAddressTitle = containerUnicastAddress.findViewById(R.id.title);
         unicastAddressTitle.setText(R.string.summary_unicast_address);

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/AddedAppKeyAdapter.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/AddedAppKeyAdapter.java
@@ -39,6 +39,7 @@ import java.util.Set;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import no.nordicsemi.android.meshprovisioner.configuration.ProvisionedMeshNode;
 import no.nordicsemi.android.nrfmeshprovisioner.NodeConfigurationActivity;
 import no.nordicsemi.android.nrfmeshprovisioner.R;
 import no.nordicsemi.android.nrfmeshprovisioner.livedata.ExtendedMeshNode;
@@ -52,10 +53,11 @@ public class AddedAppKeyAdapter extends RecyclerView.Adapter<AddedAppKeyAdapter.
 
     public AddedAppKeyAdapter(final NodeConfigurationActivity activity, final ExtendedMeshNode extendedMeshNode) {
         this.mContext = activity.getApplicationContext();
-        extendedMeshNode.observe(activity, node -> {
-            if(extendedMeshNode.getMeshNode() != null) {
+        extendedMeshNode.observe(activity, extendedNode -> {
+            if(extendedNode.getMeshNode() != null) {
                 appKeys.clear();
-                appKeys.addAll(extendedMeshNode.getMeshNode().getAddedAppKeys().values());
+                final ProvisionedMeshNode node = (ProvisionedMeshNode) extendedNode.getMeshNode();
+                appKeys.addAll(node.getAddedAppKeys().values());
                 notifyDataSetChanged();
             }
         });

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/ElementAdapter.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/ElementAdapter.java
@@ -59,7 +59,7 @@ public class ElementAdapter extends RecyclerView.Adapter<ElementAdapter.ViewHold
         this.mContext = nodeConfigurationActivity.getApplicationContext();
         extendedMeshnode.observe(nodeConfigurationActivity, extendedMeshNode -> {
             if(extendedMeshNode.getMeshNode() != null) {
-                mProvisionedMeshNode = extendedMeshnode.getMeshNode();
+                mProvisionedMeshNode = (ProvisionedMeshNode) extendedMeshnode.getMeshNode();
                 mElements.clear();
                 mElements.addAll(mProvisionedMeshNode.getElements().values());
                 notifyDataSetChanged();

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/NodeAdapter.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/NodeAdapter.java
@@ -84,12 +84,9 @@ public class NodeAdapter extends RecyclerView.Adapter<NodeAdapter.ViewHolder>{
             holder.elements.setText(String.valueOf(elements.size()));
             holder.models.setText(String.valueOf(getModels(elements)));
         } else {
-            //holder.nodeInfoContainer.setVisibility(View.GONE);
-            //holder.notConfiguredView.setVisibility(View.VISIBLE);
-
-            holder.companyIdentifier.setText("Unknown");
+            holder.companyIdentifier.setText(R.string.unknown);
             holder.elements.setText(String.valueOf(node.getNumberOfElements()));
-            holder.models.setText("Unknown");
+            holder.models.setText(R.string.unknown);
         }
     }
 
@@ -100,10 +97,6 @@ public class NodeAdapter extends RecyclerView.Adapter<NodeAdapter.ViewHolder>{
 
     public boolean isEmpty() {
         return getItemCount() == 0;
-    }
-
-    public void clearItems() {
-        mNodes.clear();
     }
 
     private int getModels(final Map<Integer, Element> elements){

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/NodeAdapter.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/NodeAdapter.java
@@ -84,8 +84,12 @@ public class NodeAdapter extends RecyclerView.Adapter<NodeAdapter.ViewHolder>{
             holder.elements.setText(String.valueOf(elements.size()));
             holder.models.setText(String.valueOf(getModels(elements)));
         } else {
-            holder.nodeInfoContainer.setVisibility(View.GONE);
-            holder.notConfiguredView.setVisibility(View.VISIBLE);
+            //holder.nodeInfoContainer.setVisibility(View.GONE);
+            //holder.notConfiguredView.setVisibility(View.VISIBLE);
+
+            holder.companyIdentifier.setText("Unknown");
+            holder.elements.setText(String.valueOf(node.getNumberOfElements()));
+            holder.models.setText("Unknown");
         }
     }
 

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/livedata/ExtendedMeshNode.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/livedata/ExtendedMeshNode.java
@@ -27,20 +27,21 @@ import android.util.Log;
 
 import java.util.Map;
 
+import no.nordicsemi.android.meshprovisioner.BaseMeshNode;
 import no.nordicsemi.android.meshprovisioner.configuration.ProvisionedMeshNode;
 import no.nordicsemi.android.meshprovisioner.utils.Element;
 
 public class ExtendedMeshNode extends LiveData<ExtendedMeshNode> {
 
-    private ProvisionedMeshNode mMeshNode;
+    private BaseMeshNode mMeshNode;
     private static final String TAG = ExtendedMeshNode.class.getSimpleName();
 
-    public ExtendedMeshNode(final ProvisionedMeshNode meshNode) {
+    public ExtendedMeshNode(final BaseMeshNode meshNode) {
         this.mMeshNode = meshNode;
-        postValue(this);
+        setValue(this);
     }
 
-    public ProvisionedMeshNode getMeshNode() {
+    public BaseMeshNode getMeshNode() {
         return mMeshNode;
     }
 
@@ -48,7 +49,7 @@ public class ExtendedMeshNode extends LiveData<ExtendedMeshNode> {
      * Updates the mesh node and posts the value
      * @param meshNode Provisioned mesh node
      */
-    public void updateMeshNode(final ProvisionedMeshNode meshNode) {
+    public void updateMeshNode(final BaseMeshNode meshNode) {
         this.mMeshNode = meshNode;
         postValue(this);
     }
@@ -62,12 +63,18 @@ public class ExtendedMeshNode extends LiveData<ExtendedMeshNode> {
     }
 
     public boolean hasElements(){
-        final Map<Integer, Element> elements = mMeshNode.getElements();
-        return elements != null && !elements.isEmpty();
+        if(mMeshNode.isProvisioned()) {
+            final Map<Integer, Element> elements = ((ProvisionedMeshNode) mMeshNode).getElements();
+            return elements != null && !elements.isEmpty();
+        }
+        return false;
     }
 
     public boolean hasAddedAppKeys(){
-        final Map<Integer, String> appKeys = mMeshNode.getAddedAppKeys();
-        return appKeys != null && !appKeys.isEmpty();
+        if(mMeshNode.isProvisioned()) {
+            final Map<Integer, String> appKeys = ((ProvisionedMeshNode) mMeshNode).getAddedAppKeys();
+            return appKeys != null && !appKeys.isEmpty();
+        }
+        return false;
     }
 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/livedata/ProvisioningStateLiveData.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/livedata/ProvisioningStateLiveData.java
@@ -156,9 +156,9 @@ public class ProvisioningStateLiveData extends LiveData<ProvisioningStateLiveDat
                 provisioningProgress = new ProvisioningProgress(state, context.getString(R.string.prov_complete_received), R.drawable.ic_arrow_back_black_alpha);
                 mProvisioningProgress.add(provisioningProgress);
                 break;
-            case PROVISIONING_FAILED:
+            /*case PROVISIONING_FAILED:
                 provisioningProgress = new ProvisioningProgress(state, context.getString(R.string.prov_failed_received), R.drawable.ic_arrow_forward_black_alpha);
-                mProvisioningProgress.add(provisioningProgress);
+                mProvisioningProgress.add(provisioningProgress);*/
             default:
                 break;
             case COMPOSITION_DATA_GET_SENT:
@@ -185,12 +185,16 @@ public class ProvisioningStateLiveData extends LiveData<ProvisioningStateLiveDat
         postValue(this);
     }
 
-    public void onMeshNodeStateUpdated(final Context context, final int provisionerState, final int status) {
+    public void onMeshNodeStateUpdated(final Context context, final int provisionerState, final int statusCode) {
         final ProvisioningProgress provisioningProgress;
         final ProvisioningLiveDataState state = ProvisioningLiveDataState.fromStatusCode(provisionerState);
         switch (state) {
+            case PROVISIONING_FAILED:
+                provisioningProgress = new ProvisioningProgress(state, statusCode, context.getString(R.string.prov_failed_received), R.drawable.ic_arrow_forward_black_alpha);
+                mProvisioningProgress.add(provisioningProgress);
+                break;
             case APP_KEY_STATUS_RECEIVED:
-                provisioningProgress = new ProvisioningProgress(state, status, context.getString(R.string.prov_app_key_status_received), R.drawable.ic_arrow_forward_black_alpha);
+                provisioningProgress = new ProvisioningProgress(state, statusCode, context.getString(R.string.prov_app_key_status_received), R.drawable.ic_arrow_forward_black_alpha);
                 mProvisioningProgress.add(provisioningProgress);
                 break;
         }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/BaseMeshRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/BaseMeshRepository.java
@@ -215,7 +215,7 @@ public abstract class BaseMeshRepository {
 
     protected void onTransactionFailed(final Intent intent){
         final String action = intent.getAction();
-        final ProvisionedMeshNode node = mBinder.getMeshNode();
+        final ProvisionedMeshNode node = (ProvisionedMeshNode) mBinder.getMeshNode();
         switch (action) {
             case ACTION_TRANSACTION_FAILED:
                 if(mExtendedMeshNode != null) {
@@ -347,7 +347,7 @@ public abstract class BaseMeshRepository {
     }
 
     public void sendAppKeyAdd(final int appKeyIndex, final String appKey) {
-        mBinder.sendAppKeyAdd(mExtendedMeshNode.getMeshNode(), appKeyIndex, appKey);
+        mBinder.sendAppKeyAdd((ProvisionedMeshNode) mExtendedMeshNode.getMeshNode(), appKeyIndex, appKey);
     }
 
     public void refreshProvisioningData() {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/MeshProvisionerRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/MeshProvisionerRepository.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import javax.inject.Inject;
 
 import no.nordicsemi.android.meshprovisioner.configuration.ProvisionedMeshNode;
+import no.nordicsemi.android.meshprovisioner.states.UnprovisionedMeshNode;
 import no.nordicsemi.android.nrfmeshprovisioner.adapter.ExtendedBluetoothDevice;
 import no.nordicsemi.android.nrfmeshprovisioner.livedata.ExtendedMeshNode;
 import no.nordicsemi.android.nrfmeshprovisioner.livedata.ProvisionedNodesLiveData;
@@ -60,6 +61,7 @@ public class MeshProvisionerRepository extends BaseMeshRepository {
     @Inject
     public MeshProvisionerRepository(final Context context){
         super(context);
+        mExtendedMeshNode = new ExtendedMeshNode(new UnprovisionedMeshNode());
     }
 
     /**
@@ -140,6 +142,7 @@ public class MeshProvisionerRepository extends BaseMeshRepository {
                 break;
             case PROVISIONING_CAPABILITIES:
                 mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, provisionerState);
+                mExtendedMeshNode.updateMeshNode(mBinder.getMeshNode());
                 break;
             case PROVISIONING_START:
                 mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, provisionerState);
@@ -192,11 +195,11 @@ public class MeshProvisionerRepository extends BaseMeshRepository {
     private void handleConfigurationStates(final Intent intent){
         final int state = intent.getExtras().getInt(EXTRA_CONFIGURATION_STATE);
         final MeshNodeStates.MeshNodeStatus status = MeshNodeStates.MeshNodeStatus.fromStatusCode(state);
-        final ProvisionedMeshNode node = mBinder.getMeshNode();
+        final ProvisionedMeshNode node = (ProvisionedMeshNode) mBinder.getMeshNode();
         switch (status) {
             case COMPOSITION_DATA_GET_SENT:
                 mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);
-                mExtendedMeshNode = new ExtendedMeshNode(node);
+                mExtendedMeshNode.updateMeshNode(node);
                 break;
             case COMPOSITION_DATA_STATUS_RECEIVED:
                 mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/MeshProvisionerRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/MeshProvisionerRepository.java
@@ -43,6 +43,7 @@ import no.nordicsemi.android.nrfmeshprovisioner.viewmodels.MeshNodeStates;
 import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.ACTION_CONNECT_TO_UNPROVISIONED_NODE;
 import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_APP_KEY_INDEX;
 import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_CONFIGURATION_STATE;
+import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_DATA;
 import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_DEVICE;
 import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_ELEMENT_ADDRESS;
 import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_IS_SUCCESS;
@@ -131,57 +132,58 @@ public class MeshProvisionerRepository extends BaseMeshRepository {
     }
 
     private void handleProvisioningStates(final Intent intent){
-        final int state = intent.getExtras().getInt(EXTRA_PROVISIONING_STATE);
-        final MeshNodeStates.MeshNodeStatus status = MeshNodeStates.MeshNodeStatus.fromStatusCode(state);
+        final int provisionerState = intent.getExtras().getInt(EXTRA_PROVISIONING_STATE);
+        final MeshNodeStates.MeshNodeStatus status = MeshNodeStates.MeshNodeStatus.fromStatusCode(provisionerState);
         switch (status) {
             case PROVISIONING_INVITE:
-                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);
+                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, provisionerState);
                 break;
             case PROVISIONING_CAPABILITIES:
-                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);
+                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, provisionerState);
                 break;
             case PROVISIONING_START:
-                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);
+                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, provisionerState);
                 break;
             case PROVISIONING_PUBLIC_KEY_SENT:
-                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);
+                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, provisionerState);
                 break;
             case PROVISIONING_PUBLIC_KEY_RECEIVED:
-                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);
+                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, provisionerState);
                 break;
             case PROVISIONING_AUTHENTICATION_INPUT_WAITING:
-                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);
+                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, provisionerState);
                 break;
             case PROVISIONING_AUTHENTICATION_INPUT_ENTERED:
-                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);
+                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, provisionerState);
                 break;
             case PROVISIONING_INPUT_COMPLETE:
-                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);
+                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, provisionerState);
                 break;
             case PROVISIONING_CONFIRMATION_SENT:
-                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);
+                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, provisionerState);
                 break;
             case PROVISIONING_CONFIRMATION_RECEIVED:
-                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);
+                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, provisionerState);
                 break;
             case PROVISIONING_RANDOM_SENT:
-                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);
+                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, provisionerState);
                 break;
             case PROVISIONING_RANDOM_RECEIVED:
-                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);
+                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, provisionerState);
                 break;
             case PROVISIONING_DATA_SENT:
-                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);
+                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, provisionerState);
                 break;
             case PROVISIONING_COMPLETE:
                 mIsProvisioningComplete = true;
-                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);
+                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, provisionerState);
                 break;
             case PROVISIONING_FAILED:
-                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);
+                final int statusCode = intent.getIntExtra(EXTRA_DATA, 7);
+                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, provisionerState, statusCode);
                 break;
             default:
-                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, state);
+                mProvisioningStateLiveData.onMeshNodeStateUpdated(mContext, provisionerState);
                 break;
 
         }
@@ -258,6 +260,10 @@ public class MeshProvisionerRepository extends BaseMeshRepository {
         intent.setAction(ACTION_CONNECT_TO_UNPROVISIONED_NODE);
         intent.putExtra(EXTRA_DEVICE, device);
         mContext.startService(intent);
+    }
+
+    public void identifyNode() {
+        mBinder.identifyNode();
     }
 
     public void startProvisioning(final String nodeName) {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/MeshProvisionerRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/MeshProvisionerRepository.java
@@ -265,12 +265,12 @@ public class MeshProvisionerRepository extends BaseMeshRepository {
         mContext.startService(intent);
     }
 
-    public void identifyNode() {
-        mBinder.identifyNode();
+    public void identifyNode(final String nodeName){
+        mBinder.identifyNode(nodeName);
     }
 
-    public void startProvisioning(final String nodeName) {
-        mBinder.startProvisioning(nodeName);
+    public void startProvisioning() {
+        mBinder.startProvisioning();
     }
 
     public void confirmProvisioning(final String pin) {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ModelConfigurationRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ModelConfigurationRepository.java
@@ -107,7 +107,7 @@ public class ModelConfigurationRepository extends BaseMeshRepository {
     private void handleConfigurationStates(final Intent intent) {
         final int state = intent.getExtras().getInt(EXTRA_CONFIGURATION_STATE);
         final MeshNodeStates.MeshNodeStatus status = MeshNodeStates.MeshNodeStatus.fromStatusCode(state);
-        final ProvisionedMeshNode node = mBinder.getMeshNode();
+        final ProvisionedMeshNode node = (ProvisionedMeshNode) mBinder.getMeshNode();
         final MeshModel model = mBinder.getMeshModel();
         switch (status) {
             case COMPOSITION_DATA_GET_SENT:
@@ -183,7 +183,6 @@ public class ModelConfigurationRepository extends BaseMeshRepository {
 
     private void handleGenericOnOffState(final Intent intent) {
         final String action = intent.getAction();
-        final ProvisionedMeshNode node = mBinder.getMeshNode();
         final MeshModel model = mBinder.getMeshModel();
         switch (action) {
             case ACTION_GENERIC_ON_OFF_STATE:
@@ -210,7 +209,7 @@ public class ModelConfigurationRepository extends BaseMeshRepository {
      * @param appKeyIndex index of the application key that has already been added to the mesh node
      */
     public void sendBindAppKey(final int appKeyIndex) {
-        mBinder.sendBindAppKey(mExtendedMeshNode.getMeshNode(), mElement.getValue().getElementAddress(), mMeshModel.getValue(), appKeyIndex);
+        mBinder.sendBindAppKey((ProvisionedMeshNode) mExtendedMeshNode.getMeshNode(), mElement.getValue().getElementAddress(), mMeshModel.getValue(), appKeyIndex);
     }
 
     /**
@@ -219,11 +218,11 @@ public class ModelConfigurationRepository extends BaseMeshRepository {
      * @param appKeyIndex index of the application key that has already been added to the mesh node
      */
     public void sendUnbindAppKey(final int appKeyIndex) {
-        mBinder.sendUnbindAppKey(mExtendedMeshNode.getMeshNode(), mElement.getValue().getElementAddress(), mMeshModel.getValue(), appKeyIndex);
+        mBinder.sendUnbindAppKey((ProvisionedMeshNode) mExtendedMeshNode.getMeshNode(), mElement.getValue().getElementAddress(), mMeshModel.getValue(), appKeyIndex);
     }
 
     public void sendConfigModelPublishAddressSet(final byte[] publishAddress) {
-        final ProvisionedMeshNode node = mExtendedMeshNode.getMeshNode();
+        final ProvisionedMeshNode node = (ProvisionedMeshNode) mExtendedMeshNode.getMeshNode();
         final Element element = mElement.getValue();
         final MeshModel model = mMeshModel.getValue();
         if (!model.getBoundAppKeyIndexes().isEmpty()) {
@@ -235,14 +234,14 @@ public class ModelConfigurationRepository extends BaseMeshRepository {
     }
 
     public void sendConfigModelSubscriptionAdd(final byte[] subscriptionAddress) {
-        final ProvisionedMeshNode node = mExtendedMeshNode.getMeshNode();
+        final ProvisionedMeshNode node = (ProvisionedMeshNode) mExtendedMeshNode.getMeshNode();
         final Element element = mElement.getValue();
         final MeshModel model = mMeshModel.getValue();
         mBinder.sendConfigModelSubscriptionAdd(node, element, model, subscriptionAddress);
     }
 
     public void sendConfigModelSubscriptionDelete(final byte[] subscriptionAddress) {
-        final ProvisionedMeshNode node = mExtendedMeshNode.getMeshNode();
+        final ProvisionedMeshNode node = (ProvisionedMeshNode) mExtendedMeshNode.getMeshNode();
         final Element element = mElement.getValue();
         final MeshModel model = mMeshModel.getValue();
         mBinder.sendConfigModelSubscriptionDelete(node, element, model, subscriptionAddress);

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/NodeConfigurationRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/NodeConfigurationRepository.java
@@ -111,13 +111,13 @@ public class NodeConfigurationRepository extends BaseMeshRepository {
     }
 
     public void sendGetCompositionData() {
-        mBinder.sendCompositionDataGet(mExtendedMeshNode.getMeshNode());
+        mBinder.sendCompositionDataGet((ProvisionedMeshNode) mExtendedMeshNode.getMeshNode());
     }
 
     private void handleConfigurationStates(final Intent intent){
         final int state = intent.getExtras().getInt(EXTRA_CONFIGURATION_STATE);
         final MeshNodeStates.MeshNodeStatus status = MeshNodeStates.MeshNodeStatus.fromStatusCode(state);
-        final ProvisionedMeshNode node = mBinder.getMeshNode();
+        final ProvisionedMeshNode node = (ProvisionedMeshNode) mBinder.getMeshNode();
         switch (status) {
             case COMPOSITION_DATA_GET_SENT:
                 break;

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/service/MeshService.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/service/MeshService.java
@@ -81,7 +81,6 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
         MeshStatusCallbacks,
         MeshManagerTransportCallbacks {
 
-
     public static final String NRF_MESH_GROUP_ID = "NRF_MESH_GROUP_ID";
     private static final String PRIMARY_CHANNEL = "PRIMARY_CHANNEL";
     private static final String PRIMARY_CHANNEL_ID = "no.nordicsemi.android.nrfmeshprovisioner";
@@ -116,7 +115,7 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
     /**
      * Contains the {@link UnprovisionedMeshNode}
      **/
-    private ProvisionedMeshNode mMeshNode;
+    private BaseMeshNode mMeshNode;
     /**
      * Mesh model to configure
      **/
@@ -159,7 +158,7 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
                 final byte[] serviceData = scanRecord.getServiceData(new ParcelUuid((MESH_PROXY_UUID)));
                 if (serviceData != null) {
                     if (mMeshManagerApi.isAdvertisedWithNodeIdentity(serviceData)) {
-                        final ProvisionedMeshNode node = mMeshNode;
+                        final ProvisionedMeshNode node = (ProvisionedMeshNode) mMeshNode;
                         if (mMeshManagerApi.nodeIdentityMatches(node, serviceData)) {
                             stopScan();
                             sendBroadcastConnectivityState(getString(R.string.state_scanning_provisioned_node_found, scanRecord.getDeviceName()));
@@ -335,7 +334,7 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
                     mMeshNode.setBluetoothDeviceAddress(device.getAddress());
                     //Adding a slight delay here so we don't send anything before we receive the mesh beacon message
                     mHandler.postDelayed(() -> {
-                        mMeshManagerApi.getCompositionData(mMeshNode);
+                        mMeshManagerApi.getCompositionData((ProvisionedMeshNode) mMeshNode);
                         //We set this to true so that once provisioning is complete, it will
                         // continue to with the app key add configuration after the Composition data is received
                         mShouldAddAppKeyBeAdded = true;
@@ -408,6 +407,7 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
     public void onProvisioningCapabilitiesReceived(final UnprovisionedMeshNode meshNode) {
         final Intent intent = new Intent(ACTION_PROVISIONING_STATE);
         intent.putExtra(EXTRA_PROVISIONING_STATE, MeshNodeStates.MeshNodeStatus.PROVISIONING_CAPABILITIES.getState());
+        mMeshNode = meshNode;
         LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
     }
 
@@ -612,7 +612,7 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
     @Override
     public void onAppKeyBindStatusReceived(final ProvisionedMeshNode node, final boolean success, final int status, final int elementAddress, final int appKeyIndex, final int modelIdentifier) {
         mMeshNode = node;
-        final Element element = mMeshNode.getElements().get(elementAddress);
+        final Element element = node.getElements().get(elementAddress);
         mElement = element;
         mMeshModel = element.getMeshModels().get(modelIdentifier);
         final Intent intent = new Intent(ACTION_CONFIGURATION_STATE);
@@ -636,7 +636,7 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
     @Override
     public void onPublicationStatusReceived(final ProvisionedMeshNode node, final boolean success, final int status, final byte[] elementAddress, final byte[] publishAddress, final int modelIdentifier) {
         mMeshNode = node;
-        final Element element = mMeshNode.getElements().get(AddressUtils.getUnicastAddressInt(elementAddress));
+        final Element element = node.getElements().get(AddressUtils.getUnicastAddressInt(elementAddress));
         mElement = element;
         mMeshModel = element.getMeshModels().get(modelIdentifier);
 
@@ -668,7 +668,7 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
     @Override
     public void onSubscriptionStatusReceived(final ProvisionedMeshNode node, final boolean success, final int status, final byte[] elementAddress, final byte[] subscriptionAddress, final int modelIdentifier) {
         mMeshNode = node;
-        final Element element = mMeshNode.getElements().get(AddressUtils.getUnicastAddressInt(elementAddress));
+        final Element element = node.getElements().get(AddressUtils.getUnicastAddressInt(elementAddress));
         mElement = element;
         mMeshModel = element.getMeshModels().get(modelIdentifier);
 
@@ -912,7 +912,7 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
             return mMeshManagerApi.generateNetworkId(networkKey);
         }
 
-        public ProvisionedMeshNode getMeshNode() {
+        public BaseMeshNode getMeshNode() {
             return mMeshNode;
         }
 
@@ -995,14 +995,14 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
         public void sendAppKeyAdd(final int appKeyIndex, final String appKey) {
             mAppKeyIndex = appKeyIndex;
             mAppKey = appKey;
-            mMeshManagerApi.addAppKey(mMeshNode, appKeyIndex, appKey);
+            mMeshManagerApi.addAppKey((ProvisionedMeshNode) mMeshNode, appKeyIndex, appKey);
         }
 
         public void sendAppKeyAdd(final ProvisionedMeshNode meshNode, final int appKeyIndex, final String appKey) {
             mMeshNode = meshNode;
             mAppKeyIndex = appKeyIndex;
             mAppKey = appKey;
-            mMeshManagerApi.addAppKey(mMeshNode, appKeyIndex, appKey);
+            mMeshManagerApi.addAppKey(meshNode, appKeyIndex, appKey);
         }
 
         /**

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/service/MeshService.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/service/MeshService.java
@@ -482,9 +482,10 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
     }
 
     @Override
-    public void onProvisioningFailed(final UnprovisionedMeshNode meshNode, final String error) {
+    public void onProvisioningFailed(final UnprovisionedMeshNode meshNode, final int errorCode) {
         final Intent intent = new Intent(ACTION_PROVISIONING_STATE);
         intent.putExtra(EXTRA_PROVISIONING_STATE, MeshNodeStates.MeshNodeStatus.PROVISIONING_FAILED.getState());
+        intent.putExtra(EXTRA_DATA, errorCode);
         LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
         mIsProvisioningComplete = false;
     }
@@ -950,6 +951,10 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
         public ConfigModelPublicationStatusLiveData getConfigModelPublicationStatus() {
             return mConfigModelPublicationStatus;
 
+        }
+
+        public void identifyNode(){
+            mMeshManagerApi.identifyNode();
         }
 
         public void startProvisioning(final String nodeName) {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/service/MeshService.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/service/MeshService.java
@@ -388,6 +388,7 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
 
     @Override
     public void sendPdu(final BaseMeshNode meshNode, final byte[] pdu) {
+        mMeshNode = meshNode;
         mBleMeshManager.sendPdu(pdu);
     }
 
@@ -953,11 +954,7 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
 
         }
 
-        public void identifyNode(){
-            mMeshManagerApi.identifyNode();
-        }
-
-        public void startProvisioning(final String nodeName) {
+        public void identifyNode(final String nodeName){
             mIsProvisioningComplete = false;
             mIsConfigurationComplete = false;
             final String networkKey = mProvisioningSettings.getNetworkKey();
@@ -967,7 +964,20 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
             final int unicastAddress = mProvisioningSettings.getUnicastAddress();
             final int globalTtl = mProvisioningSettings.getGlobalTtl();
             final BluetoothDevice device = mBluetoothDevice;
-            mMeshManagerApi.startProvisioning(device.getAddress(), nodeName, networkKey, keyIndex, flags, ivIndex, unicastAddress, globalTtl);
+            mMeshManagerApi.identifyNode(device.getAddress(), nodeName);
+        }
+
+        public void startProvisioning() {
+            mIsProvisioningComplete = false;
+            mIsConfigurationComplete = false;
+            final String networkKey = mProvisioningSettings.getNetworkKey();
+            final int keyIndex = mProvisioningSettings.getKeyIndex();
+            final int flags = mProvisioningSettings.getFlags();
+            final int ivIndex = mProvisioningSettings.getIvIndex();
+            final int unicastAddress = mProvisioningSettings.getUnicastAddress();
+            final int globalTtl = mProvisioningSettings.getGlobalTtl();
+            final BluetoothDevice device = mBluetoothDevice;
+            mMeshManagerApi.startProvisioning((UnprovisionedMeshNode) mMeshNode);
         }
 
         public void confirmProvisioning(final String pin) {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/MeshProvisionerViewModel.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/MeshProvisionerViewModel.java
@@ -28,6 +28,7 @@ import android.arch.lifecycle.ViewModel;
 import javax.inject.Inject;
 
 import no.nordicsemi.android.nrfmeshprovisioner.adapter.ExtendedBluetoothDevice;
+import no.nordicsemi.android.nrfmeshprovisioner.livedata.ExtendedMeshNode;
 import no.nordicsemi.android.nrfmeshprovisioner.livedata.ProvisionedNodesLiveData;
 import no.nordicsemi.android.nrfmeshprovisioner.livedata.ProvisioningLiveData;
 import no.nordicsemi.android.nrfmeshprovisioner.livedata.ProvisioningStateLiveData;
@@ -88,11 +89,15 @@ public class MeshProvisionerViewModel extends ViewModel {
         mMeshProvisionerRepository.unbindService();
     }
 
+    public ExtendedMeshNode getMeshNode(){
+        return mMeshProvisionerRepository.getExtendedMeshNode();
+    }
+
     public void identifyNode() {
         mMeshProvisionerRepository.identifyNode();
     }
 
-    public void provisionNode(final String nodeName) {
+    public void startProvisioning(final String nodeName) {
         mMeshProvisionerRepository.startProvisioning(nodeName);
     }
 

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/MeshProvisionerViewModel.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/MeshProvisionerViewModel.java
@@ -88,6 +88,10 @@ public class MeshProvisionerViewModel extends ViewModel {
         mMeshProvisionerRepository.unbindService();
     }
 
+    public void identifyNode() {
+        mMeshProvisionerRepository.identifyNode();
+    }
+
     public void provisionNode(final String nodeName) {
         mMeshProvisionerRepository.startProvisioning(nodeName);
     }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/MeshProvisionerViewModel.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/MeshProvisionerViewModel.java
@@ -93,12 +93,12 @@ public class MeshProvisionerViewModel extends ViewModel {
         return mMeshProvisionerRepository.getExtendedMeshNode();
     }
 
-    public void identifyNode() {
-        mMeshProvisionerRepository.identifyNode();
+    public void identifyNode(final String nodeName){
+        mMeshProvisionerRepository.identifyNode(nodeName);
     }
 
-    public void startProvisioning(final String nodeName) {
-        mMeshProvisionerRepository.startProvisioning(nodeName);
+    public void startProvisioning() {
+        mMeshProvisionerRepository.startProvisioning();
     }
 
     public void sendProvisioneePin(final String pin) {

--- a/Example/nrf-mesh/app/src/main/res/drawable/ic_arrow_downward_black_alpha_24dp.xml
+++ b/Example/nrf-mesh/app/src/main/res/drawable/ic_arrow_downward_black_alpha_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:alpha="0.6" android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#010101" android:pathData="M20,12l-1.41,-1.41L13,16.17V4h-2v12.17l-5.58,-5.59L4,12l8,8 8,-8z"/>
+</vector>

--- a/Example/nrf-mesh/app/src/main/res/drawable/ic_arrow_upward_black_alpha_24dp.xml
+++ b/Example/nrf-mesh/app/src/main/res/drawable/ic_arrow_upward_black_alpha_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:alpha="0.6" android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M4,12l1.41,1.41L11,7.83V20h2V7.83l5.58,5.59L20,12l-8,-8 -8,8z"/>
+</vector>

--- a/Example/nrf-mesh/app/src/main/res/drawable/ic_capabilities.xml
+++ b/Example/nrf-mesh/app/src/main/res/drawable/ic_capabilities.xml
@@ -1,0 +1,5 @@
+<vector android:alpha="0.6" android:height="24dp"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M5,3H7V5H5V10A2,2 0,0 1,3 12A2,2 0,0 1,5 14V19H7V21H5C3.93,20.73 3,20.1 3,19V15A2,2 0,0 0,1 13H0V11H1A2,2 0,0 0,3 9V5A2,2 0,0 1,5 3M19,3A2,2 0,0 1,21 5V9A2,2 0,0 0,23 11H24V13H23A2,2 0,0 0,21 15V19A2,2 0,0 1,19 21H17V19H19V14A2,2 0,0 1,21 12A2,2 0,0 1,19 10V5H17V3H19M12,15A1,1 0,0 1,13 16A1,1 0,0 1,12 17A1,1 0,0 1,11 16A1,1 0,0 1,12 15M8,15A1,1 0,0 1,9 16A1,1 0,0 1,8 17A1,1 0,0 1,7 16A1,1 0,0 1,8 15M16,15A1,1 0,0 1,17 16A1,1 0,0 1,16 17A1,1 0,0 1,15 16A1,1 0,0 1,16 15Z"/>
+</vector>

--- a/Example/nrf-mesh/app/src/main/res/drawable/ic_linear_scale_black_alpha_24dp.xml
+++ b/Example/nrf-mesh/app/src/main/res/drawable/ic_linear_scale_black_alpha_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:alpha="0.6" android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M19.5,9.5c-1.03,0 -1.9,0.62 -2.29,1.5h-2.92c-0.39,-0.88 -1.26,-1.5 -2.29,-1.5s-1.9,0.62 -2.29,1.5H6.79c-0.39,-0.88 -1.26,-1.5 -2.29,-1.5C3.12,9.5 2,10.62 2,12s1.12,2.5 2.5,2.5c1.03,0 1.9,-0.62 2.29,-1.5h2.92c0.39,0.88 1.26,1.5 2.29,1.5s1.9,-0.62 2.29,-1.5h2.92c0.39,0.88 1.26,1.5 2.29,1.5 1.38,0 2.5,-1.12 2.5,-2.5s-1.12,-2.5 -2.5,-2.5z"/>
+</vector>

--- a/Example/nrf-mesh/app/src/main/res/drawable/ic_space_bar_black_alpha_24dp.xml
+++ b/Example/nrf-mesh/app/src/main/res/drawable/ic_space_bar_black_alpha_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:alpha="0.6" android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M18,9v4H6V9H4v6h16V9z"/>
+</vector>

--- a/Example/nrf-mesh/app/src/main/res/layout/activity_mesh_provisioner.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/activity_mesh_provisioner.xml
@@ -74,7 +74,8 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_below="@+id/appbar_layout"
-            android:visibility="gone">
+            android:visibility="gone"
+            tools:visibility="visible">
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -82,7 +83,7 @@
                 android:orientation="vertical">
 
                 <android.support.v7.widget.CardView
-                    android:id="@+id/network_key_card"
+                    android:id="@+id/capabilities_card"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginBottom="@dimen/activity_horizontal_margin"
@@ -96,7 +97,7 @@
                         android:layout_height="match_parent">
 
                         <android.support.v7.widget.Toolbar
-                            android:id="@+id/network_key_tool_bar"
+                            android:id="@+id/capabilities_bar"
                             android:layout_width="0dp"
                             android:layout_height="?actionBarSize"
                             app:layout_constraintLeft_toLeftOf="parent"
@@ -107,31 +108,31 @@
                             app:titleMarginStart="@dimen/toolbar_title_margin"/>
 
                         <include
-                            android:id="@+id/container_name"
+                            android:id="@+id/container_element_count"
                             layout="@layout/layout_container"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
                             app:layout_constraintLeft_toLeftOf="parent"
                             app:layout_constraintRight_toRightOf="parent"
-                            app:layout_constraintTop_toBottomOf="@+id/network_key_tool_bar"/>
+                            app:layout_constraintTop_toBottomOf="@+id/capabilities_bar"/>
 
                         <include
-                            android:id="@+id/container_unicast_address"
+                            android:id="@+id/container_algorithm"
                             layout="@layout/layout_container"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
                             app:layout_constraintLeft_toLeftOf="parent"
                             app:layout_constraintRight_toRightOf="parent"
-                            app:layout_constraintTop_toBottomOf="@+id/container_name"/>
+                            app:layout_constraintTop_toBottomOf="@+id/container_element_count"/>
 
                         <include
-                            android:id="@+id/container_app_key"
+                            android:id="@+id/container_public_key_type"
                             layout="@layout/layout_container"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
                             app:layout_constraintLeft_toLeftOf="parent"
                             app:layout_constraintRight_toRightOf="parent"
-                            app:layout_constraintTop_toBottomOf="@+id/container_unicast_address"/>
+                            app:layout_constraintTop_toBottomOf="@+id/container_algorithm"/>
 
                         <View
                             android:id="@+id/div1"
@@ -140,7 +141,7 @@
                             android:background="@drawable/divider"
                             app:layout_constraintLeft_toLeftOf="parent"
                             app:layout_constraintRight_toRightOf="parent"
-                            app:layout_constraintTop_toBottomOf="@+id/container_app_key"/>
+                            app:layout_constraintTop_toBottomOf="@+id/container_public_key_type"/>
 
                         <Button
                             android:id="@+id/action_provision_device"
@@ -154,6 +155,20 @@
                             android:text="@string/provision_action"
                             app:layout_constraintBottom_toBottomOf="parent"
                             app:layout_constraintRight_toRightOf="parent"
+                            app:layout_constraintTop_toBottomOf="@+id/div1"/>
+
+                        <Button
+                            android:id="@+id/action_identify_device"
+                            style="@style/Widget.AppCompat.Button.Borderless.Colored"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_horizontal"
+                            android:layout_marginEnd="8dp"
+                            android:layout_marginStart="8dp"
+                            android:padding="@dimen/activity_horizontal_margin"
+                            android:text="@string/identify_action"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintRight_toLeftOf="@id/action_provision_device"
                             app:layout_constraintTop_toBottomOf="@+id/div1"/>
                     </android.support.constraint.ConstraintLayout>
                 </android.support.v7.widget.CardView>

--- a/Example/nrf-mesh/app/src/main/res/layout/activity_mesh_provisioner.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/activity_mesh_provisioner.xml
@@ -66,7 +66,7 @@
             android:layout_height="wrap_content"
             android:layout_alignParentBottom="true"
             android:layout_centerHorizontal="true"
-            android:layout_marginBottom="8dp"
+            android:layout_marginBottom="@dimen/item_padding_bottom"
             android:src="@drawable/background_title"/>
 
         <ScrollView
@@ -75,12 +75,15 @@
             android:layout_height="match_parent"
             android:layout_below="@+id/appbar_layout"
             android:visibility="gone"
-            tools:visibility="visible">
+            tools:visibility="visible"
+            android:clipToPadding="false"
+            android:scrollbars="none">
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:paddingBottom="@dimen/item_padding_bottom">
 
                 <android.support.v7.widget.CardView
                     android:id="@+id/capabilities_card"
@@ -117,7 +120,7 @@
                             app:layout_constraintTop_toBottomOf="@+id/capabilities_bar"/>
 
                         <include
-                            android:id="@+id/container_algorithm"
+                            android:id="@+id/container_supported_algorithm"
                             layout="@layout/layout_container"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
@@ -132,7 +135,7 @@
                             android:layout_height="wrap_content"
                             app:layout_constraintLeft_toLeftOf="parent"
                             app:layout_constraintRight_toRightOf="parent"
-                            app:layout_constraintTop_toBottomOf="@+id/container_algorithm"/>
+                            app:layout_constraintTop_toBottomOf="@+id/container_supported_algorithm"/>
 
                         <View
                             android:id="@+id/div1"
@@ -170,8 +173,15 @@
                             app:layout_constraintBottom_toBottomOf="parent"
                             app:layout_constraintRight_toLeftOf="@id/action_provision_device"
                             app:layout_constraintTop_toBottomOf="@+id/div1"/>
+
                     </android.support.constraint.ConstraintLayout>
                 </android.support.v7.widget.CardView>
+
+                <include
+                    layout="@layout/layout_capabilities"
+                    android:id="@+id/capabilities_container"
+                    android:visibility="gone"
+                    tools:visibility="visible"/>
             </LinearLayout>
         </ScrollView>
 

--- a/Example/nrf-mesh/app/src/main/res/layout/activity_mesh_provisioner.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/activity_mesh_provisioner.xml
@@ -155,23 +155,9 @@
                             android:layout_marginEnd="8dp"
                             android:layout_marginStart="8dp"
                             android:padding="@dimen/activity_horizontal_margin"
-                            android:text="@string/provision_action"
-                            app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintRight_toRightOf="parent"
-                            app:layout_constraintTop_toBottomOf="@+id/div1"/>
-
-                        <Button
-                            android:id="@+id/action_identify_device"
-                            style="@style/Widget.AppCompat.Button.Borderless.Colored"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"
-                            android:layout_gravity="center_horizontal"
-                            android:layout_marginEnd="8dp"
-                            android:layout_marginStart="8dp"
-                            android:padding="@dimen/activity_horizontal_margin"
                             android:text="@string/identify_action"
                             app:layout_constraintBottom_toBottomOf="parent"
-                            app:layout_constraintRight_toLeftOf="@id/action_provision_device"
+                            app:layout_constraintRight_toRightOf="parent"
                             app:layout_constraintTop_toBottomOf="@+id/div1"/>
 
                     </android.support.constraint.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/activity_node_details.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/activity_node_details.xml
@@ -136,7 +136,7 @@
                             app:layout_constraintTop_toBottomOf="@+id/container_timestamp"/>
 
                         <include
-                            android:id="@+id/container_algorithm"
+                            android:id="@+id/container_supported_algorithm"
                             layout="@layout/info_node_unicast_address"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
@@ -151,7 +151,7 @@
                             android:layout_height="wrap_content"
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintEnd_toStartOf="@id/copy"
-                            app:layout_constraintTop_toBottomOf="@+id/container_algorithm"/>
+                            app:layout_constraintTop_toBottomOf="@+id/container_supported_algorithm"/>
 
                         <ImageView
                             android:id="@+id/copy"

--- a/Example/nrf-mesh/app/src/main/res/layout/activity_node_details.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/activity_node_details.xml
@@ -108,7 +108,7 @@
                             app:titleMarginStart="@dimen/toolbar_title_margin"/>
 
                         <include
-                            android:id="@+id/container_name"
+                            android:id="@+id/container_element_count"
                             layout="@layout/info_node_name"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
@@ -123,7 +123,7 @@
                             android:layout_height="wrap_content"
                             app:layout_constraintLeft_toLeftOf="parent"
                             app:layout_constraintRight_toRightOf="parent"
-                            app:layout_constraintTop_toBottomOf="@+id/container_name"/>
+                            app:layout_constraintTop_toBottomOf="@+id/container_element_count"/>
 
                         <include
                             android:id="@+id/container_identifier"
@@ -136,7 +136,7 @@
                             app:layout_constraintTop_toBottomOf="@+id/container_timestamp"/>
 
                         <include
-                            android:id="@+id/container_unicast_address"
+                            android:id="@+id/container_algorithm"
                             layout="@layout/info_node_unicast_address"
                             android:layout_width="0dp"
                             android:layout_height="wrap_content"
@@ -151,7 +151,7 @@
                             android:layout_height="wrap_content"
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintEnd_toStartOf="@id/copy"
-                            app:layout_constraintTop_toBottomOf="@+id/container_unicast_address"/>
+                            app:layout_constraintTop_toBottomOf="@+id/container_algorithm"/>
 
                         <ImageView
                             android:id="@+id/copy"

--- a/Example/nrf-mesh/app/src/main/res/layout/fragment_settings.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/fragment_settings.xml
@@ -104,7 +104,7 @@
                     android:layout_height="match_parent">
 
                     <android.support.v7.widget.Toolbar
-                        android:id="@+id/network_key_tool_bar"
+                        android:id="@+id/capabilities_bar"
                         android:layout_width="0dp"
                         android:layout_height="?actionBarSize"
                         app:layout_constraintLeft_toLeftOf="parent"
@@ -121,7 +121,7 @@
                         android:layout_height="wrap_content"
                         app:layout_constraintLeft_toLeftOf="parent"
                         app:layout_constraintRight_toRightOf="parent"
-                        app:layout_constraintTop_toBottomOf="@+id/network_key_tool_bar"/>
+                        app:layout_constraintTop_toBottomOf="@+id/capabilities_bar"/>
 
                     <include
                         android:id="@+id/container_index"
@@ -151,7 +151,7 @@
                         app:layout_constraintTop_toBottomOf="@+id/container_flags"/>
 
                     <include
-                        android:id="@+id/container_unicast_address"
+                        android:id="@+id/container_algorithm"
                         layout="@layout/layout_container"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"

--- a/Example/nrf-mesh/app/src/main/res/layout/fragment_settings.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/fragment_settings.xml
@@ -151,7 +151,7 @@
                         app:layout_constraintTop_toBottomOf="@+id/container_flags"/>
 
                     <include
-                        android:id="@+id/container_algorithm"
+                        android:id="@+id/container_supported_algorithm"
                         layout="@layout/layout_container"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"

--- a/Example/nrf-mesh/app/src/main/res/layout/info_element_count.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/info_element_count.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018, Nordic Semiconductor
+  ~ All rights reserved.
+  ~
+  ~ Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+  ~
+  ~ 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  ~
+  ~ 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+  ~ documentation and/or other materials provided with the distribution.
+  ~
+  ~ 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+  ~ software without specific prior written permission.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+  ~ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/activity_horizontal_margin">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:textColor="@android:color/black"
+        android:textSize="16sp"
+        android:text="@string/element_count_title"
+        app:layout_constraintLeft_toRightOf="@id/image"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:textSize="12sp"
+        app:layout_constraintLeft_toRightOf="@id/image"
+        app:layout_constraintTop_toBottomOf="@id/title"/>
+
+    <ImageView
+        android:id="@+id/image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="@+id/text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/title"
+        app:srcCompat="@drawable/ic_index"
+        tools:ignore="VectorDrawableCompat"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/info_input_oob_actions.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/info_input_oob_actions.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018, Nordic Semiconductor
+  ~ All rights reserved.
+  ~
+  ~ Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+  ~
+  ~ 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  ~
+  ~ 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+  ~ documentation and/or other materials provided with the distribution.
+  ~
+  ~ 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+  ~ software without specific prior written permission.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+  ~ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/activity_horizontal_margin">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:textColor="@android:color/black"
+        android:textSize="16sp"
+        android:text="@string/supported_input_oob_actions_title"
+        app:layout_constraintLeft_toRightOf="@id/image"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:textSize="12sp"
+        app:layout_constraintLeft_toRightOf="@id/image"
+        app:layout_constraintTop_toBottomOf="@id/title"/>
+
+    <ImageView
+        android:id="@+id/image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="@+id/text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/title"
+        app:srcCompat="@drawable/ic_arrow_downward_black_alpha_24dp"
+        tools:ignore="VectorDrawableCompat"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/info_input_oob_size.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/info_input_oob_size.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018, Nordic Semiconductor
+  ~ All rights reserved.
+  ~
+  ~ Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+  ~
+  ~ 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  ~
+  ~ 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+  ~ documentation and/or other materials provided with the distribution.
+  ~
+  ~ 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+  ~ software without specific prior written permission.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+  ~ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/activity_horizontal_margin">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:textColor="@android:color/black"
+        android:textSize="16sp"
+        android:text="@string/input_oob_size_title"
+        app:layout_constraintLeft_toRightOf="@id/image"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:textSize="12sp"
+        app:layout_constraintLeft_toRightOf="@id/image"
+        app:layout_constraintTop_toBottomOf="@id/title"/>
+
+    <ImageView
+        android:id="@+id/image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="@+id/text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/title"
+        app:srcCompat="@drawable/ic_space_bar_black_alpha_24dp"
+        tools:ignore="VectorDrawableCompat"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/info_output_oob_actions.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/info_output_oob_actions.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018, Nordic Semiconductor
+  ~ All rights reserved.
+  ~
+  ~ Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+  ~
+  ~ 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  ~
+  ~ 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+  ~ documentation and/or other materials provided with the distribution.
+  ~
+  ~ 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+  ~ software without specific prior written permission.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+  ~ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/activity_horizontal_margin">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:textColor="@android:color/black"
+        android:textSize="16sp"
+        android:text="@string/supported_output_oob_actions_title"
+        app:layout_constraintLeft_toRightOf="@id/image"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:textSize="12sp"
+        app:layout_constraintLeft_toRightOf="@id/image"
+        app:layout_constraintTop_toBottomOf="@id/title"/>
+
+    <ImageView
+        android:id="@+id/image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="@+id/text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/title"
+        app:srcCompat="@drawable/ic_arrow_upward_black_alpha_24dp"
+        tools:ignore="VectorDrawableCompat"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/info_output_oob_size.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/info_output_oob_size.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018, Nordic Semiconductor
+  ~ All rights reserved.
+  ~
+  ~ Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+  ~
+  ~ 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  ~
+  ~ 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+  ~ documentation and/or other materials provided with the distribution.
+  ~
+  ~ 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+  ~ software without specific prior written permission.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+  ~ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/activity_horizontal_margin">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:textColor="@android:color/black"
+        android:textSize="16sp"
+        android:text="@string/output_oob_size_title"
+        app:layout_constraintLeft_toRightOf="@id/image"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:textSize="12sp"
+        app:layout_constraintLeft_toRightOf="@id/image"
+        app:layout_constraintTop_toBottomOf="@id/title"/>
+
+    <ImageView
+        android:id="@+id/image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="@+id/text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/title"
+        app:srcCompat="@drawable/ic_space_bar_black_alpha_24dp"
+        tools:ignore="VectorDrawableCompat"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/info_public_key_type.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/info_public_key_type.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018, Nordic Semiconductor
+  ~ All rights reserved.
+  ~
+  ~ Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+  ~
+  ~ 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  ~
+  ~ 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+  ~ documentation and/or other materials provided with the distribution.
+  ~
+  ~ 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+  ~ software without specific prior written permission.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+  ~ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/activity_horizontal_margin">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:textColor="@android:color/black"
+        android:textSize="16sp"
+        android:text="@string/public_key_type_title"
+        app:layout_constraintLeft_toRightOf="@id/image"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:textSize="12sp"
+        app:layout_constraintLeft_toRightOf="@id/image"
+        app:layout_constraintTop_toBottomOf="@id/title"/>
+
+    <ImageView
+        android:id="@+id/image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="@+id/text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/title"
+        app:srcCompat="@drawable/ic_vpn_key_black_alpha_24dp"
+        tools:ignore="VectorDrawableCompat"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/info_static_oob_type.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/info_static_oob_type.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018, Nordic Semiconductor
+  ~ All rights reserved.
+  ~
+  ~ Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+  ~
+  ~ 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  ~
+  ~ 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+  ~ documentation and/or other materials provided with the distribution.
+  ~
+  ~ 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+  ~ software without specific prior written permission.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+  ~ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/activity_horizontal_margin">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:textColor="@android:color/black"
+        android:textSize="16sp"
+        android:text="@string/static_oob_type_title"
+        app:layout_constraintLeft_toRightOf="@id/image"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:textSize="12sp"
+        app:layout_constraintLeft_toRightOf="@id/image"
+        app:layout_constraintTop_toBottomOf="@id/title"/>
+
+    <ImageView
+        android:id="@+id/image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="@+id/text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/title"
+        app:srcCompat="@drawable/ic_linear_scale_black_alpha_24dp"
+        tools:ignore="VectorDrawableCompat"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/info_supported_algorithms.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/info_supported_algorithms.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018, Nordic Semiconductor
+  ~ All rights reserved.
+  ~
+  ~ Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+  ~
+  ~ 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  ~
+  ~ 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+  ~ documentation and/or other materials provided with the distribution.
+  ~
+  ~ 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+  ~ software without specific prior written permission.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+  ~ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/activity_horizontal_margin">
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:textColor="@android:color/black"
+        android:textSize="16sp"
+        android:text="@string/supported_algorithms_title"
+        app:layout_constraintLeft_toRightOf="@id/image"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/activity_horizontal_margin"
+        android:textSize="12sp"
+        app:layout_constraintLeft_toRightOf="@id/image"
+        app:layout_constraintTop_toBottomOf="@id/title"/>
+
+    <ImageView
+        android:id="@+id/image"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="@+id/text"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/title"
+        app:srcCompat="@drawable/ic_security_black_24dp_alpha"
+        tools:ignore="VectorDrawableCompat"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/layout_capabilities.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/layout_capabilities.xml
@@ -26,7 +26,7 @@
 
         <include
             android:id="@+id/container_element_count"
-            layout="@layout/layout_container"
+            layout="@layout/info_element_count"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintLeft_toLeftOf="parent"
@@ -34,8 +34,8 @@
             app:layout_constraintTop_toBottomOf="@+id/capabilities_bar"/>
 
         <include
-            android:id="@+id/container_algorithm"
-            layout="@layout/layout_container"
+            android:id="@+id/container_supported_algorithm"
+            layout="@layout/info_supported_algorithms"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintLeft_toLeftOf="parent"
@@ -44,16 +44,16 @@
 
         <include
             android:id="@+id/container_public_key_type"
-            layout="@layout/layout_container"
+            layout="@layout/info_public_key_type"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/container_algorithm"/>
+            app:layout_constraintTop_toBottomOf="@+id/container_supported_algorithm"/>
 
         <include
-            android:id="@+id/container_static_oob"
-            layout="@layout/layout_container"
+            android:id="@+id/container_static_oob_type"
+            layout="@layout/info_static_oob_type"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintLeft_toLeftOf="parent"
@@ -61,17 +61,26 @@
             app:layout_constraintTop_toBottomOf="@+id/container_public_key_type"/>
 
         <include
-            android:id="@+id/container_output_actions"
-            layout="@layout/layout_container"
+            android:id="@+id/container_output_oob_size"
+            layout="@layout/info_output_oob_size"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/container_static_oob"/>
+            app:layout_constraintTop_toBottomOf="@+id/container_static_oob_type"/>
 
         <include
-            android:id="@+id/output_oob_size"
-            layout="@layout/layout_container"
+            android:id="@+id/container_output_actions"
+            layout="@layout/info_output_oob_actions"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/container_output_oob_size"/>
+
+        <include
+            android:id="@+id/container_input_oob_size"
+            layout="@layout/info_input_oob_size"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintLeft_toLeftOf="parent"
@@ -80,21 +89,13 @@
 
         <include
             android:id="@+id/container_input_actions"
-            layout="@layout/layout_container"
+            layout="@layout/info_input_oob_actions"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/output_oob_size"/>
+            app:layout_constraintTop_toBottomOf="@+id/container_input_oob_size"/>
 
-        <include
-            android:id="@+id/input_oob_size"
-            layout="@layout/layout_container"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/container_input_actions"/>
 
     </android.support.constraint.ConstraintLayout>
 </android.support.v7.widget.CardView>

--- a/Example/nrf-mesh/app/src/main/res/layout/layout_capabilities.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/layout_capabilities.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.CardView
+    android:id="@+id/capabilities_card"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/activity_horizontal_margin"
+    android:background="@android:color/white"
+    app:cardElevation="1dp"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <android.support.constraint.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <android.support.v7.widget.Toolbar
+            android:id="@+id/capabilities_bar"
+            android:layout_width="0dp"
+            android:layout_height="?actionBarSize"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:logo="@drawable/ic_capabilities"
+            app:title="Capabilities"
+            app:titleMarginStart="@dimen/toolbar_title_margin"/>
+
+        <include
+            android:id="@+id/container_element_count"
+            layout="@layout/layout_container"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/capabilities_bar"/>
+
+        <include
+            android:id="@+id/container_algorithm"
+            layout="@layout/layout_container"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/container_element_count"/>
+
+        <include
+            android:id="@+id/container_public_key_type"
+            layout="@layout/layout_container"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/container_algorithm"/>
+
+        <include
+            android:id="@+id/container_static_oob"
+            layout="@layout/layout_container"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/container_public_key_type"/>
+
+        <include
+            android:id="@+id/container_output_actions"
+            layout="@layout/layout_container"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/container_static_oob"/>
+
+        <include
+            android:id="@+id/output_oob_size"
+            layout="@layout/layout_container"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/container_output_actions"/>
+
+        <include
+            android:id="@+id/container_input_actions"
+            layout="@layout/layout_container"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/output_oob_size"/>
+
+        <include
+            android:id="@+id/input_oob_size"
+            layout="@layout/layout_container"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/container_input_actions"/>
+
+    </android.support.constraint.ConstraintLayout>
+</android.support.v7.widget.CardView>

--- a/Example/nrf-mesh/app/src/main/res/layout/network_item.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/network_item.xml
@@ -101,7 +101,6 @@
                     app:layout_constraintStart_toEndOf="@id/unicast_title"
                     app:layout_constraintTop_toTopOf="@id/unicast_title"/>
 
-
                 <TextView
                     android:id="@+id/company_identifier_title"
                     android:layout_width="wrap_content"

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -101,6 +101,7 @@
     <string name="prov_app_key_bind_status_received">App key bind status received…</string>
 
     <string name="provision_action">Provision</string>
+    <string name="identify_action">Identify</string>
 
     <string name="ok">OK</string>
 

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -330,4 +330,5 @@
     <string name="supported_output_oob_actions_title">Supported Ouput OOB Actions</string>
     <string name="supported_input_oob_actions_title">Supported Input OOB Actions</string>
     <string name="input_oob_size_title">Input OOB Size</string>
+    <string name="unknown">Unknown</string>
 </resources>

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -322,4 +322,12 @@
     <string name="title_transaction_failed">Transaction Failed</string>
     <string name="segments_not_received_timed_out">All message segments were not received, operation timed out!</string>
     <string name="operation_timed_out">Operation timed out</string>
+    <string name="element_count_title">Element Count</string>
+    <string name="supported_algorithms_title">Supported Algorithms</string>
+    <string name="public_key_type_title">Public Key Type</string>
+    <string name="static_oob_type_title">Static OOB Type</string>
+    <string name="output_oob_size_title">Output OOB Size</string>
+    <string name="supported_output_oob_actions_title">Supported Ouput OOB Actions</string>
+    <string name="supported_input_oob_actions_title">Supported Input OOB Actions</string>
+    <string name="input_oob_size_title">Input OOB Size</string>
 </resources>

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNode.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNode.java
@@ -33,6 +33,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import no.nordicsemi.android.meshprovisioner.states.ProvisioningCapabilities;
 import no.nordicsemi.android.meshprovisioner.utils.Element;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
 import no.nordicsemi.android.meshprovisioner.utils.SparseIntArrayParcelable;
@@ -80,6 +81,7 @@ public abstract class BaseMeshNode implements Parcelable {
     private String bluetoothDeviceAddress;
     protected long mTimeStampInMillis;
     protected SparseIntArrayParcelable mSeqAuth = new SparseIntArrayParcelable();
+    private ProvisioningCapabilities provisioningCapabilities;
 
     protected BaseMeshNode() {
 
@@ -182,5 +184,13 @@ public abstract class BaseMeshNode implements Parcelable {
 
     public final void setConfigurationSrc(final byte[] src) {
         mConfigurationSrc = src;
+    }
+
+    public void setProvisioningCapabilities(final ProvisioningCapabilities provisioningCapabilities) {
+        this.provisioningCapabilities = provisioningCapabilities;
+    }
+
+    public ProvisioningCapabilities getProvisioningCapabilities() {
+        return provisioningCapabilities;
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNode.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNode.java
@@ -81,7 +81,8 @@ public abstract class BaseMeshNode implements Parcelable {
     private String bluetoothDeviceAddress;
     protected long mTimeStampInMillis;
     protected SparseIntArrayParcelable mSeqAuth = new SparseIntArrayParcelable();
-    private ProvisioningCapabilities provisioningCapabilities;
+    protected ProvisioningCapabilities provisioningCapabilities;
+    protected int numberOfElements;
 
     protected BaseMeshNode() {
 
@@ -186,11 +187,11 @@ public abstract class BaseMeshNode implements Parcelable {
         mConfigurationSrc = src;
     }
 
-    public void setProvisioningCapabilities(final ProvisioningCapabilities provisioningCapabilities) {
-        this.provisioningCapabilities = provisioningCapabilities;
-    }
-
     public ProvisioningCapabilities getProvisioningCapabilities() {
         return provisioningCapabilities;
+    }
+
+    public int getNumberOfElements() {
+        return numberOfElements;
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/InternalMeshManagerCallbacks.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/InternalMeshManagerCallbacks.java
@@ -32,12 +32,4 @@ public interface InternalMeshManagerCallbacks {
      * @param meshNode node that was provisioned
      */
     void onNodeProvisioned(final ProvisionedMeshNode meshNode);
-
-    /**
-     * Internal callback to notify the {@link MeshManagerApi} of incremented unicast address.
-     * <p>This is called after the composition data status is received so that we can increment address according to the number of elements on a node</p>
-     *
-     * @param unicastAddress updated unicast address
-     */
-    void onUnicastAddressChanged(final int unicastAddress);
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
@@ -47,6 +47,7 @@ import no.nordicsemi.android.meshprovisioner.configuration.ConfigMessageState;
 import no.nordicsemi.android.meshprovisioner.configuration.MeshModel;
 import no.nordicsemi.android.meshprovisioner.configuration.ProvisionedMeshNode;
 import no.nordicsemi.android.meshprovisioner.configuration.SequenceNumber;
+import no.nordicsemi.android.meshprovisioner.states.UnprovisionedMeshNode;
 import no.nordicsemi.android.meshprovisioner.utils.AddressUtils;
 import no.nordicsemi.android.meshprovisioner.utils.InterfaceAdapter;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
@@ -579,10 +580,40 @@ public class MeshManagerApi implements InternalTransportCallbacks, InternalMeshM
         return data;
     }
 
+
+
     /**
-     * Starts the provisioning process
+     * Identifies the node that is to be provisioned.
+     * <p>
+     * This method will send a provisioning invite to the connected peripheral. This will help users to identify a particular node before starting the provisioning process.
+     * If a user connected to the correct peripheral you can call {@link #startProvisioning(String, String, String, int, int, int, int, int)} to continue provisioning.
+     * </p
+     *
      */
-    public void startProvisioning(@NonNull final String address, final String nodeName, @NonNull final String networkKeyValue, final int keyIndex, final int flags, final int ivIndex, final int unicastAddress, final int globalTtl) throws IllegalArgumentException {
+    public void identifyNode() throws IllegalArgumentException {
+        //We must save all the provisioning data here so that they could be reused when provisioning the next devices
+        mMeshProvisioningHandler.identifyNode(new UnprovisionedMeshNode());
+    }
+
+    /**
+     * Starts provisioning an unprovisioned mesh node
+     * <p>
+     * This method will start the provisioning process. During this process you may notice the unprovisioned node may blink if its supported by the node.
+     * Also the node may not blink if {@link #identifyNode()} was invoked before calling this method.
+     * However, if {@link #identifyNode()} was called before this, invoking this method will continue the provisioning process.
+     * </p>
+     *
+     * @param address         Bluetooth address of the node
+     * @param nodeName        Friendly node name
+     * @param networkKeyValue Network key
+     * @param keyIndex        Index of the network key
+     * @param flags           Flag containing the key refresh or the iv update operations
+     * @param ivIndex         32-bit value shared across the network
+     * @param unicastAddress  Unicast address to be assigned to the node
+     * @param globalTtl       Global ttl which is also the number of hops to be used for a message
+     */
+    public void startProvisioning(@NonNull final String address, final String nodeName, @NonNull final String networkKeyValue,
+                                  final int keyIndex, final int flags, final int ivIndex, final int unicastAddress, final int globalTtl) throws IllegalArgumentException {
         //We must save all the provisioning data here so that they could be reused when provisioning the next devices
         mProvisioningSettings.setNetworkKey(networkKeyValue);
         mProvisioningSettings.setKeyIndex(keyIndex);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
@@ -254,6 +254,7 @@ public class MeshManagerApi implements InternalTransportCallbacks, InternalMeshM
     public void onNodeProvisioned(final ProvisionedMeshNode meshNode) {
         final int unicastAddress = AddressUtils.getUnicastAddressInt(meshNode.getUnicastAddress());
         mProvisionedNodes.put(unicastAddress, meshNode);
+        incrementUnicastAddress(meshNode);
         saveProvisionedNode(meshNode);
     }
 
@@ -312,15 +313,13 @@ public class MeshManagerApi implements InternalTransportCallbacks, InternalMeshM
         editor.apply();
     }
 
-    @Override
-    public void onUnicastAddressChanged(final int unicastAddress) {
-        //Now that we have received the unicast addresses assigned to element addresses,
-        //increment it here again so the next node to be provisioned will have the next available address in the network
-        int unicastAdd = unicastAddress + 1;
+    private void incrementUnicastAddress(final ProvisionedMeshNode meshNode) {
+        //Since we know the number of elements this node contains we can predict the next available address for the next node.
+        int unicastAdd = (meshNode.getUnicastAddressInt() + meshNode.getNumberOfElements());
         //We check if the incremented unicast address is already taken by the app/configurator
         final int tempSrc = (mConfigurationSrc[0] & 0xFF) << 8 | (mConfigurationSrc[1] & 0xFF);
         if(unicastAdd == tempSrc) {
-            unicastAdd = unicastAddress + 1;
+            unicastAdd = unicastAdd + 1;
         }
         mProvisioningSettings.setUnicastAddress(unicastAdd);
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshMessageHandler.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshMessageHandler.java
@@ -196,7 +196,7 @@ class MeshMessageHandler implements InternalMeshMsgHandlerCallbacks {
                 case COMPOSITION_DATA_STATUS_STATE:
                     final ConfigCompositionDataStatus compositionDataStatus = (ConfigCompositionDataStatus) mMeshMessageState;
                     if (compositionDataStatus.parseMessage(pdu)) {
-                        mInternalMeshManagerCallbacks.onUnicastAddressChanged(compositionDataStatus.getUnicastAddress());
+                        //mInternalMeshManagerCallbacks.onUnicastAddressChanged(compositionDataStatus.getUnicastAddress());
                         switchToNoOperationState(new DefaultNoOperationMessageState(mContext, meshNode, this));
                     }
                     break;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshProvisioningHandler.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshProvisioningHandler.java
@@ -505,7 +505,7 @@ public class MeshProvisioningHandler {
         final byte[] startData = new byte[5];
         startData[0] = ParseProvisioningAlgorithm.getAlgorithmValue(algorithm);
         startData[1] = 0;//(byte) publicKeyType;
-        final int outputOobActionType = (byte) ParseOutputOOBActions.selectOutputActionsFromBitMask(outputOOBAction);
+        final short outputOobActionType = (byte) ParseOutputOOBActions.selectOutputActionsFromBitMask(outputOOBAction);
         if (outputOobActionType == ParseOutputOOBActions.NO_OUTPUT) {
             startData[2] = 0;
             //prefer no oob

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshProvisioningStatusCallbacks.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshProvisioningStatusCallbacks.java
@@ -51,7 +51,7 @@ public interface MeshProvisioningStatusCallbacks {
 
     void onProvisioningDataSent(final UnprovisionedMeshNode unprovisionedMeshNode);
 
-    void onProvisioningFailed(final UnprovisionedMeshNode unprovisionedMeshNode, final String error);
+    void onProvisioningFailed(final UnprovisionedMeshNode unprovisionedMeshNode, final int errorCode);
 
     void onProvisioningComplete(final ProvisionedMeshNode provisionedMeshNode);
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/ProvisionedMeshNode.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/ProvisionedMeshNode.java
@@ -63,6 +63,7 @@ public class ProvisionedMeshNode extends BaseMeshNode {
         k2Output = SecureUtils.calculateK2(networkKey, SecureUtils.K2_MASTER_INPUT);
         mTimeStampInMillis = unprovisionedMeshNode.getTimeStamp();
         mConfigurationSrc = unprovisionedMeshNode.getConfigurationSrc();
+        numberOfElements = unprovisionedMeshNode.getNumberOfElements();
     }
 
     protected ProvisionedMeshNode(Parcel in) {
@@ -97,6 +98,7 @@ public class ProvisionedMeshNode extends BaseMeshNode {
         mTimeStampInMillis = in.readLong();
         mConfigurationSrc = in.createByteArray();
         mSeqAuth = in.readParcelable(SparseIntArrayParcelable.class.getClassLoader());
+        numberOfElements = in.readInt();
     }
 
     @Override
@@ -132,6 +134,7 @@ public class ProvisionedMeshNode extends BaseMeshNode {
         dest.writeLong(mTimeStampInMillis);
         dest.writeByteArray(mConfigurationSrc);
         dest.writeParcelable(mSeqAuth, flags);
+        dest.writeInt(numberOfElements);
     }
 
     private void sortElements(final HashMap<Integer, Element> unorderedElements){

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningCapabilities.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningCapabilities.java
@@ -65,7 +65,7 @@ public final class ProvisioningCapabilities implements Parcelable {
         return rawCapabilities;
     }
 
-    void setRawCapabilities(final byte[] rawCapabilities) {
+    protected void setRawCapabilities(final byte[] rawCapabilities) {
         this.rawCapabilities = rawCapabilities;
     }
 
@@ -73,7 +73,7 @@ public final class ProvisioningCapabilities implements Parcelable {
         return numberOfElements;
     }
 
-    void setNumberOfElements(final byte numberOfElements) {
+    protected void setNumberOfElements(final byte numberOfElements) {
         this.numberOfElements = numberOfElements;
     }
 
@@ -81,7 +81,7 @@ public final class ProvisioningCapabilities implements Parcelable {
         return algorithm;
     }
 
-    void setSupportedAlgorithm(final short algorithm) {
+    protected void setSupportedAlgorithm(final short algorithm) {
         this.algorithm = algorithm;
     }
 
@@ -89,7 +89,7 @@ public final class ProvisioningCapabilities implements Parcelable {
         return publicKeyType;
     }
 
-    void setPublicKeyType(final byte publicKeyType) {
+    protected void setPublicKeyType(final byte publicKeyType) {
         this.publicKeyType = publicKeyType;
     }
 
@@ -97,7 +97,7 @@ public final class ProvisioningCapabilities implements Parcelable {
         return staticOOBType;
     }
 
-    void setStaticOOBType(final byte staticOOBType) {
+    protected void setStaticOOBType(final byte staticOOBType) {
         this.staticOOBType = staticOOBType;
     }
 
@@ -105,7 +105,7 @@ public final class ProvisioningCapabilities implements Parcelable {
         return outputOOBSize;
     }
 
-    void setOutputOOBSize(final byte outputOOBSize) {
+    protected void setOutputOOBSize(final byte outputOOBSize) {
         this.outputOOBSize = outputOOBSize;
     }
 
@@ -113,7 +113,7 @@ public final class ProvisioningCapabilities implements Parcelable {
         return outputOOBAction;
     }
 
-    void setOutputOOBAction(final short outputOOBAction) {
+    protected void setOutputOOBAction(final short outputOOBAction) {
         this.outputOOBAction = outputOOBAction;
     }
 
@@ -121,7 +121,7 @@ public final class ProvisioningCapabilities implements Parcelable {
         return inputOOBSize;
     }
 
-    void setInputOOBSize(final byte inputOOBSize) {
+    protected void setInputOOBSize(final byte inputOOBSize) {
         this.inputOOBSize = inputOOBSize;
     }
 
@@ -129,7 +129,7 @@ public final class ProvisioningCapabilities implements Parcelable {
         return inputOOBAction;
     }
 
-    void setInputOOBAction(final short inputOOBAction) {
+    protected void setInputOOBAction(final short inputOOBAction) {
         this.inputOOBAction = inputOOBAction;
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningCapabilities.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningCapabilities.java
@@ -1,134 +1,135 @@
-/*
- * Copyright (c) 2018, Nordic Semiconductor
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
- *
- * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
- * documentation and/or other materials provided with the distribution.
- *
- * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
- * software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
- * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
- * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-
 package no.nordicsemi.android.meshprovisioner.states;
 
-import android.util.Log;
+import android.os.Parcel;
+import android.os.Parcelable;
 
-import no.nordicsemi.android.meshprovisioner.MeshProvisioningStatusCallbacks;
-import no.nordicsemi.android.meshprovisioner.utils.ParseInputOOBActions;
-import no.nordicsemi.android.meshprovisioner.utils.ParseOutputOOBActions;
-import no.nordicsemi.android.meshprovisioner.utils.ParsePublicKeyInformation;
-import no.nordicsemi.android.meshprovisioner.utils.ParseStaticOutputOOBInformation;
+public final class ProvisioningCapabilities implements Parcelable {
 
-public class ProvisioningCapabilities extends ProvisioningState {
-    private static final String TAG = ProvisioningInvite.class.getSimpleName();
+    private byte [] rawCapabilities;
+    private byte numberOfElements;
+    private short algorithm;
+    private byte publicKeyType;
+    private byte staticOOBType;
+    private byte outputOOBSize;
+    private short outputOOBAction;
+    private byte inputOOBSize;
+    private short inputOOBAction;
 
-    private final UnprovisionedMeshNode mUnprovisionedMeshNode;
-    private final MeshProvisioningStatusCallbacks mCallbacks;
+    ProvisioningCapabilities(){
 
-    private int numberOfElements;
-    private int algorithm;
-    private int publicKeyType;
-    private int staticOOBType;
-    private int outputOOBSize;
-    private int outputOOBAction;
-    private int inputOOBSize;
-    private int inputOOBAction;
+    }
 
-    public ProvisioningCapabilities(final UnprovisionedMeshNode unprovisionedMeshNode, final MeshProvisioningStatusCallbacks callbacks) {
-        super();
-        this.mCallbacks = callbacks;
-        this.mUnprovisionedMeshNode = unprovisionedMeshNode;
+    ProvisioningCapabilities(Parcel in) {
+        rawCapabilities = in.createByteArray();
+        numberOfElements = in.readByte();
+        algorithm = (short) in.readInt();
+        publicKeyType = in.readByte();
+        staticOOBType = in.readByte();
+        outputOOBSize = in.readByte();
+        outputOOBAction = (short) in.readInt();
+        inputOOBSize = in.readByte();
+        inputOOBAction = (short) in.readInt();
     }
 
     @Override
-    public State getState() {
-        return State.PROVISIONING_CAPABILITIES;
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeByteArray(rawCapabilities);
+        dest.writeByte(numberOfElements);
+        dest.writeInt((int) algorithm);
+        dest.writeByte(publicKeyType);
+        dest.writeByte(staticOOBType);
+        dest.writeByte(outputOOBSize);
+        dest.writeInt((int) outputOOBAction);
+        dest.writeByte(inputOOBSize);
+        dest.writeInt((int) inputOOBAction);
     }
 
-    public int getNumberOfElements() {
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    public static final Creator<ProvisioningCapabilities> CREATOR = new Creator<ProvisioningCapabilities>() {
+        @Override
+        public ProvisioningCapabilities createFromParcel(Parcel in) {
+            return new ProvisioningCapabilities(in);
+        }
+
+        @Override
+        public ProvisioningCapabilities[] newArray(int size) {
+            return new ProvisioningCapabilities[size];
+        }
+    };
+
+    public byte[] getRawCapabilities() {
+        return rawCapabilities;
+    }
+
+    void setRawCapabilities(final byte[] rawCapabilities) {
+        this.rawCapabilities = rawCapabilities;
+    }
+
+    public byte getNumberOfElements() {
         return numberOfElements;
     }
 
-    public int getAlgorithm() {
+    void setNumberOfElements(final byte numberOfElements) {
+        this.numberOfElements = numberOfElements;
+    }
+
+    public short getSupportedAlgorithm() {
         return algorithm;
     }
 
-    public int getPublicKeyType() {
+    void setSupportedAlgorithm(final short algorithm) {
+        this.algorithm = algorithm;
+    }
+
+    public byte getPublicKeyType() {
         return publicKeyType;
     }
 
-    public int getStaticOOBType() {
+    void setPublicKeyType(final byte publicKeyType) {
+        this.publicKeyType = publicKeyType;
+    }
+
+    public byte getStaticOOBType() {
         return staticOOBType;
     }
 
-    public int getOutputOOBSize() {
+    void setStaticOOBType(final byte staticOOBType) {
+        this.staticOOBType = staticOOBType;
+    }
+
+    public byte getOutputOOBSize() {
         return outputOOBSize;
     }
 
-    public int getOutputOOBAction() {
+    void setOutputOOBSize(final byte outputOOBSize) {
+        this.outputOOBSize = outputOOBSize;
+    }
+
+    public short getOutputOOBAction() {
         return outputOOBAction;
     }
 
-    public int getInputOOBSize() {
+    void setOutputOOBAction(final short outputOOBAction) {
+        this.outputOOBAction = outputOOBAction;
+    }
+
+    public byte getInputOOBSize() {
         return inputOOBSize;
     }
 
-    public int getInputOOBAction() {
+    void setInputOOBSize(final byte inputOOBSize) {
+        this.inputOOBSize = inputOOBSize;
+    }
+
+    public short getInputOOBAction() {
         return inputOOBAction;
     }
 
-    @Override
-    public void executeSend() {
-
-    }
-
-    @Override
-    public boolean parseData(final byte[] data) {
-        mCallbacks.onProvisioningCapabilitiesReceived(mUnprovisionedMeshNode);
-        return parseProvisioningCapabilities(data);
-    }
-
-    private boolean parseProvisioningCapabilities(final byte[] provisioningCapabilities) {
-
-        if (provisioningCapabilities[2] == 0)
-            throw new IllegalArgumentException("Number of elements cannot be zero");
-
-        numberOfElements = (provisioningCapabilities[2]);
-        Log.v(TAG, "Number of elements: " + numberOfElements);
-
-        algorithm = (((provisioningCapabilities[3] & 0xff) << 8) | (provisioningCapabilities[4] & 0xff));
-        Log.v(TAG, "Algorithm: " + algorithm);
-
-        publicKeyType = (provisioningCapabilities[5]); // 0 is unavailable and 1 is available
-        Log.v(TAG, "Public key type: " + ParsePublicKeyInformation.parsePublicKeyInformation(publicKeyType));
-
-        staticOOBType = (provisioningCapabilities[6]); // 0 is unavailable and 1 is available
-        Log.v(TAG, "Static OOB type: " + ParseStaticOutputOOBInformation.parseStaticOOBActionInformation(staticOOBType));
-
-        outputOOBSize = (provisioningCapabilities[7]);
-        Log.v(TAG, "Output OOB size: " + outputOOBSize);
-
-        outputOOBAction = ((provisioningCapabilities[8] & 0xff) << 8) | (provisioningCapabilities[9] & 0xff);
-        ParseOutputOOBActions.parseOutputActionsFromBitMask(outputOOBAction);
-
-        inputOOBSize = (provisioningCapabilities[10]);
-        Log.v(TAG, "Input OOB size: " + inputOOBSize);
-
-        inputOOBAction = (((provisioningCapabilities[11] & 0xff) << 8) | (provisioningCapabilities[12] & 0xff));
-        ParseInputOOBActions.parseInputActionsFromBitMask(inputOOBAction);
-
-
-        return true;
+    void setInputOOBAction(final short inputOOBAction) {
+        this.inputOOBAction = inputOOBAction;
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningCapabilitiesState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningCapabilitiesState.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2018, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.android.meshprovisioner.states;
+
+import android.util.Log;
+
+import no.nordicsemi.android.meshprovisioner.MeshProvisioningStatusCallbacks;
+import no.nordicsemi.android.meshprovisioner.utils.AlgorithmInformationParser;
+import no.nordicsemi.android.meshprovisioner.utils.ParseInputOOBActions;
+import no.nordicsemi.android.meshprovisioner.utils.ParseOutputOOBActions;
+import no.nordicsemi.android.meshprovisioner.utils.ParsePublicKeyInformation;
+import no.nordicsemi.android.meshprovisioner.utils.ParseStaticOutputOOBInformation;
+
+public class ProvisioningCapabilitiesState extends ProvisioningState {
+    private static final String TAG = ProvisioningInviteState.class.getSimpleName();
+
+    private final UnprovisionedMeshNode mUnprovisionedMeshNode;
+    private final MeshProvisioningStatusCallbacks mCallbacks;
+
+    private ProvisioningCapabilities capabilities;
+
+    public ProvisioningCapabilitiesState(final UnprovisionedMeshNode unprovisionedMeshNode, final MeshProvisioningStatusCallbacks callbacks) {
+        super();
+        this.mCallbacks = callbacks;
+        this.mUnprovisionedMeshNode = unprovisionedMeshNode;
+    }
+
+    @Override
+    public State getState() {
+        return State.PROVISIONING_CAPABILITIES;
+    }
+
+    public ProvisioningCapabilities getCapabilities() {
+        return capabilities;
+    }
+
+    @Override
+    public void executeSend() {
+
+    }
+
+    @Override
+    public boolean parseData(final byte[] data) {
+        final boolean flag = parseProvisioningCapabilities(data);
+        mUnprovisionedMeshNode.setProvisioningCapabilities(capabilities);
+        mCallbacks.onProvisioningCapabilitiesReceived(mUnprovisionedMeshNode);
+        return flag;
+    }
+
+    private boolean parseProvisioningCapabilities(final byte[] provisioningCapabilities) {
+
+        final ProvisioningCapabilities capabilities = new ProvisioningCapabilities();
+        capabilities.setRawCapabilities(provisioningCapabilities);
+
+        if (provisioningCapabilities[2] == 0) {
+            throw new IllegalArgumentException("Number of elements cannot be zero");
+        }
+
+        final byte numberOfElements = (provisioningCapabilities[2]);
+        Log.v(TAG, "Number of elements: " + numberOfElements);
+        capabilities.setNumberOfElements(numberOfElements);
+
+        final short algorithm = (short) (((provisioningCapabilities[3] & 0xff) << 8) | (provisioningCapabilities[4] & 0xff));
+        Log.v(TAG, "Algorithm: " + AlgorithmInformationParser.parseAlgorithm(algorithm));
+        capabilities.setSupportedAlgorithm(algorithm);
+
+        final byte publicKeyType = (provisioningCapabilities[5]); // 0 is unavailable and 1 is available
+        Log.v(TAG, "Public key type: " + ParsePublicKeyInformation.parsePublicKeyInformation(publicKeyType));
+        capabilities.setPublicKeyType(publicKeyType);
+
+        final byte staticOOBType = (provisioningCapabilities[6]); // 0 is unavailable and 1 is available
+        Log.v(TAG, "Static OOB type: " + ParseStaticOutputOOBInformation.parseStaticOOBActionInformation(staticOOBType));
+        capabilities.setStaticOOBType(staticOOBType);
+
+        final byte outputOOBSize = (provisioningCapabilities[7]);
+        Log.v(TAG, "Output OOB size: " + outputOOBSize);
+        capabilities.setOutputOOBSize(outputOOBSize);
+
+        final short outputOOBAction = (short) (((provisioningCapabilities[8] & 0xff) << 8) | (provisioningCapabilities[9] & 0xff));
+        ParseOutputOOBActions.parseOutputActionsFromBitMask(outputOOBAction);
+        capabilities.setOutputOOBAction(outputOOBAction);
+
+        final byte inputOOBSize = (provisioningCapabilities[10]);
+        Log.v(TAG, "Input OOB size: " + inputOOBSize);
+        capabilities.setInputOOBSize(inputOOBSize);
+
+        final short inputOOBAction = (short) (((provisioningCapabilities[11] & 0xff) << 8) | (provisioningCapabilities[12] & 0xff));
+        ParseInputOOBActions.parseInputActionsFromBitMask(inputOOBAction);
+        capabilities.setInputOOBAction(inputOOBAction);
+        this.capabilities = capabilities;
+
+        return true;
+    }
+}

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningCompleteState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningCompleteState.java
@@ -22,45 +22,30 @@
 
 package no.nordicsemi.android.meshprovisioner.states;
 
-import no.nordicsemi.android.meshprovisioner.InternalTransportCallbacks;
-import no.nordicsemi.android.meshprovisioner.MeshManagerApi;
-import no.nordicsemi.android.meshprovisioner.MeshProvisioningStatusCallbacks;
+public class ProvisioningCompleteState extends ProvisioningState {
 
-public class ProvisioningInputComplete extends ProvisioningState {
+    private final UnprovisionedMeshNode unprovisionedMeshNode;
 
-    private final UnprovisionedMeshNode mUnprovisionedMeshNode;
-    private final InternalTransportCallbacks mInternalTransportCallbacks;
-    private final MeshProvisioningStatusCallbacks mMeshProvisioningStatusCallbacks;
-
-
-    public ProvisioningInputComplete(final UnprovisionedMeshNode unprovisionedMeshNode, final InternalTransportCallbacks mInternalTransportCallbacks, final MeshProvisioningStatusCallbacks meshProvisioningStatusCallbacks) {
+    public ProvisioningCompleteState(final UnprovisionedMeshNode unprovisionedMeshNode) {
         super();
-        this.mUnprovisionedMeshNode = unprovisionedMeshNode;
-        this.mInternalTransportCallbacks = mInternalTransportCallbacks;
-        this.mMeshProvisioningStatusCallbacks = meshProvisioningStatusCallbacks;
+        this.unprovisionedMeshNode = unprovisionedMeshNode;
+        unprovisionedMeshNode.setIsProvisioned(true);
+        unprovisionedMeshNode.setProvisionedTime(System.currentTimeMillis());
     }
 
     @Override
     public State getState() {
-        return State.PROVISINING_INPUT_COMPLETE;
+        return State.PROVISINING_COMPLETE;
     }
 
     @Override
     public void executeSend() {
-        mMeshProvisioningStatusCallbacks.onProvisioningInputCompleteSent(mUnprovisionedMeshNode);
-        mInternalTransportCallbacks.sendPdu(mUnprovisionedMeshNode, createProvisioningInputComplete());
+
     }
 
     @Override
     public boolean parseData(final byte[] data) {
         return true;
-    }
-
-    private byte[] createProvisioningInputComplete() {
-        final byte[] provisioningPDU = new byte[2];
-        provisioningPDU[0] = MeshManagerApi.PDU_TYPE_PROVISIONING;
-        provisioningPDU[1] = TYPE_PROVISIONING_INPUT_COMPLETE;
-        return provisioningPDU;
     }
 
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningConfirmationState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningConfirmationState.java
@@ -22,10 +22,11 @@
 
 package no.nordicsemi.android.meshprovisioner.states;
 
+import android.text.TextUtils;
 import android.util.Log;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
+import java.nio.charset.Charset;
 
 import no.nordicsemi.android.meshprovisioner.InternalTransportCallbacks;
 import no.nordicsemi.android.meshprovisioner.MeshManagerApi;
@@ -34,15 +35,17 @@ import no.nordicsemi.android.meshprovisioner.MeshProvisioningStatusCallbacks;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
 
-public class ProvisioningRandomConfirmation extends ProvisioningState {
+public class ProvisioningConfirmationState extends ProvisioningState {
 
-    private final String TAG = ProvisioningRandomConfirmation.class.getSimpleName();
+    private final String TAG = ProvisioningConfirmationState.class.getSimpleName();
+
+    private final MeshProvisioningHandler pduHandler;
     private final UnprovisionedMeshNode mUnprovisionedMeshNode;
     private final MeshProvisioningStatusCallbacks mMeshProvisioningStatusCallbacks;
-    private final MeshProvisioningHandler pduHandler;
     private final InternalTransportCallbacks mInternalTransportCallbacks;
+    private String pin;
 
-    public ProvisioningRandomConfirmation(final MeshProvisioningHandler pduHandler, final UnprovisionedMeshNode unprovisionedMeshNode, final InternalTransportCallbacks mInternalTransportCallbacks, final MeshProvisioningStatusCallbacks meshProvisioningStatusCallbacks) {
+    public ProvisioningConfirmationState(final MeshProvisioningHandler pduHandler, final UnprovisionedMeshNode unprovisionedMeshNode, final InternalTransportCallbacks mInternalTransportCallbacks, final MeshProvisioningStatusCallbacks meshProvisioningStatusCallbacks) {
         super();
         this.pduHandler = pduHandler;
         this.mUnprovisionedMeshNode = unprovisionedMeshNode;
@@ -50,37 +53,36 @@ public class ProvisioningRandomConfirmation extends ProvisioningState {
         this.mMeshProvisioningStatusCallbacks = meshProvisioningStatusCallbacks;
     }
 
+    public void setPin(final String pin) {
+        this.pin = pin;
+    }
+
     @Override
     public State getState() {
-        return State.PROVISINING_RANDOM;
+        return State.PROVISIONING_CONFIRMATION;
     }
 
     @Override
     public void executeSend() {
-        final byte[] provisionerRandomConfirmationPDU = createProvisionerRandomPDU();
-        mMeshProvisioningStatusCallbacks.onProvisioningRandomSent(mUnprovisionedMeshNode);
-        mInternalTransportCallbacks.sendPdu(mUnprovisionedMeshNode, provisionerRandomConfirmationPDU);
+
+        final byte[] provisioningConfirmationPDU;
+        if (!TextUtils.isEmpty(pin)) {
+            provisioningConfirmationPDU = createProvisioningConfirmation(pin.getBytes());
+        } else {
+            provisioningConfirmationPDU = createProvisioningConfirmation(null);
+        }
+        mMeshProvisioningStatusCallbacks.onProvisioningConfirmationSent(mUnprovisionedMeshNode);
+        mInternalTransportCallbacks.sendPdu(mUnprovisionedMeshNode, provisioningConfirmationPDU);
     }
 
     @Override
     public boolean parseData(final byte[] data) {
-        mMeshProvisioningStatusCallbacks.onProvisioningRandomReceived(mUnprovisionedMeshNode);
-        parseProvisioneeRandom(data);
-        return provisioneeMatches();
+        mMeshProvisioningStatusCallbacks.onProvisioningConfirmationReceived(mUnprovisionedMeshNode);
+        parseProvisioneeConfirmation(data);
+        return true;
     }
 
-    private byte[] createProvisionerRandomPDU() {
-        final byte[] provisionerRandom = mUnprovisionedMeshNode.getProvisionerRandom();
-        final ByteBuffer buffer = ByteBuffer.allocate(provisionerRandom.length + 2);
-        buffer.put(new byte[]{MeshManagerApi.PDU_TYPE_PROVISIONING, TYPE_PROVISIONING_RANDOM_CONFIRMATION});
-        buffer.put(provisionerRandom);
-        final byte[] data = buffer.array();
-        Log.v(TAG, "Provisioner random PDU: " + MeshParserUtils.bytesToHex(data, false));
-        return data;
-    }
-
-    private boolean provisioneeMatches() {
-        final byte[] provisioneeRandom = mUnprovisionedMeshNode.getProvisioneeRandom();
+    private byte[] createProvisioningConfirmation(final byte[] userInput) {
 
         final byte[] confirmationInputs = pduHandler.generateConfirmationInputs();
         Log.v(TAG, "Confirmation inputs: " + MeshParserUtils.bytesToHex(confirmationInputs, false));
@@ -95,28 +97,45 @@ public class ProvisioningRandomConfirmation extends ProvisioningState {
         final byte[] confirmationKey = SecureUtils.calculateK1(ecdhSecret, confirmationSalt, SecureUtils.PRCK);
         Log.v(TAG, "Confirmation key: " + MeshParserUtils.bytesToHex(confirmationKey, false));
 
+        //Generate provisioner random number
+        final byte[] provisionerRandom = SecureUtils.generateRandomNumber();
+        mUnprovisionedMeshNode.setProvisionerRandom(provisionerRandom);
+        Log.v(TAG, "Provisioner random: " + MeshParserUtils.bytesToHex(provisionerRandom, false));
+
         //Generate authentication value from the user input pin
-        final byte[] authenticationValue = mUnprovisionedMeshNode.getAuthenticationValue();
+        final byte[] authenticationValue = generateAuthenticationValue(userInput);
+        mUnprovisionedMeshNode.setAuthenticationValue(authenticationValue);
         Log.v(TAG, "Authentication value: " + MeshParserUtils.bytesToHex(authenticationValue, false));
 
-        ByteBuffer buffer = ByteBuffer.allocate(provisioneeRandom.length + authenticationValue.length);
-        buffer.put(provisioneeRandom);
+        ByteBuffer buffer = ByteBuffer.allocate(provisionerRandom.length + authenticationValue.length);
+        buffer.put(provisionerRandom);
         buffer.put(authenticationValue);
         final byte[] confirmationData = buffer.array();
 
         final byte[] confirmationValue = SecureUtils.calculateCMAC(confirmationData, confirmationKey);
 
-        if (Arrays.equals(confirmationValue, mUnprovisionedMeshNode.getProvisioneeConfirmation())) {
-            Log.v(TAG, "Confirmation values match!!!!: " + MeshParserUtils.bytesToHex(confirmationValue, false));
-            return true;
-        }
+        buffer = ByteBuffer.allocate(confirmationValue.length + 2);
+        buffer.put(new byte[]{MeshManagerApi.PDU_TYPE_PROVISIONING, TYPE_PROVISIONING_CONFIRMATION});
+        buffer.put(confirmationValue);
+        final byte[] provisioningConfirmationPDU = buffer.array();
+        Log.v(TAG, "Provisioning confirmation: " + MeshParserUtils.bytesToHex(provisioningConfirmationPDU, false));
 
-        return false;
+        return provisioningConfirmationPDU;
     }
 
-    private void parseProvisioneeRandom(final byte[] provisioneeRandomPDU) {
-        final ByteBuffer buffer = ByteBuffer.allocate(provisioneeRandomPDU.length - 2);
-        buffer.put(provisioneeRandomPDU, 2, buffer.limit());
-        mUnprovisionedMeshNode.setProvisioneeRandom(buffer.array());
+    private byte[] generateAuthenticationValue(final byte[] pin) {
+        ByteBuffer buffer = ByteBuffer.allocate(16);
+        if (pin != null) {
+            final Integer authValue = Integer.valueOf(new String(pin, Charset.forName("UTF-8")));
+            buffer.position(12);
+            buffer.putInt(authValue);
+        }
+        return buffer.array();
+    }
+
+    private void parseProvisioneeConfirmation(final byte[] provisioneeConfirmation) {
+        final ByteBuffer buffer = ByteBuffer.allocate(provisioneeConfirmation.length - 2);
+        buffer.put(provisioneeConfirmation, 2, buffer.limit());
+        mUnprovisionedMeshNode.setProvisioneeConfirmation(buffer.array());
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningConfirmationState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningConfirmationState.java
@@ -84,7 +84,7 @@ public class ProvisioningConfirmationState extends ProvisioningState {
 
     private byte[] createProvisioningConfirmation(final byte[] userInput) {
 
-        final byte[] confirmationInputs = pduHandler.generateConfirmationInputs();
+        final byte[] confirmationInputs = pduHandler.generateConfirmationInputs(mUnprovisionedMeshNode.getProvisionerPublicKeyXY(), mUnprovisionedMeshNode.getProvisioneePublicKeyXY());
         Log.v(TAG, "Confirmation inputs: " + MeshParserUtils.bytesToHex(confirmationInputs, false));
 
         //Generate a confirmation salt of the confirmation inputs

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningDataState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningDataState.java
@@ -33,15 +33,15 @@ import no.nordicsemi.android.meshprovisioner.MeshProvisioningStatusCallbacks;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
 
-public class ProvisioningData extends ProvisioningState {
+public class ProvisioningDataState extends ProvisioningState {
 
-    private final String TAG = ProvisioningRandomConfirmation.class.getSimpleName();
+    private final String TAG = ProvisioningRandomConfirmationState.class.getSimpleName();
     private final UnprovisionedMeshNode mUnprovisionedMeshNode;
     private final MeshProvisioningStatusCallbacks mMeshProvisioningStatusCallbacks;
     private final MeshProvisioningHandler pduHandler;
     private final InternalTransportCallbacks mInternalTransportCallbacks;
 
-    public ProvisioningData(final MeshProvisioningHandler pduHandler, final UnprovisionedMeshNode unprovisionedMeshNode, final InternalTransportCallbacks mInternalTransportCallbacks, final MeshProvisioningStatusCallbacks meshProvisioningStatusCallbacks) {
+    public ProvisioningDataState(final MeshProvisioningHandler pduHandler, final UnprovisionedMeshNode unprovisionedMeshNode, final InternalTransportCallbacks mInternalTransportCallbacks, final MeshProvisioningStatusCallbacks meshProvisioningStatusCallbacks) {
         super();
         this.pduHandler = pduHandler;
         this.mUnprovisionedMeshNode = unprovisionedMeshNode;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningDataState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningDataState.java
@@ -142,7 +142,7 @@ public class ProvisioningDataState extends ProvisioningState {
      */
     private byte[] generateProvisioningSalt() {
 
-        final byte[] confirmationSalt = SecureUtils.calculateSalt(pduHandler.generateConfirmationInputs());
+        final byte[] confirmationSalt = SecureUtils.calculateSalt(pduHandler.generateConfirmationInputs(mUnprovisionedMeshNode.getProvisionerPublicKeyXY(), mUnprovisionedMeshNode.getProvisioneePublicKeyXY()));
         final byte[] provisionerRandom = mUnprovisionedMeshNode.getProvisionerRandom();
         final byte[] provisioneeRandom = mUnprovisionedMeshNode.getProvisioneeRandom();
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningFailedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningFailedState.java
@@ -26,11 +26,13 @@ import android.content.Context;
 
 import no.nordicsemi.android.meshprovisioner.R;
 
-public class ProvisioningFailed extends ProvisioningState {
+public class ProvisioningFailedState extends ProvisioningState {
 
     private final Context mContext;
     private final UnprovisionedMeshNode mUnprovisionedMeshNode;
-    public ProvisioningFailed(final Context context, final UnprovisionedMeshNode unprovisionedMeshNode) {
+    private int error;
+
+    public ProvisioningFailedState(final Context context, final UnprovisionedMeshNode unprovisionedMeshNode) {
         super();
         this.mContext = context;
         this.mUnprovisionedMeshNode = unprovisionedMeshNode;
@@ -48,9 +50,13 @@ public class ProvisioningFailed extends ProvisioningState {
 
     @Override
     public boolean parseData(final byte[] data) {
-        final int errorCode = data[2];
-        error = parseProvisioningFailure(mContext, errorCode);
+        error = data[2];
+
         return true;
+    }
+
+    public int getErrorCode() {
+        return error;
     }
 
     public static String parseProvisioningFailure(final Context context, final int errorCode) {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningInputCompleteState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningInputCompleteState.java
@@ -26,32 +26,29 @@ import no.nordicsemi.android.meshprovisioner.InternalTransportCallbacks;
 import no.nordicsemi.android.meshprovisioner.MeshManagerApi;
 import no.nordicsemi.android.meshprovisioner.MeshProvisioningStatusCallbacks;
 
-public class ProvisioningInvite extends ProvisioningState {
+public class ProvisioningInputCompleteState extends ProvisioningState {
 
-    private final String TAG = ProvisioningInvite.class.getSimpleName();
     private final UnprovisionedMeshNode mUnprovisionedMeshNode;
-    private final int attentionTimer;
-    private final MeshProvisioningStatusCallbacks mMeshProvisioningStatusCallbacks;
     private final InternalTransportCallbacks mInternalTransportCallbacks;
+    private final MeshProvisioningStatusCallbacks mMeshProvisioningStatusCallbacks;
 
-    public ProvisioningInvite(final UnprovisionedMeshNode unprovisionedMeshNode, final int attentionTimer, final InternalTransportCallbacks mInternalTransportCallbacks, final MeshProvisioningStatusCallbacks meshProvisioningStatusCallbacks) {
+
+    public ProvisioningInputCompleteState(final UnprovisionedMeshNode unprovisionedMeshNode, final InternalTransportCallbacks mInternalTransportCallbacks, final MeshProvisioningStatusCallbacks meshProvisioningStatusCallbacks) {
         super();
         this.mUnprovisionedMeshNode = unprovisionedMeshNode;
-        this.attentionTimer = attentionTimer;
-        this.mMeshProvisioningStatusCallbacks = meshProvisioningStatusCallbacks;
         this.mInternalTransportCallbacks = mInternalTransportCallbacks;
+        this.mMeshProvisioningStatusCallbacks = meshProvisioningStatusCallbacks;
     }
 
     @Override
     public State getState() {
-        return State.PROVISIONING_INVITE;
+        return State.PROVISINING_INPUT_COMPLETE;
     }
 
     @Override
     public void executeSend() {
-        final byte[] invitePDU = createInvitePDU();
-        mMeshProvisioningStatusCallbacks.onProvisioningInviteSent(mUnprovisionedMeshNode);
-        mInternalTransportCallbacks.sendPdu(mUnprovisionedMeshNode, invitePDU);
+        mMeshProvisioningStatusCallbacks.onProvisioningInputCompleteSent(mUnprovisionedMeshNode);
+        mInternalTransportCallbacks.sendPdu(mUnprovisionedMeshNode, createProvisioningInputComplete());
     }
 
     @Override
@@ -59,15 +56,11 @@ public class ProvisioningInvite extends ProvisioningState {
         return true;
     }
 
-    /**
-     * Generates the invitePDU for provisioning based on the attention timer provided by the user.
-     */
-    private byte[] createInvitePDU() {
-
-        final byte[] data = new byte[3];
-        data[0] = MeshManagerApi.PDU_TYPE_PROVISIONING; //Provisioning Opcode;
-        data[1] = TYPE_PROVISIONING_INVITE; //PDU type in
-        data[2] = (byte) attentionTimer;
-        return data;
+    private byte[] createProvisioningInputComplete() {
+        final byte[] provisioningPDU = new byte[2];
+        provisioningPDU[0] = MeshManagerApi.PDU_TYPE_PROVISIONING;
+        provisioningPDU[1] = TYPE_PROVISIONING_INPUT_COMPLETE;
+        return provisioningPDU;
     }
+
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningInviteState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningInviteState.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2018, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.android.meshprovisioner.states;
+
+import no.nordicsemi.android.meshprovisioner.InternalTransportCallbacks;
+import no.nordicsemi.android.meshprovisioner.MeshManagerApi;
+import no.nordicsemi.android.meshprovisioner.MeshProvisioningStatusCallbacks;
+
+public class ProvisioningInviteState extends ProvisioningState {
+
+    private final String TAG = ProvisioningInviteState.class.getSimpleName();
+    private final UnprovisionedMeshNode mUnprovisionedMeshNode;
+    private final int attentionTimer;
+    private final MeshProvisioningStatusCallbacks mMeshProvisioningStatusCallbacks;
+    private final InternalTransportCallbacks mInternalTransportCallbacks;
+
+    public ProvisioningInviteState(final UnprovisionedMeshNode unprovisionedMeshNode, final int attentionTimer, final InternalTransportCallbacks mInternalTransportCallbacks, final MeshProvisioningStatusCallbacks meshProvisioningStatusCallbacks) {
+        super();
+        this.mUnprovisionedMeshNode = unprovisionedMeshNode;
+        this.attentionTimer = attentionTimer;
+        this.mMeshProvisioningStatusCallbacks = meshProvisioningStatusCallbacks;
+        this.mInternalTransportCallbacks = mInternalTransportCallbacks;
+    }
+
+    @Override
+    public State getState() {
+        return State.PROVISIONING_INVITE;
+    }
+
+    @Override
+    public void executeSend() {
+        final byte[] invitePDU = createInvitePDU();
+        mMeshProvisioningStatusCallbacks.onProvisioningInviteSent(mUnprovisionedMeshNode);
+        mInternalTransportCallbacks.sendPdu(mUnprovisionedMeshNode, invitePDU);
+    }
+
+    @Override
+    public boolean parseData(final byte[] data) {
+        return true;
+    }
+
+    /**
+     * Generates the invitePDU for provisioning based on the attention timer provided by the user.
+     */
+    private byte[] createInvitePDU() {
+
+        final byte[] data = new byte[3];
+        data[0] = MeshManagerApi.PDU_TYPE_PROVISIONING; //Provisioning Opcode;
+        data[1] = TYPE_PROVISIONING_INVITE; //PDU type in
+        data[2] = (byte) attentionTimer;
+        return data;
+    }
+}

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningPublicKeyState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningPublicKeyState.java
@@ -53,10 +53,10 @@ import no.nordicsemi.android.meshprovisioner.MeshManagerApi;
 import no.nordicsemi.android.meshprovisioner.MeshProvisioningStatusCallbacks;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 
-public class ProvisioningPublicKey extends ProvisioningState {
+public class ProvisioningPublicKeyState extends ProvisioningState {
 
     private static final int PROVISIONING_PUBLIC_KEY_XY_PDU_LENGTH = 69;
-    private final String TAG = ProvisioningPublicKey.class.getSimpleName();
+    private final String TAG = ProvisioningPublicKeyState.class.getSimpleName();
     private final byte[] publicKeyXY = new byte[PROVISIONING_PUBLIC_KEY_XY_PDU_LENGTH];
     private final MeshProvisioningStatusCallbacks mMeshProvisioningStatusCallbacks;
     private final UnprovisionedMeshNode mUnprovisionedMeshNode;
@@ -67,7 +67,7 @@ public class ProvisioningPublicKey extends ProvisioningState {
     private ECPrivateKey mProvisionerPrivaetKey;
 
 
-    public ProvisioningPublicKey(final UnprovisionedMeshNode unprovisionedMeshNode, final InternalTransportCallbacks mInternalTransportCallbacks, final MeshProvisioningStatusCallbacks meshProvisioningStatusCallbacks) {
+    public ProvisioningPublicKeyState(final UnprovisionedMeshNode unprovisionedMeshNode, final InternalTransportCallbacks mInternalTransportCallbacks, final MeshProvisioningStatusCallbacks meshProvisioningStatusCallbacks) {
         super();
         this.mUnprovisionedMeshNode = unprovisionedMeshNode;
         this.mMeshProvisioningStatusCallbacks = meshProvisioningStatusCallbacks;
@@ -101,9 +101,8 @@ public class ProvisioningPublicKey extends ProvisioningState {
             keyPairGenerator.initialize(parameterSpec);
             final KeyPair keyPair = keyPairGenerator.generateKeyPair();
             final ECPublicKey publicKey = (ECPublicKey) keyPair.getPublic();
-            final ECPrivateKey privateKey = (ECPrivateKey) keyPair.getPrivate();
 
-            mProvisionerPrivaetKey = privateKey;
+            mProvisionerPrivaetKey = (ECPrivateKey) keyPair.getPrivate();
 
             final ECPoint point = publicKey.getQ();
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningRandomConfirmationState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningRandomConfirmationState.java
@@ -82,7 +82,7 @@ public class ProvisioningRandomConfirmationState extends ProvisioningState {
     private boolean provisioneeMatches() {
         final byte[] provisioneeRandom = mUnprovisionedMeshNode.getProvisioneeRandom();
 
-        final byte[] confirmationInputs = pduHandler.generateConfirmationInputs();
+        final byte[] confirmationInputs = pduHandler.generateConfirmationInputs(mUnprovisionedMeshNode.getProvisionerPublicKeyXY(), mUnprovisionedMeshNode.getProvisioneePublicKeyXY());
         Log.v(TAG, "Confirmation inputs: " + MeshParserUtils.bytesToHex(confirmationInputs, false));
 
         //Generate a confirmation salt of the confirmation inputs

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningRandomConfirmationState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningRandomConfirmationState.java
@@ -22,11 +22,10 @@
 
 package no.nordicsemi.android.meshprovisioner.states;
 
-import android.text.TextUtils;
 import android.util.Log;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.Charset;
+import java.util.Arrays;
 
 import no.nordicsemi.android.meshprovisioner.InternalTransportCallbacks;
 import no.nordicsemi.android.meshprovisioner.MeshManagerApi;
@@ -35,17 +34,15 @@ import no.nordicsemi.android.meshprovisioner.MeshProvisioningStatusCallbacks;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
 
-public class ProvisioningConfirmation extends ProvisioningState {
+public class ProvisioningRandomConfirmationState extends ProvisioningState {
 
-    private final String TAG = ProvisioningConfirmation.class.getSimpleName();
-
-    private final MeshProvisioningHandler pduHandler;
+    private final String TAG = ProvisioningRandomConfirmationState.class.getSimpleName();
     private final UnprovisionedMeshNode mUnprovisionedMeshNode;
     private final MeshProvisioningStatusCallbacks mMeshProvisioningStatusCallbacks;
+    private final MeshProvisioningHandler pduHandler;
     private final InternalTransportCallbacks mInternalTransportCallbacks;
-    private String pin;
 
-    public ProvisioningConfirmation(final MeshProvisioningHandler pduHandler, final UnprovisionedMeshNode unprovisionedMeshNode, final InternalTransportCallbacks mInternalTransportCallbacks, final MeshProvisioningStatusCallbacks meshProvisioningStatusCallbacks) {
+    public ProvisioningRandomConfirmationState(final MeshProvisioningHandler pduHandler, final UnprovisionedMeshNode unprovisionedMeshNode, final InternalTransportCallbacks mInternalTransportCallbacks, final MeshProvisioningStatusCallbacks meshProvisioningStatusCallbacks) {
         super();
         this.pduHandler = pduHandler;
         this.mUnprovisionedMeshNode = unprovisionedMeshNode;
@@ -53,36 +50,37 @@ public class ProvisioningConfirmation extends ProvisioningState {
         this.mMeshProvisioningStatusCallbacks = meshProvisioningStatusCallbacks;
     }
 
-    public void setPin(final String pin) {
-        this.pin = pin;
-    }
-
     @Override
     public State getState() {
-        return State.PROVISIONING_CONFIRMATION;
+        return State.PROVISINING_RANDOM;
     }
 
     @Override
     public void executeSend() {
-
-        final byte[] provisioningConfirmationPDU;
-        if (!TextUtils.isEmpty(pin)) {
-            provisioningConfirmationPDU = createProvisioningConfirmation(pin.getBytes());
-        } else {
-            provisioningConfirmationPDU = createProvisioningConfirmation(null);
-        }
-        mMeshProvisioningStatusCallbacks.onProvisioningConfirmationSent(mUnprovisionedMeshNode);
-        mInternalTransportCallbacks.sendPdu(mUnprovisionedMeshNode, provisioningConfirmationPDU);
+        final byte[] provisionerRandomConfirmationPDU = createProvisionerRandomPDU();
+        mMeshProvisioningStatusCallbacks.onProvisioningRandomSent(mUnprovisionedMeshNode);
+        mInternalTransportCallbacks.sendPdu(mUnprovisionedMeshNode, provisionerRandomConfirmationPDU);
     }
 
     @Override
     public boolean parseData(final byte[] data) {
-        mMeshProvisioningStatusCallbacks.onProvisioningConfirmationReceived(mUnprovisionedMeshNode);
-        parseProvisioneeConfirmation(data);
-        return true;
+        mMeshProvisioningStatusCallbacks.onProvisioningRandomReceived(mUnprovisionedMeshNode);
+        parseProvisioneeRandom(data);
+        return provisioneeMatches();
     }
 
-    private byte[] createProvisioningConfirmation(final byte[] userInput) {
+    private byte[] createProvisionerRandomPDU() {
+        final byte[] provisionerRandom = mUnprovisionedMeshNode.getProvisionerRandom();
+        final ByteBuffer buffer = ByteBuffer.allocate(provisionerRandom.length + 2);
+        buffer.put(new byte[]{MeshManagerApi.PDU_TYPE_PROVISIONING, TYPE_PROVISIONING_RANDOM_CONFIRMATION});
+        buffer.put(provisionerRandom);
+        final byte[] data = buffer.array();
+        Log.v(TAG, "Provisioner random PDU: " + MeshParserUtils.bytesToHex(data, false));
+        return data;
+    }
+
+    private boolean provisioneeMatches() {
+        final byte[] provisioneeRandom = mUnprovisionedMeshNode.getProvisioneeRandom();
 
         final byte[] confirmationInputs = pduHandler.generateConfirmationInputs();
         Log.v(TAG, "Confirmation inputs: " + MeshParserUtils.bytesToHex(confirmationInputs, false));
@@ -97,45 +95,28 @@ public class ProvisioningConfirmation extends ProvisioningState {
         final byte[] confirmationKey = SecureUtils.calculateK1(ecdhSecret, confirmationSalt, SecureUtils.PRCK);
         Log.v(TAG, "Confirmation key: " + MeshParserUtils.bytesToHex(confirmationKey, false));
 
-        //Generate provisioner random number
-        final byte[] provisionerRandom = SecureUtils.generateRandomNumber();
-        mUnprovisionedMeshNode.setProvisionerRandom(provisionerRandom);
-        Log.v(TAG, "Provisioner random: " + MeshParserUtils.bytesToHex(provisionerRandom, false));
-
         //Generate authentication value from the user input pin
-        final byte[] authenticationValue = generateAuthenticationValue(userInput);
-        mUnprovisionedMeshNode.setAuthenticationValue(authenticationValue);
+        final byte[] authenticationValue = mUnprovisionedMeshNode.getAuthenticationValue();
         Log.v(TAG, "Authentication value: " + MeshParserUtils.bytesToHex(authenticationValue, false));
 
-        ByteBuffer buffer = ByteBuffer.allocate(provisionerRandom.length + authenticationValue.length);
-        buffer.put(provisionerRandom);
+        ByteBuffer buffer = ByteBuffer.allocate(provisioneeRandom.length + authenticationValue.length);
+        buffer.put(provisioneeRandom);
         buffer.put(authenticationValue);
         final byte[] confirmationData = buffer.array();
 
         final byte[] confirmationValue = SecureUtils.calculateCMAC(confirmationData, confirmationKey);
 
-        buffer = ByteBuffer.allocate(confirmationValue.length + 2);
-        buffer.put(new byte[]{MeshManagerApi.PDU_TYPE_PROVISIONING, TYPE_PROVISIONING_CONFIRMATION});
-        buffer.put(confirmationValue);
-        final byte[] provisioningConfirmationPDU = buffer.array();
-        Log.v(TAG, "Provisioning confirmation: " + MeshParserUtils.bytesToHex(provisioningConfirmationPDU, false));
-
-        return provisioningConfirmationPDU;
-    }
-
-    private byte[] generateAuthenticationValue(final byte[] pin) {
-        ByteBuffer buffer = ByteBuffer.allocate(16);
-        if (pin != null) {
-            final Integer authValue = Integer.valueOf(new String(pin, Charset.forName("UTF-8")));
-            buffer.position(12);
-            buffer.putInt(authValue);
+        if (Arrays.equals(confirmationValue, mUnprovisionedMeshNode.getProvisioneeConfirmation())) {
+            Log.v(TAG, "Confirmation values match!!!!: " + MeshParserUtils.bytesToHex(confirmationValue, false));
+            return true;
         }
-        return buffer.array();
+
+        return false;
     }
 
-    private void parseProvisioneeConfirmation(final byte[] provisioneeConfirmation) {
-        final ByteBuffer buffer = ByteBuffer.allocate(provisioneeConfirmation.length - 2);
-        buffer.put(provisioneeConfirmation, 2, buffer.limit());
-        mUnprovisionedMeshNode.setProvisioneeConfirmation(buffer.array());
+    private void parseProvisioneeRandom(final byte[] provisioneeRandomPDU) {
+        final ByteBuffer buffer = ByteBuffer.allocate(provisioneeRandomPDU.length - 2);
+        buffer.put(provisioneeRandomPDU, 2, buffer.limit());
+        mUnprovisionedMeshNode.setProvisioneeRandom(buffer.array());
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningStartState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningStartState.java
@@ -31,9 +31,9 @@ import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 import no.nordicsemi.android.meshprovisioner.utils.ParseOutputOOBActions;
 import no.nordicsemi.android.meshprovisioner.utils.ParseProvisioningAlgorithm;
 
-public class ProvisioningStart extends ProvisioningState {
+public class ProvisioningStartState extends ProvisioningState {
 
-    private final String TAG = ProvisioningStart.class.getSimpleName();
+    private final String TAG = ProvisioningStartState.class.getSimpleName();
     private final UnprovisionedMeshNode mUnprovisionedMeshNode;
     private final MeshProvisioningStatusCallbacks mMeshProvisioningStatusCallbacks;
     private final InternalTransportCallbacks mInternalTransportCallbacks;
@@ -47,7 +47,7 @@ public class ProvisioningStart extends ProvisioningState {
     private int inputOOBSize;
     private int inputOOBAction;
 
-    public ProvisioningStart(final UnprovisionedMeshNode unprovisionedMeshNode, final InternalTransportCallbacks mInternalTransportCallbacks, final MeshProvisioningStatusCallbacks meshProvisioningStatusCallbacks) {
+    public ProvisioningStartState(final UnprovisionedMeshNode unprovisionedMeshNode, final InternalTransportCallbacks mInternalTransportCallbacks, final MeshProvisioningStatusCallbacks meshProvisioningStatusCallbacks) {
         super();
         this.mUnprovisionedMeshNode = unprovisionedMeshNode;
         this.mInternalTransportCallbacks = mInternalTransportCallbacks;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningStartState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningStartState.java
@@ -77,7 +77,7 @@ public class ProvisioningStartState extends ProvisioningState {
         provisioningPDU[1] = TYPE_PROVISIONING_START;
         provisioningPDU[2] = ParseProvisioningAlgorithm.getAlgorithmValue(algorithm);
         provisioningPDU[3] = 0;//(byte) publicKeyType;
-        final int outputOobActionType = (byte) ParseOutputOOBActions.selectOutputActionsFromBitMask(outputOOBAction);
+        final short outputOobActionType = (byte) ParseOutputOOBActions.selectOutputActionsFromBitMask(outputOOBAction);
         if(outputOobActionType == ParseOutputOOBActions.NO_OUTPUT){
             provisioningPDU[4] = 0;
             //prefer no oob

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/ProvisioningState.java
@@ -34,8 +34,6 @@ public abstract class ProvisioningState {
     static final byte TYPE_PROVISIONING_DATA = 0x07;
     static final byte TYPE_PROVISIONING_COMPLETE = 0x08;
 
-    protected String error;
-
     public ProvisioningState() {
     }
 
@@ -44,10 +42,6 @@ public abstract class ProvisioningState {
     public abstract void executeSend();
 
     public abstract boolean parseData(final byte[] data);
-
-    public String getError() {
-        return error;
-    }
 
     public enum State {
         PROVISIONING_INVITE(0), PROVISIONING_CAPABILITIES(1), PROVISIONING_START(2), PROVISIONING_PUBLIC_KEY(3),

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/UnprovisionedMeshNode.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/states/UnprovisionedMeshNode.java
@@ -54,6 +54,8 @@ public final class UnprovisionedMeshNode extends BaseMeshNode {
         unicastAddress = in.createByteArray();
         deviceKey = in.createByteArray();
         ttl = in.readInt();
+        provisioningCapabilities = in.readParcelable(ProvisioningCapabilities.class.getClassLoader());
+        numberOfElements = provisioningCapabilities.getNumberOfElements();
     }
 
     @Override
@@ -76,6 +78,7 @@ public final class UnprovisionedMeshNode extends BaseMeshNode {
         dest.writeByteArray(unicastAddress);
         dest.writeByteArray(deviceKey);
         dest.writeInt(ttl);
+        dest.writeParcelable(provisioningCapabilities, flags);
     }
 
 
@@ -166,5 +169,10 @@ public final class UnprovisionedMeshNode extends BaseMeshNode {
 
     public final void setProvisionedTime(final long timeStampInMillis) {
         mTimeStampInMillis = timeStampInMillis;
+    }
+
+    protected void setProvisioningCapabilities(final ProvisioningCapabilities provisioningCapabilities) {
+        numberOfElements = provisioningCapabilities.getNumberOfElements();
+        this.provisioningCapabilities = provisioningCapabilities;
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/AlgorithmInformationParser.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/AlgorithmInformationParser.java
@@ -20,32 +20,20 @@
  * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package no.nordicsemi.android.meshprovisioner.states;
+package no.nordicsemi.android.meshprovisioner.utils;
 
-public class ProvisioningComplete extends ProvisioningState {
+public class AlgorithmInformationParser {
 
-    private final UnprovisionedMeshNode unprovisionedMeshNode;
+    private static final short NONE = 0x0000;
+    private static final short FIPS_P_256_ELLIPTIC_CURVE = 0x0001;
 
-    public ProvisioningComplete(final UnprovisionedMeshNode unprovisionedMeshNode) {
-        super();
-        this.unprovisionedMeshNode = unprovisionedMeshNode;
-        unprovisionedMeshNode.setIsProvisioned(true);
-        unprovisionedMeshNode.setProvisionedTime(System.currentTimeMillis());
+    public static String parseAlgorithm(final short type) {
+        switch (type) {
+            case FIPS_P_256_ELLIPTIC_CURVE:
+                return "FIPS P-256 Elliptic Curve";
+            case NONE:
+            default:
+                return "Unknown";
+        }
     }
-
-    @Override
-    public State getState() {
-        return State.PROVISINING_COMPLETE;
-    }
-
-    @Override
-    public void executeSend() {
-
-    }
-
-    @Override
-    public boolean parseData(final byte[] data) {
-        return true;
-    }
-
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/ParseInputOOBActions.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/ParseInputOOBActions.java
@@ -27,11 +27,11 @@ import android.util.Log;
 public class ParseInputOOBActions {
     private static final String TAG = ParseInputOOBActions.class.getSimpleName();
 
-    private static final int NO_INPUT = 0x00;
-    private static final int PUSH = 0x01;
-    private static final int TWIST = 0x02;
-    private static final int INPUT_NUMBER = 0x04;
-    private static final int INPUT_ALPHA_NUMBERIC = 0x08;
+    private static final short NO_INPUT = 0x0000;
+    private static final short PUSH = 0x0001;
+    private static final short TWIST = 0x0002;
+    private static final short INPUT_NUMBER = 0x0004;
+    private static final short INPUT_ALPHA_NUMBERIC = 0x0008;
 
     /**
      * Returns the Input OOB Action description
@@ -39,18 +39,18 @@ public class ParseInputOOBActions {
      * @param type Input OOB type
      * @return Input OOB type descrption
      */
-    public static String getInputOOBActionDescription(final int type) {
+    public static String getInputOOBActionDescription(final short type) {
         switch (type) {
             case NO_INPUT:
-                return "No Input";
+                return "Not supported";
             case PUSH:
                 return "Push";
             case TWIST:
                 return "Twist";
             case INPUT_NUMBER:
-                return "Input number";
+                return "Input Number";
             case INPUT_ALPHA_NUMBERIC:
-                return "Input alpha numeric";
+                return "Input Alpha Numeric";
             default:
                 return "Unknown";
         }
@@ -94,7 +94,7 @@ public class ParseInputOOBActions {
      * @param type input OOB type
      * @return Output OOB type description
      */
-    public static int getOuputOOBActionValue(final int type) {
+    public static int getOuputOOBActionValue(final short type) {
         switch (type) {
             case PUSH:
                 return 0;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/ParseOutputOOBActions.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/ParseOutputOOBActions.java
@@ -32,12 +32,12 @@ public class ParseOutputOOBActions {
     /**
      * Input OOB Actions
      */
-    public static final int NO_OUTPUT = 0x0000;
-    private static final int BLINK = 0x0001;
-    private static final int BEEP = 0x0002;
-    private static final int VIBRATE = 0x0004;
-    private static final int OUTPUT_NUMERIC = 0x0008;
-    private static final int OUTPUT_ALPHA_NUMERIC = 0x0010;
+    public static final short NO_OUTPUT = 0x0000;
+    private static final short BLINK = 0x0001;
+    private static final short BEEP = 0x0002;
+    private static final short VIBRATE = 0x0004;
+    private static final short OUTPUT_NUMERIC = 0x0008;
+    private static final short OUTPUT_ALPHA_NUMERIC = 0x0010;
 
     /**
      * Returns the Output OOB Action description
@@ -45,10 +45,10 @@ public class ParseOutputOOBActions {
      * @param type Output OOB type
      * @return Input OOB type descrption
      */
-    public static String getOuputOOBActionDescription(final int type) {
+    public static String getOuputOOBActionDescription(final short type) {
         switch (type) {
             case NO_OUTPUT:
-                return "No Input";
+                return "Not Supported";
             case BLINK:
                 return "Blink";
             case BEEP:
@@ -56,9 +56,9 @@ public class ParseOutputOOBActions {
             case VIBRATE:
                 return "Vibrate";
             case OUTPUT_NUMERIC:
-                return "Output numeric";
+                return "Output Numeric";
             case OUTPUT_ALPHA_NUMERIC:
-                return "Output alpha numeric";
+                return "Output Alpha Numeric";
             default:
                 return "Unknown";
         }
@@ -112,7 +112,7 @@ public class ParseOutputOOBActions {
      * @param outputAction type of output action
      * @return selected output action type
      */
-    public static int selectOutputActionsFromBitMask(final int outputAction) {
+    public static short selectOutputActionsFromBitMask(final int outputAction) {
         final byte[] outputActions = {BLINK, BEEP, VIBRATE, OUTPUT_NUMERIC, OUTPUT_ALPHA_NUMERIC};
         final ArrayList<Byte> suppportedActionValues = new ArrayList<>();
         for(byte action : outputActions){
@@ -135,7 +135,7 @@ public class ParseOutputOOBActions {
      * @param type output OOB type
      * @return Output OOB type descrption
      */
-    public static int getOuputOOBActionValue(final int type) {
+    public static int getOuputOOBActionValue(final short type) {
         switch (type) {
             case BLINK:
                 return 0;


### PR DESCRIPTION
Provisioning a node now has to be done in a two step process. First by calling identifyNode and then calling startProvisioning
