### PR TITLE
Feature/add generic api support for vendor models #48

### DIFF
--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ModelConfigurationActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ModelConfigurationActivity.java
@@ -22,17 +22,25 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner;
 
+import android.arch.lifecycle.Observer;
 import android.arch.lifecycle.ViewModelProvider;
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.annotation.Nullable;
+import android.support.design.widget.TextInputEditText;
+import android.support.design.widget.TextInputLayout;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.Toolbar;
 import android.support.v7.widget.helper.ItemTouchHelper;
+import android.text.Editable;
+import android.text.TextUtils;
+import android.text.TextWatcher;
+import android.text.method.KeyListener;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
@@ -45,6 +53,7 @@ import android.widget.Toast;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import javax.inject.Inject;
 
@@ -63,6 +72,8 @@ import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentConfigurati
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentPublishAddress;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentSubscriptionAddress;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentTransactionStatus;
+import no.nordicsemi.android.nrfmeshprovisioner.utils.HexKeyListener;
+import no.nordicsemi.android.nrfmeshprovisioner.utils.Utils;
 import no.nordicsemi.android.nrfmeshprovisioner.viewmodels.ModelConfigurationViewModel;
 import no.nordicsemi.android.nrfmeshprovisioner.widgets.ItemTouchHelperAdapter;
 import no.nordicsemi.android.nrfmeshprovisioner.widgets.RemovableItemTouchHelperCallback;
@@ -512,8 +523,90 @@ public class ModelConfigurationActivity extends AppCompatActivity implements Inj
             } else {
                 final CardView cardView = findViewById(R.id.node_controls_card);
                 final View nodeControlsContainer = LayoutInflater.from(this).inflate(R.layout.layout_vendor_model_controls, cardView);
+                final TextInputLayout opCodeLayout = nodeControlsContainer.findViewById(R.id.op_code_layout);
+                final TextInputEditText opCodeEditText = nodeControlsContainer.findViewById(R.id.op_code);
+
+                final KeyListener hexKeyListener = new HexKeyListener();
+
+                final TextInputLayout parametersLayout = nodeControlsContainer.findViewById(R.id.parameters_layout);
+                final TextInputEditText parametersEditText = nodeControlsContainer.findViewById(R.id.parameters);
+                final TextView receivedMessage = nodeControlsContainer.findViewById(R.id.received_message);
+                final Button actionSend = nodeControlsContainer.findViewById(R.id.action_send);
+
+                opCodeEditText.setKeyListener(hexKeyListener);
+                opCodeEditText.addTextChangedListener(new TextWatcher() {
+                    @Override
+                    public void beforeTextChanged(final CharSequence s, final int start, final int count, final int after) {
+
+                    }
+
+                    @Override
+                    public void onTextChanged(final CharSequence s, final int start, final int before, final int count) {
+                        opCodeLayout.setError(null);
+                    }
+
+                    @Override
+                    public void afterTextChanged(final Editable s) {
+
+                    }
+                });
+
+                parametersEditText.setKeyListener(hexKeyListener);
+                parametersEditText.addTextChangedListener(new TextWatcher() {
+                    @Override
+                    public void beforeTextChanged(final CharSequence s, final int start, final int count, final int after) {
+
+                    }
+
+                    @Override
+                    public void onTextChanged(final CharSequence s, final int start, final int before, final int count) {
+                        parametersLayout.setError(null);
+                    }
+
+                    @Override
+                    public void afterTextChanged(final Editable s) {
+
+                    }
+                });
+
+                actionSend.setOnClickListener(v -> {
+                    final String opCode = opCodeEditText.getText().toString().trim();
+                    if(!validateInput(opCode)) {
+                        return;
+                    }
+
+                    final String parameters = parametersEditText.getText().toString().trim();
+                    /*if(!validateInput(parameters)) {
+                        return;
+                    }*/
+                    final ProvisionedMeshNode node = (ProvisionedMeshNode) mViewModel.getExtendedMeshNode().getMeshNode();
+
+                    mViewModel.sendVendorModelAcknowledgedMessage(node, model, model.getBoundAppKeyIndexes().get(0), Integer.parseInt(opCode, 16), MeshParserUtils.toByteArray(parameters));
+                });
+
+                mViewModel.getVendorModelState().observe(this, bytes -> receivedMessage.setText(MeshParserUtils.bytesToHex(bytes, false)));
             }
         }
+    }
+
+    private boolean validateInput(final String input) throws IllegalArgumentException{
+        try {
+
+            if(TextUtils.isEmpty(input)){
+                throw new IllegalArgumentException(getString(R.string.error_empty_value));
+            }
+
+            if(!input.matches(Utils.HEX_PATTERN) || input.startsWith("0x")) {
+                throw new IllegalArgumentException(getString(R.string.invalid_hex_value));
+            }
+
+            if(MeshParserUtils.validateNetworkKeyInput(this, input)){
+                return true;
+            }
+        } catch (IllegalArgumentException ex) {
+            //networkKeyInputLayout.setError(ex.getMessage());
+        }
+        return true;
     }
 
     @Override

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ModelConfigurationActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ModelConfigurationActivity.java
@@ -27,7 +27,6 @@ import android.arch.lifecycle.ViewModelProviders;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
-import android.os.Parcelable;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.CardView;
 import android.support.v7.widget.LinearLayoutManager;
@@ -510,6 +509,9 @@ public class ModelConfigurationActivity extends AppCompatActivity implements Inj
                         mActionOnOff.setText(R.string.action_generic_on);
                     }
                 });
+            } else {
+                final CardView cardView = findViewById(R.id.node_controls_card);
+                final View nodeControlsContainer = LayoutInflater.from(this).inflate(R.layout.layout_vendor_model_controls, cardView);
             }
         }
     }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/BaseMeshRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/BaseMeshRepository.java
@@ -60,6 +60,7 @@ import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.ACTION_IS_REC
 import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.ACTION_ON_DEVICE_READY;
 import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.ACTION_PROVISIONING_STATE;
 import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.ACTION_TRANSACTION_FAILED;
+import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.ACTION_VENDOR_MODEL_MESSAGE_STATE;
 import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_DATA;
 import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_ELEMENT_ADDRESS;
 
@@ -173,6 +174,9 @@ public abstract class BaseMeshRepository {
                     onConfigurationMessageStateChanged(intent);
                     break;
                 case ACTION_GENERIC_ON_OFF_STATE:
+                    onGenericMessageStateChanged(intent);
+                    break;
+                case ACTION_VENDOR_MODEL_MESSAGE_STATE:
                     onGenericMessageStateChanged(intent);
                     break;
                 case ACTION_TRANSACTION_FAILED:

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ModelConfigurationRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ModelConfigurationRepository.java
@@ -38,11 +38,14 @@ import no.nordicsemi.android.meshprovisioner.utils.Element;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 import no.nordicsemi.android.nrfmeshprovisioner.R;
 import no.nordicsemi.android.nrfmeshprovisioner.livedata.ExtendedMeshNode;
+import no.nordicsemi.android.nrfmeshprovisioner.livedata.SingleLiveEvent;
 import no.nordicsemi.android.nrfmeshprovisioner.viewmodels.MeshNodeStates;
 
 import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.ACTION_GENERIC_ON_OFF_STATE;
+import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.ACTION_VENDOR_MODEL_MESSAGE_STATE;
 import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_APP_KEY_INDEX;
 import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_CONFIGURATION_STATE;
+import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_DATA;
 import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_ELEMENT_ADDRESS;
 import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_GENERIC_ON_OFF_PRESENT_STATE;
 import static no.nordicsemi.android.nrfmeshprovisioner.utils.Utils.EXTRA_IS_SUCCESS;
@@ -55,6 +58,7 @@ public class ModelConfigurationRepository extends BaseMeshRepository {
 
     private static final String TAG = ModelConfigurationRepository.class.getSimpleName();
     private MutableLiveData<Boolean> mPresentState = new MutableLiveData<>();
+    private SingleLiveEvent<byte[]> mVendorModelState = new SingleLiveEvent<>();
 
     public ModelConfigurationRepository(final Context context) {
         super(context);
@@ -62,6 +66,10 @@ public class ModelConfigurationRepository extends BaseMeshRepository {
 
     public LiveData<Boolean> getGenericOnOffState() {
         return mPresentState;
+    }
+
+    public LiveData<byte[]> getVendorModelState(){
+        return mVendorModelState;
     }
 
     public LiveData<Boolean> isConnected() {
@@ -189,6 +197,10 @@ public class ModelConfigurationRepository extends BaseMeshRepository {
                 final boolean presentState = intent.getExtras().getBoolean(EXTRA_GENERIC_ON_OFF_PRESENT_STATE);
                 //TODO implement target state and remaining state.
                 mPresentState.postValue(presentState);
+                break;
+            case ACTION_VENDOR_MODEL_MESSAGE_STATE:
+                final byte[] data = intent.getExtras().getByteArray(EXTRA_DATA);
+                mVendorModelState.postValue(data);
                 break;
         }
     }
@@ -332,5 +344,9 @@ public class ModelConfigurationRepository extends BaseMeshRepository {
         } else {
             Toast.makeText(mContext, R.string.error_no_app_keys_bound, Toast.LENGTH_SHORT).show();
         }
+    }
+
+    public void sendVendorModelUnacknowledgedMessage(final ProvisionedMeshNode node, final MeshModel model, final byte[] address, final int appKeyIndex, final int opcode, final byte[] parameters) {
+        mBinder.sendVendorModelUnacknowledgedMessage(node, model, address, appKeyIndex, opcode, parameters);
     }
 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ModelConfigurationRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/repository/ModelConfigurationRepository.java
@@ -346,7 +346,11 @@ public class ModelConfigurationRepository extends BaseMeshRepository {
         }
     }
 
-    public void sendVendorModelUnacknowledgedMessage(final ProvisionedMeshNode node, final MeshModel model, final byte[] address, final int appKeyIndex, final int opcode, final byte[] parameters) {
-        mBinder.sendVendorModelUnacknowledgedMessage(node, model, address, appKeyIndex, opcode, parameters);
+    public void sendVendorModelUnacknowledgedMessage(final ProvisionedMeshNode node, final MeshModel model, final int appKeyIndex, final int opcode, final byte[] parameters) {
+        mBinder.sendVendorModelUnacknowledgedMessage(node, model, mElement.getValue().getElementAddress(), appKeyIndex, opcode, parameters);
+    }
+
+    public void sendVendorModelAcknowledgedMessage(final ProvisionedMeshNode node, final MeshModel model, final int appKeyIndex, final int opcode, final byte[] parameters) {
+        mBinder.sendVendorModelAcknowledgedMessage(node, model, mElement.getValue().getElementAddress(), appKeyIndex, opcode, parameters);
     }
 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/service/MeshService.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/service/MeshService.java
@@ -1143,5 +1143,9 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
         public void sendVendorModelUnacknowledgedMessage(final ProvisionedMeshNode node, final MeshModel model, final byte[] address, final int appKeyIndex, final int opcode, final byte[] parameters) {
             mMeshManagerApi.sendVendorModelUnacknowledgedMessage(node, model, address, appKeyIndex, opcode, parameters);
         }
+
+        public void sendVendorModelAcknowledgedMessage(final ProvisionedMeshNode node, final MeshModel model, final byte[] address, final int appKeyIndex, final int opcode, final byte[] parameters) {
+            mMeshManagerApi.sendVendorModelAcknowledgedMessage(node, model, address, appKeyIndex, opcode, parameters);
+        }
     }
 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/service/MeshService.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/service/MeshService.java
@@ -718,6 +718,24 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
     }
 
     @Override
+    public void onUnacknowledgedVendorModelMessageSent(final ProvisionedMeshNode node) {
+        mMeshNode = node;
+    }
+
+    @Override
+    public void onAcknowledgedVendorModelMessageSent(final ProvisionedMeshNode node) {
+        mMeshNode = node;
+    }
+
+    @Override
+    public void onVendorModelMessageStatusReceived(final ProvisionedMeshNode node, final byte[] pdu) {
+        mMeshNode = node;
+        final Intent intent = new Intent(ACTION_VENDOR_MODEL_MESSAGE_STATE);
+        intent.putExtra(EXTRA_DATA, pdu);
+        LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
+    }
+
+    @Override
     public void onMeshNodeResetSent(final ProvisionedMeshNode node) {
         mMeshNode = node;
         final Intent intent = new Intent(ACTION_CONFIGURATION_STATE);
@@ -1120,6 +1138,10 @@ public class MeshService extends Service implements BleMeshManagerCallbacks,
 
         public void resetMeshNode(final ProvisionedMeshNode provisionedMeshNode) {
             mMeshManagerApi.resetMeshNode(provisionedMeshNode);
+        }
+
+        public void sendVendorModelUnacknowledgedMessage(final ProvisionedMeshNode node, final MeshModel model, final byte[] address, final int appKeyIndex, final int opcode, final byte[] parameters) {
+            mMeshManagerApi.sendVendorModelUnacknowledgedMessage(node, model, address, appKeyIndex, opcode, parameters);
         }
     }
 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/utils/Utils.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/utils/Utils.java
@@ -54,6 +54,10 @@ public class Utils {
     public static final String ACTION_CONFIGURATION_STATE = "ACTION_CONFIGURATION_STATE";
     public static final String ACTION_GENERIC_STATE = "ACTION_GENERIC_STATE";
     public static final String ACTION_GENERIC_ON_OFF_STATE = "ACTION_GENERIC_ON_OFF_STATE";
+
+    public static final String ACTION_VENDOR_MODEL_MESSAGE = "ACTION_VENDOR_MODEL_MESSAGE";
+    public static final String ACTION_VENDOR_MODEL_MESSAGE_STATE = "ACTION_VENDOR_MODEL_MESSAGE_STATE";
+
     public static final String ACTION_TRANSACTION_FAILED = "ACTION_TRANSACTION_FAILED";
     public static final String ACTION_UPDATE_PROVISIONED_NODES = "ACTION_UPDATE_PROVISIONED_NODES";
 
@@ -234,6 +238,7 @@ public class Utils {
         intentFilter.addAction(ACTION_CONFIGURATION_STATE);
         intentFilter.addAction(ACTION_TRANSACTION_FAILED);
         intentFilter.addAction(ACTION_GENERIC_ON_OFF_STATE);
+        intentFilter.addAction(ACTION_VENDOR_MODEL_MESSAGE_STATE);
         return intentFilter;
     }
 

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/ModelConfigurationViewModel.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/ModelConfigurationViewModel.java
@@ -144,4 +144,12 @@ public class ModelConfigurationViewModel extends ViewModel {
     public LiveData<Boolean> getGenericOnOffState() {
         return mModelConfigurationRepository.getGenericOnOffState();
     }
+
+    public LiveData<byte[]> getVendorModelState() {
+        return mModelConfigurationRepository.getVendorModelState();
+    }
+
+    public void sendVendorModelUnacknowledgedMessage(final ProvisionedMeshNode node, final MeshModel model, final byte[] address, final int appKeyIndex, final int opcode, final byte[] parameters){
+        mModelConfigurationRepository.sendVendorModelUnacknowledgedMessage(node, model, address, appKeyIndex, opcode, parameters);
+    }
 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/ModelConfigurationViewModel.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/ModelConfigurationViewModel.java
@@ -149,7 +149,11 @@ public class ModelConfigurationViewModel extends ViewModel {
         return mModelConfigurationRepository.getVendorModelState();
     }
 
-    public void sendVendorModelUnacknowledgedMessage(final ProvisionedMeshNode node, final MeshModel model, final byte[] address, final int appKeyIndex, final int opcode, final byte[] parameters){
-        mModelConfigurationRepository.sendVendorModelUnacknowledgedMessage(node, model, address, appKeyIndex, opcode, parameters);
+    public void sendVendorModelUnacknowledgedMessage(final ProvisionedMeshNode node, final MeshModel model, final int appKeyIndex, final int opcode, final byte[] parameters){
+        mModelConfigurationRepository.sendVendorModelUnacknowledgedMessage(node, model, appKeyIndex, opcode, parameters);
+    }
+
+    public void sendVendorModelAcknowledgedMessage(final ProvisionedMeshNode node, final MeshModel model, final int appKeyIndex, final int opcode, final byte[] parameters){
+        mModelConfigurationRepository.sendVendorModelAcknowledgedMessage(node, model, appKeyIndex, opcode, parameters);
     }
 }

--- a/Example/nrf-mesh/app/src/main/res/layout/layout_vendor_model_controls.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/layout_vendor_model_controls.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_height="wrap_content"
+    android:layout_width="match_parent"
+    android:background="?selectableItemBackground">
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/node_controls_tool_bar"
+        android:layout_width="match_parent"
+        android:layout_height="?actionBarSize"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:logo="@drawable/ic_subscribe_black_alpha_24dp"
+        app:title="@string/title_vendor_model_controls"
+        app:titleMarginStart="@dimen/toolbar_title_margin"/>
+
+    <android.support.design.widget.TextInputLayout
+        android:id="@+id/op_code_layout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/node_controls_tool_bar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:layout_marginEnd="@dimen/activity_horizontal_margin">
+
+        <android.support.design.widget.TextInputEditText
+            android:id="@+id/op_code"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/opcode"/>
+
+    </android.support.design.widget.TextInputLayout>
+
+    <android.support.design.widget.TextInputLayout
+        android:id="@+id/parameters_layout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@id/op_code_layout"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
+        android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:layout_marginEnd="@dimen/activity_horizontal_margin">
+
+        <android.support.design.widget.TextInputEditText
+            android:id="@+id/parameters"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="@string/parameters"/>
+
+    </android.support.design.widget.TextInputLayout>
+
+    <TextView
+        android:id="@+id/text_view1"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
+        android:layout_marginBottom="@dimen/activity_vertical_margin"
+        android:text="@string/received_message"
+        app:layout_constraintStart_toStartOf="@id/parameters_layout"
+        app:layout_constraintTop_toBottomOf="@id/parameters_layout"
+        app:layout_constraintBottom_toTopOf="@id/div"/>
+
+    <TextView
+        android:id="@+id/received_message"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/none"
+        app:layout_constraintBottom_toBottomOf="@id/text_view1"
+        app:layout_constraintEnd_toEndOf="@id/parameters_layout"/>
+
+    <include
+        android:id="@+id/div"
+        layout="@layout/layout_divider"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        app:layout_constraintTop_toBottomOf="@id/received_message"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <Button
+        android:id="@+id/action_send"
+        style="@style/Widget.AppCompat.Button.Borderless.Colored"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginEnd="@dimen/item_padding_start"
+        android:layout_marginStart="@dimen/item_padding_end"
+        android:text="@string/action_subscribe_address"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/div"/>
+
+</android.support.constraint.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/layout_vendor_model_controls.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/layout_vendor_model_controls.xml
@@ -17,21 +17,54 @@
         app:title="@string/title_vendor_model_controls"
         app:titleMarginStart="@dimen/toolbar_title_margin"/>
 
+    <TextView
+        android:id="@+id/text_view"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/message_type"
+        android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:layout_marginEnd="@dimen/activity_horizontal_margin"
+        app:layout_constraintTop_toBottomOf="@id/node_controls_tool_bar"
+        app:layout_constraintStart_toStartOf="parent"/>
+
+    <CheckBox
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="@id/text_view"
+        app:layout_constraintBottom_toBottomOf="@id/text_view"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginEnd="@dimen/activity_horizontal_margin"/>
+
     <android.support.design.widget.TextInputLayout
         android:id="@+id/op_code_layout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/node_controls_tool_bar"
+        app:layout_constraintTop_toBottomOf="@id/text_view"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
         android:layout_marginStart="@dimen/activity_horizontal_margin"
         android:layout_marginEnd="@dimen/activity_horizontal_margin">
-
-        <android.support.design.widget.TextInputEditText
-            android:id="@+id/op_code"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/opcode"/>
+            android:orientation="horizontal">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:text="0x"
+                android:textSize="16sp"/>
+
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/op_code"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text|textCapCharacters"
+                android:singleLine="true"
+                android:hint="@string/opcode"/>
+        </LinearLayout>
 
     </android.support.design.widget.TextInputLayout>
 
@@ -46,12 +79,25 @@
         android:layout_marginStart="@dimen/activity_horizontal_margin"
         android:layout_marginEnd="@dimen/activity_horizontal_margin">
 
-        <android.support.design.widget.TextInputEditText
-            android:id="@+id/parameters"
+        <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:hint="@string/parameters"/>
+            android:orientation="horizontal">
 
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                android:text="0x"
+                android:textSize="16sp"/>
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/parameters"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text|textCapCharacters"
+                android:singleLine="true"
+                android:hint="@string/parameters"/>
+        </LinearLayout>
     </android.support.design.widget.TextInputLayout>
 
     <TextView
@@ -59,11 +105,9 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/activity_vertical_margin"
-        android:layout_marginBottom="@dimen/activity_vertical_margin"
         android:text="@string/received_message"
         app:layout_constraintStart_toStartOf="@id/parameters_layout"
-        app:layout_constraintTop_toBottomOf="@id/parameters_layout"
-        app:layout_constraintBottom_toTopOf="@id/div"/>
+        app:layout_constraintTop_toBottomOf="@id/parameters_layout"/>
 
     <TextView
         android:id="@+id/received_message"
@@ -71,16 +115,18 @@
         android:layout_height="wrap_content"
         android:text="@string/none"
         app:layout_constraintBottom_toBottomOf="@id/text_view1"
-        app:layout_constraintEnd_toEndOf="@id/parameters_layout"/>
+        app:layout_constraintEnd_toEndOf="@id/parameters_layout"
+        app:layout_constraintTop_toTopOf="@+id/text_view1"/>
 
     <include
         android:id="@+id/div"
         layout="@layout/layout_divider"
         android:layout_width="0dp"
         android:layout_height="1dp"
-        app:layout_constraintTop_toBottomOf="@id/received_message"
+        android:layout_marginTop="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+        app:layout_constraintTop_toBottomOf="@id/received_message"/>
 
     <Button
         android:id="@+id/action_send"
@@ -90,7 +136,8 @@
         android:layout_gravity="center_horizontal"
         android:layout_marginEnd="@dimen/item_padding_start"
         android:layout_marginStart="@dimen/item_padding_end"
-        android:text="@string/action_subscribe_address"
+        android:padding="@dimen/activity_horizontal_margin"
+        android:text="@string/action_send"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/div"/>

--- a/Example/nrf-mesh/app/src/main/res/layout/layout_vendor_model_controls.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/layout_vendor_model_controls.xml
@@ -28,6 +28,7 @@
         app:layout_constraintStart_toStartOf="parent"/>
 
     <CheckBox
+        android:id="@+id/chk_acknowledged"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         app:layout_constraintTop_toTopOf="@id/text_view"
@@ -54,8 +55,9 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="8dp"
-                android:text="0x"
+                android:text="@string/enforce_vendor_op_code"
                 android:textSize="16sp"/>
+
 
             <android.support.design.widget.TextInputEditText
                 android:id="@+id/op_code"
@@ -100,23 +102,33 @@
         </LinearLayout>
     </android.support.design.widget.TextInputLayout>
 
-    <TextView
-        android:id="@+id/text_view1"
+    <LinearLayout
+        android:id="@+id/received_message_container"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/activity_vertical_margin"
-        android:text="@string/received_message"
+        android:orientation="horizontal"
+        app:layout_constraintTop_toBottomOf="@id/parameters_layout"
         app:layout_constraintStart_toStartOf="@id/parameters_layout"
-        app:layout_constraintTop_toBottomOf="@id/parameters_layout"/>
-
-    <TextView
-        android:id="@+id/received_message"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        android:text="@string/none"
-        app:layout_constraintBottom_toBottomOf="@id/text_view1"
         app:layout_constraintEnd_toEndOf="@id/parameters_layout"
-        app:layout_constraintTop_toTopOf="@+id/text_view1"/>
+        android:visibility="visible"
+        android:paddingTop="@dimen/item_padding_top"
+        android:paddingBottom="@dimen/item_padding_bottom">
+
+        <TextView
+            android:id="@+id/text_view1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/received_message"/>
+
+        <TextView
+            android:id="@+id/received_message"
+            android:layout_width="0dp"
+            android:layout_weight="1"
+            android:layout_height="wrap_content"
+            android:text="@string/none"
+            android:gravity="end"/>
+
+    </LinearLayout>
 
     <include
         android:id="@+id/div"
@@ -126,7 +138,7 @@
         android:layout_marginTop="16dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/received_message"/>
+        app:layout_constraintTop_toBottomOf="@id/received_message_container"/>
 
     <Button
         android:id="@+id/action_send"

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -271,6 +271,7 @@
     <string name="title_publlish_address_status">Publish Address Status</string>
     <string name="title_subscription_status">Subscription Status</string>
     <string name="hex_format">0x%s</string>
+    <string name="hex_prefix">0x</string>
     <string name="invalid_hex_value">Invalid hex value</string>
     <string name="invalid_address_value">Invalid address</string>
     <string name="mesh_provioner_service_running">Mesh provisioner service is running in background.</string>
@@ -339,4 +340,5 @@
     <string name="action_send">Send</string>
     <string name="error_empty_value">Value cannot be empty</string>
     <string name="message_type">Acknowledged Message</string>
+    <string name="enforce_vendor_op_code">0xC0 | 0x</string>
 </resources>

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -333,8 +333,10 @@
     <string name="unknown">Unknown</string>
 
     <string name="title_vendor_model_controls">Vendor Model Controls</string>
-    <string name="opcode">Op Code</string>
+    <string name="opcode">Opcode without company id</string>
     <string name="parameters">Parameters</string>
     <string name="received_message">Received message:</string>
     <string name="action_send">Send</string>
+    <string name="error_empty_value">Value cannot be empty</string>
+    <string name="message_type">Acknowledged Message</string>
 </resources>

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -331,4 +331,10 @@
     <string name="supported_input_oob_actions_title">Supported Input OOB Actions</string>
     <string name="input_oob_size_title">Input OOB Size</string>
     <string name="unknown">Unknown</string>
+
+    <string name="title_vendor_model_controls">Vendor Model Controls</string>
+    <string name="opcode">Op Code</string>
+    <string name="parameters">Parameters</string>
+    <string name="received_message">Received message:</string>
+    <string name="action_send">Send</string>
 </resources>

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
@@ -926,4 +926,19 @@ public class MeshManagerApi implements InternalTransportCallbacks, InternalMeshM
             throw new IllegalArgumentException("Mesh node cannot be null!");
         mMeshMessageHandler.resetMeshNode(provisionedMeshNode);
     }
+
+    /**
+     * Send vendor model specific message to a node
+     *
+     * @param node        target mesh nmesh node to send to
+     * @param model       Mesh model to control
+     * @param address     this address could be the unicast address of the element or the subscribe address
+     * @param appKeyIndex index of the app key to encrypt the message with
+     * @param opcode      opcode of the message
+     * @param parameters  parameters of the message
+     */
+
+    public void sendVendorModelUnacknowledgedMessage(final ProvisionedMeshNode node, final MeshModel model, final byte[] address, final int appKeyIndex, final int opcode, final byte[] parameters) {
+        mMeshMessageHandler.sendVendorModelUnacknowledgedMessage(node, model, address, false, appKeyIndex, opcode, parameters);
+    }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
@@ -928,7 +928,7 @@ public class MeshManagerApi implements InternalTransportCallbacks, InternalMeshM
     }
 
     /**
-     * Send vendor model specific message to a node
+     * Send unacknowledged vendor model specific message to a node
      *
      * @param node        target mesh nmesh node to send to
      * @param model       Mesh model to control
@@ -940,5 +940,20 @@ public class MeshManagerApi implements InternalTransportCallbacks, InternalMeshM
 
     public void sendVendorModelUnacknowledgedMessage(final ProvisionedMeshNode node, final MeshModel model, final byte[] address, final int appKeyIndex, final int opcode, final byte[] parameters) {
         mMeshMessageHandler.sendVendorModelUnacknowledgedMessage(node, model, address, false, appKeyIndex, opcode, parameters);
+    }
+
+    /**
+     * Send acknowledged vendor model specific message to a node
+     *
+     * @param node        target mesh nmesh node to send to
+     * @param model       Mesh model to control
+     * @param address     this address could be the unicast address of the element or the subscribe address
+     * @param appKeyIndex index of the app key to encrypt the message with
+     * @param opcode      opcode of the message
+     * @param parameters  parameters of the message
+     */
+
+    public void sendVendorModelAcknowledgedMessage(final ProvisionedMeshNode node, final MeshModel model, final byte[] address, final int appKeyIndex, final int opcode, final byte[] parameters) {
+        mMeshMessageHandler.sendVendorModelAcknowledgedMessage(node, model, address, false, appKeyIndex, opcode, parameters);
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshMessageHandler.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshMessageHandler.java
@@ -49,6 +49,10 @@ import no.nordicsemi.android.meshprovisioner.configuration.GenericOnOffStatus;
 import no.nordicsemi.android.meshprovisioner.configuration.MeshMessageState;
 import no.nordicsemi.android.meshprovisioner.configuration.MeshModel;
 import no.nordicsemi.android.meshprovisioner.configuration.ProvisionedMeshNode;
+import no.nordicsemi.android.meshprovisioner.configuration.VendorModelMessage;
+import no.nordicsemi.android.meshprovisioner.configuration.VendorModelMessageState;
+import no.nordicsemi.android.meshprovisioner.configuration.VendorModelMessageStatus;
+import no.nordicsemi.android.meshprovisioner.configuration.VendorModelMessageUnacknowledged;
 import no.nordicsemi.android.meshprovisioner.opcodes.ConfigMessageOpCodes;
 
 class MeshMessageHandler implements InternalMeshMsgHandlerCallbacks {
@@ -84,99 +88,115 @@ class MeshMessageHandler implements InternalMeshMsgHandlerCallbacks {
         if (mMeshMessageState.getState() == null)
             return;
 
-        switch (mMeshMessageState.getState()) {
-            case COMPOSITION_DATA_GET_STATE:
-                //Composition data get complete,
-                //We directly switch to next state because there is no acknowledgements involved
-                final ConfigCompositionDataStatus compositionDataStatus = new ConfigCompositionDataStatus(mContext, meshNode, this);
-                compositionDataStatus.setTransportCallbacks(mInternalTransportCallbacks);
-                compositionDataStatus.setStatusCallbacks(mStatusCallbacks);
-                switchState(compositionDataStatus);
-                break;
-            case APP_KEY_ADD_STATE:
-                final ConfigAppKeyAdd configAppKeyAdd = ((ConfigAppKeyAdd) mMeshMessageState);
-                //Create the next corresponding status state
-                final ConfigAppKeyStatus configAppKeyStatus = new ConfigAppKeyStatus(mContext, meshNode, configAppKeyAdd.getSrc(),
-                        configAppKeyAdd.getAppKey(), this);
-                configAppKeyStatus.setTransportCallbacks(mInternalTransportCallbacks);
-                configAppKeyStatus.setStatusCallbacks(mStatusCallbacks);
-                //Switch states
-                switchState(configAppKeyStatus);
-                break;
-            case CONFIG_MODEL_APP_BIND_STATE:
-                final ConfigModelAppBind configModelAppBind = ((ConfigModelAppBind) mMeshMessageState);
-                //Create the next corresponding status state
-                final ConfigModelAppStatus configModelAppBindStatus = new ConfigModelAppStatus(mContext, meshNode, configModelAppBind.getState().getState(), this);
-                configModelAppBindStatus.setTransportCallbacks(mInternalTransportCallbacks);
-                configModelAppBindStatus.setStatusCallbacks(mStatusCallbacks);
-                //Switch states
-                switchState(configModelAppBindStatus);
-                break;
-            case CONFIG_MODEL_APP_UNBIND_STATE:
-                final ConfigModelAppUnbind configModelAppUnbind = ((ConfigModelAppUnbind) mMeshMessageState);
-                //Create the next corresponding status state
-                final ConfigModelAppStatus configModelAppUnbindStatus = new ConfigModelAppStatus(mContext, meshNode, configModelAppUnbind.getState().getState(), this);
-                configModelAppUnbindStatus.setTransportCallbacks(mInternalTransportCallbacks);
-                configModelAppUnbindStatus.setStatusCallbacks(mStatusCallbacks);
-                //Switch states
-                switchState(configModelAppUnbindStatus);
-                break;
-            case CONFIG_MODEL_PUBLICATION_SET_STATE:
-                // Create the corresponding status state
-                final ConfigModelPublicationStatus configModelPublicationStatus = new ConfigModelPublicationStatus(mContext, meshNode, this);
-                configModelPublicationStatus.setTransportCallbacks(mInternalTransportCallbacks);
-                configModelPublicationStatus.setStatusCallbacks(mStatusCallbacks);
-                //Switch states
-                switchState(configModelPublicationStatus);
-                break;
-            case CONFIG_MODEL_SUBSCRIPTION_ADD_STATE:
-                // Create the corresponding status state
-                final ConfigModelSubscriptionStatus subscriptionAddStatus = new ConfigModelSubscriptionStatus(mContext, meshNode,
-                        ConfigMessageOpCodes.CONFIG_MODEL_SUBSCRIPTION_ADD, this);
-                subscriptionAddStatus.setTransportCallbacks(mInternalTransportCallbacks);
-                subscriptionAddStatus.setStatusCallbacks(mStatusCallbacks);
-                //Switch states
-                switchState(subscriptionAddStatus);
-                break;
-            case CONFIG_MODEL_SUBSCRIPTION_DELETE_STATE:
-                //Create the next corresponding status state
-                final ConfigModelSubscriptionStatus subscriptionDeleteStatus = new ConfigModelSubscriptionStatus(mContext, meshNode,
-                        ConfigMessageOpCodes.CONFIG_MODEL_SUBSCRIPTION_DELETE, this);
-                subscriptionDeleteStatus.setTransportCallbacks(mInternalTransportCallbacks);
-                subscriptionDeleteStatus.setStatusCallbacks(mStatusCallbacks);
-                //Switch states
-                switchState(subscriptionDeleteStatus);
-                break;
-            case GENERIC_ON_OFF_GET_STATE:
-                //Create the next corresponding status state
-                final GenericOnOffStatus genericOnOffGetStatus = new GenericOnOffStatus(mContext, mMeshMessageState.getMeshNode(), this, mMeshMessageState.getMeshModel(),
-                        mMeshMessageState.getAppKeyIndex());
-                genericOnOffGetStatus.setTransportCallbacks(mInternalTransportCallbacks);
-                genericOnOffGetStatus.setStatusCallbacks(mStatusCallbacks);
-                //Switch states
-                switchState(genericOnOffGetStatus);
-                break;
-            case GENERIC_ON_OFF_SET_STATE:
-                //Create the next corresponding status state
-                final GenericOnOffStatus genericOnOffSetStatus = new GenericOnOffStatus(mContext, mMeshMessageState.getMeshNode(), this, mMeshMessageState.getMeshModel(),
-                        mMeshMessageState.getAppKeyIndex());
-                genericOnOffSetStatus.setTransportCallbacks(mInternalTransportCallbacks);
-                genericOnOffSetStatus.setStatusCallbacks(mStatusCallbacks);
-                //Switch states
-                switchState(genericOnOffSetStatus);
-                break;
-            case GENERIC_ON_OFF_SET_UNACKNOWLEDGED_STATE:
+        if(mMeshMessageState instanceof ConfigMessageState) {
+            switch (mMeshMessageState.getState()) {
+                case COMPOSITION_DATA_GET_STATE:
+                    //Composition data get complete,
+                    //We directly switch to next state because there is no acknowledgements involved
+                    final ConfigCompositionDataStatus compositionDataStatus = new ConfigCompositionDataStatus(mContext, meshNode, this);
+                    compositionDataStatus.setTransportCallbacks(mInternalTransportCallbacks);
+                    compositionDataStatus.setStatusCallbacks(mStatusCallbacks);
+                    switchState(compositionDataStatus);
+                    break;
+                case APP_KEY_ADD_STATE:
+                    final ConfigAppKeyAdd configAppKeyAdd = ((ConfigAppKeyAdd) mMeshMessageState);
+                    //Create the next corresponding status state
+                    final ConfigAppKeyStatus configAppKeyStatus = new ConfigAppKeyStatus(mContext, meshNode, configAppKeyAdd.getSrc(),
+                            configAppKeyAdd.getAppKey(), this);
+                    configAppKeyStatus.setTransportCallbacks(mInternalTransportCallbacks);
+                    configAppKeyStatus.setStatusCallbacks(mStatusCallbacks);
+                    //Switch states
+                    switchState(configAppKeyStatus);
+                    break;
+                case CONFIG_MODEL_APP_BIND_STATE:
+                    final ConfigModelAppBind configModelAppBind = ((ConfigModelAppBind) mMeshMessageState);
+                    //Create the next corresponding status state
+                    final ConfigModelAppStatus configModelAppBindStatus = new ConfigModelAppStatus(mContext, meshNode, configModelAppBind.getState().getState(), this);
+                    configModelAppBindStatus.setTransportCallbacks(mInternalTransportCallbacks);
+                    configModelAppBindStatus.setStatusCallbacks(mStatusCallbacks);
+                    //Switch states
+                    switchState(configModelAppBindStatus);
+                    break;
+                case CONFIG_MODEL_APP_UNBIND_STATE:
+                    final ConfigModelAppUnbind configModelAppUnbind = ((ConfigModelAppUnbind) mMeshMessageState);
+                    //Create the next corresponding status state
+                    final ConfigModelAppStatus configModelAppUnbindStatus = new ConfigModelAppStatus(mContext, meshNode, configModelAppUnbind.getState().getState(), this);
+                    configModelAppUnbindStatus.setTransportCallbacks(mInternalTransportCallbacks);
+                    configModelAppUnbindStatus.setStatusCallbacks(mStatusCallbacks);
+                    //Switch states
+                    switchState(configModelAppUnbindStatus);
+                    break;
+                case CONFIG_MODEL_PUBLICATION_SET_STATE:
+                    // Create the corresponding status state
+                    final ConfigModelPublicationStatus configModelPublicationStatus = new ConfigModelPublicationStatus(mContext, meshNode, this);
+                    configModelPublicationStatus.setTransportCallbacks(mInternalTransportCallbacks);
+                    configModelPublicationStatus.setStatusCallbacks(mStatusCallbacks);
+                    //Switch states
+                    switchState(configModelPublicationStatus);
+                    break;
+                case CONFIG_MODEL_SUBSCRIPTION_ADD_STATE:
+                    // Create the corresponding status state
+                    final ConfigModelSubscriptionStatus subscriptionAddStatus = new ConfigModelSubscriptionStatus(mContext, meshNode,
+                            ConfigMessageOpCodes.CONFIG_MODEL_SUBSCRIPTION_ADD, this);
+                    subscriptionAddStatus.setTransportCallbacks(mInternalTransportCallbacks);
+                    subscriptionAddStatus.setStatusCallbacks(mStatusCallbacks);
+                    //Switch states
+                    switchState(subscriptionAddStatus);
+                    break;
+                case CONFIG_MODEL_SUBSCRIPTION_DELETE_STATE:
+                    //Create the next corresponding status state
+                    final ConfigModelSubscriptionStatus subscriptionDeleteStatus = new ConfigModelSubscriptionStatus(mContext, meshNode,
+                            ConfigMessageOpCodes.CONFIG_MODEL_SUBSCRIPTION_DELETE, this);
+                    subscriptionDeleteStatus.setTransportCallbacks(mInternalTransportCallbacks);
+                    subscriptionDeleteStatus.setStatusCallbacks(mStatusCallbacks);
+                    //Switch states
+                    switchState(subscriptionDeleteStatus);
+                    break;
+                case CONFIG_NODE_RESET_STATE:
+                    //Create the next corresponding status state
+                    final ConfigNodeResetStatus configNodeResetStatus = new ConfigNodeResetStatus(mContext, mMeshMessageState.getMeshNode(), this);
+                    configNodeResetStatus.setTransportCallbacks(mInternalTransportCallbacks);
+                    configNodeResetStatus.setStatusCallbacks(mStatusCallbacks);
+                    //Switch states
+                    switchState(configNodeResetStatus);
+                    break;
+            }
+        } else if(mMeshMessageState instanceof GenericMessageState) {
+            switch (mMeshMessageState.getState()) {
+                case GENERIC_ON_OFF_GET_STATE:
+                    //Create the next corresponding status state
+                    final GenericOnOffStatus genericOnOffGetStatus = new GenericOnOffStatus(mContext, mMeshMessageState.getMeshNode(), this, mMeshMessageState.getMeshModel(),
+                            mMeshMessageState.getAppKeyIndex());
+                    genericOnOffGetStatus.setTransportCallbacks(mInternalTransportCallbacks);
+                    genericOnOffGetStatus.setStatusCallbacks(mStatusCallbacks);
+                    //Switch states
+                    switchState(genericOnOffGetStatus);
+                    break;
+                case GENERIC_ON_OFF_SET_STATE:
+                    //Create the next corresponding status state
+                    final GenericOnOffStatus genericOnOffSetStatus = new GenericOnOffStatus(mContext, mMeshMessageState.getMeshNode(), this, mMeshMessageState.getMeshModel(),
+                            mMeshMessageState.getAppKeyIndex());
+                    genericOnOffSetStatus.setTransportCallbacks(mInternalTransportCallbacks);
+                    genericOnOffSetStatus.setStatusCallbacks(mStatusCallbacks);
+                    //Switch states
+                    switchState(genericOnOffSetStatus);
+                    break;
+                case GENERIC_ON_OFF_SET_UNACKNOWLEDGED_STATE:
+                    //We don't expect a generic on off status as this is an unacknowledged message so we switch states here
+                    switchToNoOperationState(new DefaultNoOperationMessageState(mContext, meshNode, this));
+                    break;
+            }
+        } else if(mMeshMessageState instanceof VendorModelMessageState) {
+            if(mMeshMessageState instanceof VendorModelMessageUnacknowledged) {
                 //We don't expect a generic on off status as this is an unacknowledged message so we switch states here
                 switchToNoOperationState(new DefaultNoOperationMessageState(mContext, meshNode, this));
-                break;
-            case CONFIG_NODE_RESET_STATE:
-                //Create the next corresponding status state
-                final ConfigNodeResetStatus configNodeResetStatus = new ConfigNodeResetStatus(mContext, mMeshMessageState.getMeshNode(), this);
-                configNodeResetStatus.setTransportCallbacks(mInternalTransportCallbacks);
-                configNodeResetStatus.setStatusCallbacks(mStatusCallbacks);
-                //Switch states
-                switchState(configNodeResetStatus);
-                break;
+            } else {
+                final VendorModelMessageStatus vendorModelMessage = new VendorModelMessageStatus(mContext, mMeshMessageState.getMeshNode(), this,
+                        mMeshMessageState.getMeshModel(), mMeshMessageState.getAppKeyIndex());
+                vendorModelMessage.setTransportCallbacks(mInternalTransportCallbacks);
+                vendorModelMessage.setStatusCallbacks(mStatusCallbacks);
+                switchToNoOperationState(vendorModelMessage);
+            }
         }
     }
 
@@ -318,6 +338,13 @@ class MeshMessageHandler implements InternalMeshMsgHandlerCallbacks {
                         switchToNoOperationState(new DefaultNoOperationMessageState(mContext, meshNode, this));
                     }
                     break;
+            }
+        } else if (mMeshMessageState instanceof VendorModelMessageState) {
+            if (mMeshMessageState instanceof VendorModelMessageUnacknowledged) {
+                final VendorModelMessageUnacknowledged vendorModelMessageUnacknowledged = (VendorModelMessageUnacknowledged) mMeshMessageState;
+                vendorModelMessageUnacknowledged.parseMessage(pdu);
+            } else {
+
             }
         } else {
             ((DefaultNoOperationMessageState) mMeshMessageState).parseMessage(pdu);
@@ -579,7 +606,6 @@ class MeshMessageHandler implements InternalMeshMsgHandlerCallbacks {
         genericOnOffSetUnAcked.executeSend();
     }
 
-
     /**
      * Resets the specific mesh node
      *
@@ -591,5 +617,24 @@ class MeshMessageHandler implements InternalMeshMsgHandlerCallbacks {
         configNodeReset.setStatusCallbacks(mStatusCallbacks);
         mMeshMessageState = configNodeReset;
         configNodeReset.executeSend();
+    }
+
+    /**
+     * Send vendor model specific message to a node
+     *
+     * @param node        target mesh nmesh node to send to
+     * @param model       Mesh model to control
+     * @param address     this address could be the unicast address of the element or the subscribe address
+     * @param aszmic      if aszmic set to 1 the messages are encrypted with 64bit encryption otherwise 32 bit
+     * @param appKeyIndex index of the app key to encrypt the message with
+     * @param opcode      opcode of the message
+     * @param parameters  parameters of the message
+     */
+    public void sendVendorModelUnacknowledgedMessage(final ProvisionedMeshNode node, final MeshModel model, final byte[] address, final boolean aszmic, final int appKeyIndex, final int opcode, final byte[] parameters) {
+        final VendorModelMessageUnacknowledged message = new VendorModelMessageUnacknowledged(mContext, node, this, model, aszmic, address, appKeyIndex, opcode, parameters);
+        message.setTransportCallbacks(mInternalTransportCallbacks);
+        message.setStatusCallbacks(mStatusCallbacks);
+        mMeshMessageState = message;
+        message.executeSend();
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshStatusCallbacks.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshStatusCallbacks.java
@@ -149,6 +149,20 @@ public interface MeshStatusCallbacks {
     void onSubscriptionStatusReceived(final ProvisionedMeshNode node, final boolean success, final int status, final byte[] elementAddress, final byte[] subscriptionAddress, final int modelIdentifier);
 
     /**
+     * Notifies if the mesh {@link ConfigNodeReset} was sent
+     *
+     * @param node mesh node that the message was sent to
+     */
+    void onMeshNodeResetSent(final ProvisionedMeshNode node);
+
+    /**
+     * Notifies if the mesh {@link ConfigNodeResetStatus} was received
+     *
+     * @param node mesh node that the message was received from
+     */
+    void onMeshNodeResetStatusReceived(final ProvisionedMeshNode node);
+
+    /**
      * Notifies if {@link GenericOnOffGet} was sent
      *
      * @param node mesh node that the message was sent to
@@ -177,16 +191,23 @@ public interface MeshStatusCallbacks {
     void onGenericOnOffStatusReceived(final ProvisionedMeshNode node, final boolean presentOnOff, final boolean targetOnOff, final int remainingTime);
 
     /**
-     * Notifies if the mesh {@link ConfigNodeReset} was sent
-     *
-     * @param node mesh node that the message was sent to
-     */
-    void onMeshNodeResetSent(final ProvisionedMeshNode node);
-
-    /**
-     * Notifies if the mesh {@link ConfigNodeResetStatus} was received
+     * Notifies if {@link VendorModelMessageUnacknowledged} was received
      *
      * @param node mesh node that the message was received from
      */
-    void onMeshNodeResetStatusReceived(final ProvisionedMeshNode node);
+    void onUnacknowledgedVendorModelMessageSent(final ProvisionedMeshNode node);
+
+    /**
+     * Notifies if {@link VendorModelMessageState} was received
+     *
+     * @param node mesh node that the message was received from
+     */
+    void onAcknowledgedVendorModelMessageSent(final ProvisionedMeshNode node);
+
+    /**
+     * Notifies if {@link GenericOnOffStatus} was received
+     *
+     * @param node mesh node that the message was received from
+     */
+    void onVendorModelMessageStatusReceived(final ProvisionedMeshNode node, final byte[] pdu);
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/GenericOnOffGet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/GenericOnOffGet.java
@@ -39,7 +39,7 @@ public class GenericOnOffGet extends GenericMessageState {
     }
 
     @Override
-    protected boolean parseMessage(final byte[] pdu) {
+    public boolean parseMessage(final byte[] pdu) {
         final Message message = mMeshTransport.parsePdu(mSrc, pdu);
         if (message != null) {
             if (message instanceof AccessMessage) {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/GenericOnOffSet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/GenericOnOffSet.java
@@ -58,7 +58,7 @@ public class GenericOnOffSet extends GenericMessageState implements LowerTranspo
     }
 
     @Override
-    protected boolean parseMessage(final byte[] pdu) {
+    public boolean parseMessage(final byte[] pdu) {
         final Message message = mMeshTransport.parsePdu(mSrc, pdu);
         if (message != null) {
             if (message instanceof AccessMessage) {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/MeshTransport.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/MeshTransport.java
@@ -30,6 +30,7 @@ import android.util.Log;
 import no.nordicsemi.android.meshprovisioner.messages.AccessMessage;
 import no.nordicsemi.android.meshprovisioner.messages.ControlMessage;
 import no.nordicsemi.android.meshprovisioner.messages.Message;
+import no.nordicsemi.android.meshprovisioner.models.VendorModel;
 import no.nordicsemi.android.meshprovisioner.transport.LowerTransportLayerCallbacks;
 import no.nordicsemi.android.meshprovisioner.transport.NetworkLayer;
 import no.nordicsemi.android.meshprovisioner.transport.UpperTransportLayerCallbacks;
@@ -181,6 +182,58 @@ final class MeshTransport extends NetworkLayer {
         message.setPduType(NETWORK_PDU);
 
         super.createMeshMessage(message);
+        return message;
+    }
+
+    /**
+     * Creates a vendor model access message to be sent to the peripheral node
+     * <p>
+     * This method will create the access message and propagate the message through the transport layers to create the final mesh pdu.
+     * </p>
+     *
+     * @param provisionedMeshNode     mesh node to which the message is to be sent
+     * @param mMeshModel
+     * @param src                     Source address of the provisioner/configurator.
+     * @param dst                     destination address to be sent to
+     * @param key                     Key could be application key or device key.
+     * @param akf                     Application key flag defines which key to be used to decrypt the message i.e device key or application key.
+     * @param aid                     Identifier of the application key.
+     * @param aszmic                  Defines the length of the transport mic length where 1 will encrypt withn 64 bit and 0 with 32 bit encryption.
+     * @param accessOpCode            Operation code for the access message.
+     * @param accessMessageParameters Parameters for the access message.
+     * @return access message containing the mesh pdu
+     */
+    AccessMessage createVendorMeshMessage(final ProvisionedMeshNode provisionedMeshNode, final VendorModel mMeshModel, final byte[] src, final byte[] dst,
+                                          final byte[] key, final int akf, final int aid, final int aszmic,
+                                          final int accessOpCode, final byte[] accessMessageParameters) {
+
+        final int sequenceNumber = incrementSequenceNumber();
+        final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(sequenceNumber);
+
+        Log.v(TAG, "Src address: " + MeshParserUtils.bytesToHex(src, false));
+        Log.v(TAG, "Dst address: " + MeshParserUtils.bytesToHex(dst, false));
+        Log.v(TAG, "Key: " + MeshParserUtils.bytesToHex(key, false));
+        Log.v(TAG, "akf: " + akf);
+        Log.v(TAG, "aid: " + aid);
+        Log.v(TAG, "aszmic: " + aszmic);
+        Log.v(TAG, "Access message opcode: " + Integer.toHexString(accessOpCode));
+        Log.v(TAG, "Access message parameters: " + MeshParserUtils.bytesToHex(accessMessageParameters, false));
+
+        final AccessMessage message = new AccessMessage();
+        message.setCompanyIdentifier(mMeshModel.getCompanyIdentifier());
+        message.setSrc(src);
+        message.setDst(dst);
+        message.setIvIndex(provisionedMeshNode.getIvIndex());
+        message.setSequenceNumber(sequenceNum);
+        message.setKey(key);
+        message.setAkf(akf);
+        message.setAid(aid);
+        message.setAszmic(aszmic);
+        message.setOpCode(accessOpCode);
+        message.setParameters(accessMessageParameters);
+        message.setPduType(NETWORK_PDU);
+
+        super.createVendorMeshMessage(message);
         return message;
     }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/VendorModelMessage.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/VendorModelMessage.java
@@ -10,6 +10,7 @@ import no.nordicsemi.android.meshprovisioner.InternalMeshMsgHandlerCallbacks;
 import no.nordicsemi.android.meshprovisioner.messages.AccessMessage;
 import no.nordicsemi.android.meshprovisioner.messages.ControlMessage;
 import no.nordicsemi.android.meshprovisioner.messages.Message;
+import no.nordicsemi.android.meshprovisioner.models.VendorModel;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
 
@@ -18,7 +19,6 @@ public class VendorModelMessage extends VendorModelMessageState {
     private static final String TAG = VendorModelMessage.class.getSimpleName();
     private static final int VENDOR_MODEL_OPCODE_LENGTH = 4;
 
-    private final MeshModel mMeshModel;
     private final int mAszmic;
     private final byte[] dstAddress;
     private final int opCode;
@@ -56,7 +56,7 @@ public class VendorModelMessage extends VendorModelMessageState {
         final byte[] key = MeshParserUtils.toByteArray(mMeshModel.getBoundAppkeys().get(mAppKeyIndex));
         int akf = 1;
         int aid = SecureUtils.calculateK4(key);
-        accessMessage = mMeshTransport.createMeshMessage(mProvisionedMeshNode, mSrc, dstAddress, key, akf, aid, mAszmic, opCode, parameters);
+        accessMessage = mMeshTransport.createVendorMeshMessage(mProvisionedMeshNode, (VendorModel) mMeshModel, mSrc, dstAddress, key, akf, aid, mAszmic, opCode, parameters);
         mPayloads.putAll(accessMessage.getNetworkPdu());
     }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/VendorModelMessage.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/VendorModelMessage.java
@@ -1,0 +1,93 @@
+package no.nordicsemi.android.meshprovisioner.configuration;
+
+import android.content.Context;
+import android.util.Log;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import no.nordicsemi.android.meshprovisioner.InternalMeshMsgHandlerCallbacks;
+import no.nordicsemi.android.meshprovisioner.messages.AccessMessage;
+import no.nordicsemi.android.meshprovisioner.messages.ControlMessage;
+import no.nordicsemi.android.meshprovisioner.messages.Message;
+import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
+import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
+
+public class VendorModelMessage extends VendorModelMessageState {
+
+    private static final String TAG = VendorModelMessage.class.getSimpleName();
+    private static final int VENDOR_MODEL_OPCODE_LENGTH = 4;
+
+    private final MeshModel mMeshModel;
+    private final int mAszmic;
+    private final byte[] dstAddress;
+    private final int opCode;
+    private final byte[] parameters;
+
+    public VendorModelMessage(final Context context, final ProvisionedMeshNode provisionedMeshNode,
+                              final InternalMeshMsgHandlerCallbacks callbacks,
+                              final MeshModel model, final boolean aszmic,
+                              final byte[] dstAddress, final int appKeyIndex,
+                              final int opCode, final byte[] parameters) {
+        super(context, provisionedMeshNode, callbacks);
+        this.mMeshModel = model;
+        this.mAszmic = aszmic ? 1 : 0;
+        this.dstAddress = dstAddress;
+        this.mAppKeyIndex = appKeyIndex;
+        this.opCode = opCode;
+        this.parameters = parameters;
+        createAccessMessage();
+    }
+
+    @Override
+    public MessageState getState() {
+        return null;
+    }
+
+    /**
+     * Creates the access message to be sent to the node
+     */
+    private void createAccessMessage() {
+        ByteBuffer paramsBuffer;
+        paramsBuffer = ByteBuffer.allocate(parameters.length).order(ByteOrder.LITTLE_ENDIAN);
+        paramsBuffer.put(parameters);
+
+
+        final byte[] key = MeshParserUtils.toByteArray(mMeshModel.getBoundAppkeys().get(mAppKeyIndex));
+        int akf = 1;
+        int aid = SecureUtils.calculateK4(key);
+        accessMessage = mMeshTransport.createMeshMessage(mProvisionedMeshNode, mSrc, dstAddress, key, akf, aid, mAszmic, opCode, parameters);
+        mPayloads.putAll(accessMessage.getNetworkPdu());
+    }
+
+    @Override
+    public void executeSend() {
+        Log.v(TAG, "Sending acknowledged vendor model message");
+        super.executeSend();
+    }
+
+    @Override
+    public boolean parseMessage(final byte[] pdu) {
+        final Message message = mMeshTransport.parsePdu(mSrc, pdu);
+        if (message != null) {
+            if (message instanceof AccessMessage) {
+                final byte[] accessPayload = ((AccessMessage) message).getAccessPdu();
+                Log.v(TAG, "Unexpected access message received: " + MeshParserUtils.bytesToHex(accessPayload, false));
+            } else {
+                parseControlMessage((ControlMessage) message, mPayloads.size());
+                return true;
+            }
+        } else {
+            Log.v(TAG, "Message reassembly may not be complete yet");
+        }
+        return false;
+    }
+
+    @Override
+    public void sendSegmentAcknowledgementMessage(final ControlMessage controlMessage) {
+        final ControlMessage message = mMeshTransport.createSegmentBlockAcknowledgementMessage(controlMessage);
+        Log.v(TAG, "Sending acknowledgement: " + MeshParserUtils.bytesToHex(message.getNetworkPdu().get(0), false));
+        mInternalTransportCallbacks.sendPdu(mProvisionedMeshNode, message.getNetworkPdu().get(0));
+        mConfigStatusCallbacks.onBlockAcknowledgementSent(mProvisionedMeshNode);
+    }
+}

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/VendorModelMessageState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/VendorModelMessageState.java
@@ -1,0 +1,14 @@
+package no.nordicsemi.android.meshprovisioner.configuration;
+
+import android.content.Context;
+
+import no.nordicsemi.android.meshprovisioner.InternalMeshMsgHandlerCallbacks;
+
+public abstract class VendorModelMessageState extends MeshMessageState {
+
+    private static final String TAG = VendorModelMessageState.class.getSimpleName();
+
+    public VendorModelMessageState(final Context context, final ProvisionedMeshNode provisionedMeshNode, final InternalMeshMsgHandlerCallbacks callbacks) {
+        super(context, provisionedMeshNode, callbacks);
+    }
+}

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/VendorModelMessageStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/VendorModelMessageStatus.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2018, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.android.meshprovisioner.configuration;
+
+import android.content.Context;
+import android.util.Log;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import no.nordicsemi.android.meshprovisioner.InternalMeshMsgHandlerCallbacks;
+import no.nordicsemi.android.meshprovisioner.messages.AccessMessage;
+import no.nordicsemi.android.meshprovisioner.messages.ControlMessage;
+import no.nordicsemi.android.meshprovisioner.messages.Message;
+import no.nordicsemi.android.meshprovisioner.opcodes.ApplicationMessageOpCodes;
+import no.nordicsemi.android.meshprovisioner.transport.UpperTransportLayerCallbacks;
+import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
+
+public final class VendorModelMessageStatus extends GenericMessageState implements UpperTransportLayerCallbacks {
+
+    private static final String TAG = VendorModelMessageStatus.class.getSimpleName();
+    private static final int GENERIC_ON_OFF_STATE_ON = 0x01;
+    private boolean mPresentOn;
+    private boolean mTargetOn;
+    private int mRemainingTime;
+
+    public VendorModelMessageStatus(Context context,
+                                    final ProvisionedMeshNode unprovisionedMeshNode,
+                                    final InternalMeshMsgHandlerCallbacks callbacks,
+                                    final MeshModel meshModel,
+                                    final int appKeyIndex) {
+        super(context, unprovisionedMeshNode, callbacks);
+        this.mMeshModel = meshModel;
+        this.mAppKeyIndex = appKeyIndex;
+        this.mMeshTransport.setUpperTransportLayerCallbacks(this);
+    }
+
+    @Override
+    public MessageState getState() {
+        return MessageState.GENERIC_ON_OFF_STATUS_STATE;
+    }
+
+    public final boolean parseMessage(final byte[] pdu) {
+
+        final Message message = mMeshTransport.parsePdu(mSrc, pdu);
+        if (message != null) {
+            if (message instanceof AccessMessage) {
+                final byte[] accessPayload = ((AccessMessage) message).getAccessPdu();
+                Log.v(TAG, "Received vendor model message status" + MeshParserUtils.bytesToHex(accessPayload, false));
+                mConfigStatusCallbacks.onGenericOnOffStatusReceived(mProvisionedMeshNode, mPresentOn, mTargetOn, mRemainingTime);
+                mInternalTransportCallbacks.updateMeshNode(mProvisionedMeshNode);
+                return true;
+            } else {
+                parseControlMessage((ControlMessage) message, mPayloads.size());
+            }
+        } else {
+            Log.v(TAG, "Message reassembly may not be complete yet");
+        }
+        return false;
+    }
+
+    @Override
+    public void sendSegmentAcknowledgementMessage(final ControlMessage controlMessage) {
+        final ControlMessage message = mMeshTransport.createSegmentBlockAcknowledgementMessage(controlMessage);
+        Log.v(TAG, "Sending acknowledgement: " + MeshParserUtils.bytesToHex(message.getNetworkPdu().get(0), false));
+        mInternalTransportCallbacks.sendPdu(mProvisionedMeshNode, message.getNetworkPdu().get(0));
+        mConfigStatusCallbacks.onBlockAcknowledgementSent(mProvisionedMeshNode);
+    }
+
+    @Override
+    public byte[] getApplicationKey() {
+        if(mMeshModel != null){
+            if(!mMeshModel.getBoundAppkeys().isEmpty()){
+                if(mAppKeyIndex >= 0) {
+                    return MeshParserUtils.toByteArray(mMeshModel.getBoundAppKey(mAppKeyIndex));
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/VendorModelMessageStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/VendorModelMessageStatus.java
@@ -67,7 +67,7 @@ public final class VendorModelMessageStatus extends GenericMessageState implemen
             if (message instanceof AccessMessage) {
                 final byte[] accessPayload = ((AccessMessage) message).getAccessPdu();
                 Log.v(TAG, "Received vendor model message status" + MeshParserUtils.bytesToHex(accessPayload, false));
-                mConfigStatusCallbacks.onGenericOnOffStatusReceived(mProvisionedMeshNode, mPresentOn, mTargetOn, mRemainingTime);
+                mConfigStatusCallbacks.onVendorModelMessageStatusReceived(mProvisionedMeshNode, accessPayload);
                 mInternalTransportCallbacks.updateMeshNode(mProvisionedMeshNode);
                 return true;
             } else {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/VendorModelMessageUnacknowledged.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/VendorModelMessageUnacknowledged.java
@@ -10,7 +10,7 @@ import no.nordicsemi.android.meshprovisioner.InternalMeshMsgHandlerCallbacks;
 import no.nordicsemi.android.meshprovisioner.messages.AccessMessage;
 import no.nordicsemi.android.meshprovisioner.messages.ControlMessage;
 import no.nordicsemi.android.meshprovisioner.messages.Message;
-import no.nordicsemi.android.meshprovisioner.opcodes.ApplicationMessageOpCodes;
+import no.nordicsemi.android.meshprovisioner.models.VendorModel;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
 
@@ -57,7 +57,7 @@ public class VendorModelMessageUnacknowledged extends VendorModelMessageState {
         final byte[] key = MeshParserUtils.toByteArray(mMeshModel.getBoundAppkeys().get(mAppKeyIndex));
         int akf = 1;
         int aid = SecureUtils.calculateK4(key);
-        accessMessage = mMeshTransport.createMeshMessage(mProvisionedMeshNode, mSrc, dstAddress, key, akf, aid, mAszmic, opCode, parameters);
+        accessMessage = mMeshTransport.createVendorMeshMessage(mProvisionedMeshNode, (VendorModel) mMeshModel, mSrc, dstAddress, key, akf, aid, mAszmic, opCode, parameters);
         mPayloads.putAll(accessMessage.getNetworkPdu());
     }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/VendorModelMessageUnacknowledged.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/configuration/VendorModelMessageUnacknowledged.java
@@ -1,0 +1,94 @@
+package no.nordicsemi.android.meshprovisioner.configuration;
+
+import android.content.Context;
+import android.util.Log;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import no.nordicsemi.android.meshprovisioner.InternalMeshMsgHandlerCallbacks;
+import no.nordicsemi.android.meshprovisioner.messages.AccessMessage;
+import no.nordicsemi.android.meshprovisioner.messages.ControlMessage;
+import no.nordicsemi.android.meshprovisioner.messages.Message;
+import no.nordicsemi.android.meshprovisioner.opcodes.ApplicationMessageOpCodes;
+import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
+import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
+
+public class VendorModelMessageUnacknowledged extends VendorModelMessageState {
+
+    private static final String TAG = VendorModelMessageUnacknowledged.class.getSimpleName();
+    private static final int VENDOR_MODEL_OPCODE_LENGTH = 4;
+
+    private final MeshModel mMeshModel;
+    private final int mAszmic;
+    private final byte[] dstAddress;
+    private final int opCode;
+    private final byte[] parameters;
+
+    public VendorModelMessageUnacknowledged(final Context context, final ProvisionedMeshNode provisionedMeshNode,
+                                            final InternalMeshMsgHandlerCallbacks callbacks,
+                                            final MeshModel model, final boolean aszmic,
+                                            final byte[] dstAddress, final int appKeyIndex,
+                                            final int opCode, final byte[] parameters) {
+        super(context, provisionedMeshNode, callbacks);
+        this.mMeshModel = model;
+        this.mAszmic = aszmic ? 1 : 0;
+        this.dstAddress = dstAddress;
+        this.mAppKeyIndex = appKeyIndex;
+        this.opCode = opCode;
+        this.parameters = parameters;
+        createAccessMessage();
+    }
+
+    @Override
+    public MessageState getState() {
+        return null;
+    }
+
+    /**
+     * Creates the access message to be sent to the node
+     */
+    private void createAccessMessage() {
+        ByteBuffer paramsBuffer;
+        paramsBuffer = ByteBuffer.allocate(parameters.length).order(ByteOrder.LITTLE_ENDIAN);
+        paramsBuffer.put(parameters);
+
+
+        final byte[] key = MeshParserUtils.toByteArray(mMeshModel.getBoundAppkeys().get(mAppKeyIndex));
+        int akf = 1;
+        int aid = SecureUtils.calculateK4(key);
+        accessMessage = mMeshTransport.createMeshMessage(mProvisionedMeshNode, mSrc, dstAddress, key, akf, aid, mAszmic, opCode, parameters);
+        mPayloads.putAll(accessMessage.getNetworkPdu());
+    }
+
+    @Override
+    public void executeSend() {
+        Log.v(TAG, "Sending unacknowledged vendor model message");
+        super.executeSend();
+    }
+
+    @Override
+    public boolean parseMessage(final byte[] pdu) {
+        final Message message = mMeshTransport.parsePdu(mSrc, pdu);
+        if (message != null) {
+            if (message instanceof AccessMessage) {
+                final byte[] accessPayload = ((AccessMessage) message).getAccessPdu();
+                Log.v(TAG, "Unexpected access message received: " + MeshParserUtils.bytesToHex(accessPayload, false));
+            } else {
+                parseControlMessage((ControlMessage) message, mPayloads.size());
+                return true;
+            }
+        } else {
+            Log.v(TAG, "Message reassembly may not be complete yet");
+        }
+        return false;
+    }
+
+    @Override
+    public void sendSegmentAcknowledgementMessage(final ControlMessage controlMessage) {
+        final ControlMessage message = mMeshTransport.createSegmentBlockAcknowledgementMessage(controlMessage);
+        Log.v(TAG, "Sending acknowledgement: " + MeshParserUtils.bytesToHex(message.getNetworkPdu().get(0), false));
+        mInternalTransportCallbacks.sendPdu(mProvisionedMeshNode, message.getNetworkPdu().get(0));
+        mConfigStatusCallbacks.onBlockAcknowledgementSent(mProvisionedMeshNode);
+    }
+}

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/AccessLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/AccessLayer.java
@@ -52,6 +52,13 @@ public abstract class AccessLayer {
     void createMeshMessage(final Message message) {
         createAccessMessage((AccessMessage) message);
     }
+    /**
+     * Creates a vendor model access message
+     * @param message Access message containing the required opcodes and parameters to create access message pdu.
+     */
+    void createVendorMeshMessage(final Message message) {
+        createCustomAccessMessage((AccessMessage) message);
+    }
 
     /**
      * Creates an access message
@@ -86,7 +93,7 @@ public abstract class AccessLayer {
         final int opCode = accessMessage.getOpCode();
         final int companyIdentifier = accessMessage.getCompanyIdentifier();
         final byte[] parameters = accessMessage.getParameters();
-        final byte[] opCodesCompanyIdentifier = MeshParserUtils.getOpCodes(opCode, companyIdentifier);
+        final byte[] opCodesCompanyIdentifier = MeshParserUtils.createVendorOpCode(opCode, companyIdentifier);
         final ByteBuffer accessMessageBuffer = ByteBuffer.allocate(opCodesCompanyIdentifier.length + parameters.length);
         accessMessageBuffer.put(opCodesCompanyIdentifier);
         accessMessageBuffer.put(parameters);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LowerTransportLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LowerTransportLayer.java
@@ -82,6 +82,16 @@ public abstract class LowerTransportLayer extends UpperTransportLayer {
     }
 
     @Override
+    void createVendorMeshMessage(final Message message) {
+        if (message instanceof AccessMessage) {
+            super.createVendorMeshMessage(message);
+            createLowerTransportAccessPDU((AccessMessage) message);
+        } else {
+            createLowerTransportControlPDU((ControlMessage) message);
+        }
+    }
+
+    @Override
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
     public final void createLowerTransportAccessPDU(final AccessMessage message) {
         final byte[] upperTransportPDU = message.getUpperTransportPdu();

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NetworkLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NetworkLayer.java
@@ -64,6 +64,19 @@ public abstract class NetworkLayer extends LowerTransportLayer {
         createNetworkLayerPDU(message);
     }
 
+    /**
+     * Creates a vendor model mesh message
+     * @param message Message could be of type access or control message.
+     */
+    protected final void createVendorMeshMessage(final Message message) {
+        if(message instanceof AccessMessage) {
+            super.createVendorMeshMessage(message);
+        } else {
+            super.createVendorMeshMessage(message);
+        }
+        createNetworkLayerPDU(message);
+    }
+
     @Override
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
     public final Message createNetworkLayerPDU(final Message message) {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/UpperTransportLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/UpperTransportLayer.java
@@ -81,6 +81,18 @@ abstract class UpperTransportLayer extends AccessLayer {
     }
 
     /**
+     * Creates a vendor model mesh message containing an upper transport access pdu
+     * @param message The access message required to create the encrypted upper transport pdu
+     */
+    void createVendorMeshMessage(final Message message) { //Access message
+        super.createVendorMeshMessage(message);
+        final AccessMessage accessMessage = (AccessMessage) message;
+        final byte[] encryptedTransportPDU = encryptUpperTransportPDU(accessMessage);
+        Log.v(TAG, "Encrypted upper transport pdu: " + MeshParserUtils.bytesToHex(encryptedTransportPDU, false));
+        accessMessage.setUpperTransportPdu(encryptedTransportPDU);
+    }
+
+    /**
      * Creates the upper transport access pdu
      * @param accessMessage The access message required to create the encrypted upper transport pdu
      */

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
@@ -459,7 +459,7 @@ public class MeshParserUtils {
         if (companyIdentifier != 0xFFFF) {
             //TODO nRF Mesh SDK implementation contains a bug related to endianness of the company identifier
             //In order to get this working with the sdk you may have to switch the company identifier bytes here
-            return new byte[]{(byte) (0xC0 | (opCode & 0x3F)),  (byte) (companyIdentifier & 0xFF), (byte) ((companyIdentifier >> 8) & 0xFF)};
+            return new byte[]{(byte) (0xC0 | (opCode & 0x3F)), (byte) ((companyIdentifier >> 8) & 0xFF), (byte) (companyIdentifier & 0xFF)};
         }
         return null;
     }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
@@ -457,8 +457,9 @@ public class MeshParserUtils {
      */
     public static byte[] createVendorOpCode(final int opCode, final int companyIdentifier) {
         if (companyIdentifier != 0xFFFF) {
-            //TODO SDK implementation contains a bug related to endianness of the company identifier
-            return new byte[]{(byte) ((0b11 << 6) | (opCode & 0b111111)),  (byte) (companyIdentifier & 0xFF), (byte) ((companyIdentifier >> 8) & 0xFF)};
+            //TODO nRF Mesh SDK implementation contains a bug related to endianness of the company identifier
+            //In order to get this working with the sdk you may have to switch the company identifier bytes here
+            return new byte[]{(byte) (0xC0 | (opCode & 0x3F)),  (byte) (companyIdentifier & 0xFF), (byte) ((companyIdentifier >> 8) & 0xFF)};
         }
         return null;
     }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
@@ -459,7 +459,7 @@ public class MeshParserUtils {
         if (companyIdentifier != 0xFFFF) {
             //TODO nRF Mesh SDK implementation contains a bug related to endianness of the company identifier
             //In order to get this working with the sdk you may have to switch the company identifier bytes here
-            return new byte[]{(byte) (0xC0 | (opCode & 0x3F)), (byte) ((companyIdentifier >> 8) & 0xFF), (byte) (companyIdentifier & 0xFF)};
+            return new byte[]{(byte) (0xC0 | (opCode & 0x3F)), (byte) (companyIdentifier & 0xFF), (byte) ((companyIdentifier >> 8) & 0xFF)};
         }
         return null;
     }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
@@ -457,8 +457,8 @@ public class MeshParserUtils {
      */
     public static byte[] createVendorOpCode(final int opCode, final int companyIdentifier) {
         if (companyIdentifier != 0xFFFF) {
-            //TODO check against sdk implementation
-            return new byte[]{(byte) ((0b11 << 6) | (opCode & 0b111111)), (byte) ((companyIdentifier >> 8) & 0xFF), (byte) (companyIdentifier & 0xFF)};
+            //TODO SDK implementation contains a bug related to endianness of the company identifier
+            return new byte[]{(byte) ((0b11 << 6) | (opCode & 0b111111)),  (byte) (companyIdentifier & 0xFF), (byte) ((companyIdentifier >> 8) & 0xFF)};
         }
         return null;
     }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
@@ -447,7 +447,7 @@ public class MeshParserUtils {
     }
 
     /**
-     * Returns the length of the opcode.
+     * Returns the vendor opcode packed with company identifier
      * If the MSB = 0 then the length is 1
      * If the MSB = 1 then the length is 2
      * If the MSB = 2 then the length is 3
@@ -455,9 +455,10 @@ public class MeshParserUtils {
      * @param opCode operation code
      * @return length of opcodes
      */
-    public static byte[] getOpCodes(final int opCode, final int companyIdentifier) {
+    public static byte[] createVendorOpCode(final int opCode, final int companyIdentifier) {
         if (companyIdentifier != 0xFFFF) {
-            return new byte[]{(byte) ((0b11 << 6) | opCode), (byte) (companyIdentifier & 0x00FF), (byte) ((companyIdentifier >> 8) & 0x00FF)};
+            //TODO check against sdk implementation
+            return new byte[]{(byte) ((0b11 << 6) | (opCode & 0b111111)), (byte) ((companyIdentifier >> 8) & 0xFF), (byte) (companyIdentifier & 0xFF)};
         }
         return null;
     }


### PR DESCRIPTION
Adds api for sending basic vendor model messages. This would enable the users to test their vendor models by selecting the message type acknowledged/unacknowledged and then entering a specific opcode (without company id) and parameters.