### PR TITLE
Update mesh network state on sending unacked messages

### DIFF
--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelSetUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelSetUnacknowledgedState.java
@@ -55,8 +55,13 @@ class GenericLevelSetUnacknowledgedState extends GenericMessageState {
         Log.v(TAG, "Sending Generic Level set acknowledged ");
         super.executeSend();
         if (message.getNetworkPdu().size() > 0) {
-            if (mMeshStatusCallbacks != null)
+            if (mMeshStatusCallbacks != null) {
                 mMeshStatusCallbacks.onMeshMessageSent(mMeshMessage);
+                //We must update update the mesh network state here for unacknowledged messages
+                //If not the sequence numbers would be invalid for unacknowledged messages and will be dropped by the node.
+                //Mesh network state for acknowledged messages are updated in the DefaultNoOperationState once the status is received.
+                mInternalTransportCallbacks.updateMeshNetwork(mMeshMessage);
+            }
         }
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffSetUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffSetUnacknowledgedState.java
@@ -54,8 +54,13 @@ class GenericOnOffSetUnacknowledgedState extends GenericMessageState {
         super.executeSend();
 
         if (message.getNetworkPdu().size() > 0) {
-            if (mMeshStatusCallbacks != null)
+            if (mMeshStatusCallbacks != null) {
                 mMeshStatusCallbacks.onMeshMessageSent(mMeshMessage);
+                //We must update update the mesh network state here for unacknowledged messages
+                //If not the sequence numbers would be invalid for unacknowledged messages and will be dropped by the node.
+                //Mesh network state for acknowledged messages are updated in the DefaultNoOperationState once the status is received.
+                mInternalTransportCallbacks.updateMeshNetwork(mMeshMessage);
+            }
         }
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlSetUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlSetUnacknowledgedState.java
@@ -54,8 +54,13 @@ class LightCtlSetUnacknowledgedState extends GenericMessageState implements Lowe
         Log.v(TAG, "Sending light ctl set acknowledged ");
         super.executeSend();
         if (message.getNetworkPdu().size() > 0) {
-            if (mMeshStatusCallbacks != null)
+            if (mMeshStatusCallbacks != null) {
                 mMeshStatusCallbacks.onMeshMessageSent(mMeshMessage);
+                //We must update update the mesh network state here for unacknowledged messages
+                //If not the sequence numbers would be invalid for unacknowledged messages and will be dropped by the node.
+                //Mesh network state for acknowledged messages are updated in the DefaultNoOperationState once the status is received.
+                mInternalTransportCallbacks.updateMeshNetwork(mMeshMessage);
+            }
         }
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslSetUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslSetUnacknowledgedState.java
@@ -54,8 +54,13 @@ class LightHslSetUnacknowledgedState extends GenericMessageState implements Lowe
         Log.v(TAG, "Sending light hsl set acknowledged ");
         super.executeSend();
         if (message.getNetworkPdu().size() > 0) {
-            if (mMeshStatusCallbacks != null)
+            if (mMeshStatusCallbacks != null) {
                 mMeshStatusCallbacks.onMeshMessageSent(mMeshMessage);
+                //We must update update the mesh network state here for unacknowledged messages
+                //If not the sequence numbers would be invalid for unacknowledged messages and will be dropped by the node.
+                //Mesh network state for acknowledged messages are updated in the DefaultNoOperationState once the status is received.
+                mInternalTransportCallbacks.updateMeshNetwork(mMeshMessage);
+            }
         }
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessSetUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessSetUnacknowledgedState.java
@@ -54,8 +54,13 @@ class LightLightnessSetUnacknowledgedState extends GenericMessageState implement
         Log.v(TAG, "Sending Generic Level set acknowledged ");
         super.executeSend();
         if (message.getNetworkPdu().size() > 0) {
-            if (mMeshStatusCallbacks != null)
+            if (mMeshStatusCallbacks != null) {
                 mMeshStatusCallbacks.onMeshMessageSent(mMeshMessage);
+                //We must update update the mesh network state here for unacknowledged messages
+                //If not the sequence numbers would be invalid for unacknowledged messages and will be dropped by the node.
+                //Mesh network state for acknowledged messages are updated in the DefaultNoOperationState once the status is received.
+                mInternalTransportCallbacks.updateMeshNetwork(mMeshMessage);
+            }
         }
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneDeleteUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneDeleteUnacknowledgedState.java
@@ -53,8 +53,13 @@ class SceneDeleteUnacknowledgedState extends GenericMessageState implements Lowe
         Log.v(TAG, "Sending Scene Delete acknowledged");
         super.executeSend();
         if (message.getNetworkPdu().size() > 0) {
-            if (mMeshStatusCallbacks != null)
+            if (mMeshStatusCallbacks != null) {
                 mMeshStatusCallbacks.onMeshMessageSent(mMeshMessage);
+                //We must update update the mesh network state here for unacknowledged messages
+                //If not the sequence numbers would be invalid for unacknowledged messages and will be dropped by the node.
+                //Mesh network state for acknowledged messages are updated in the DefaultNoOperationState once the status is received.
+                mInternalTransportCallbacks.updateMeshNetwork(mMeshMessage);
+            }
         }
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRecallUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRecallUnacknowledgedState.java
@@ -53,8 +53,13 @@ class SceneRecallUnacknowledgedState extends GenericMessageState implements Lowe
         Log.v(TAG, "Sending Scene Store acknowledged");
         super.executeSend();
         if (message.getNetworkPdu().size() > 0) {
-            if (mMeshStatusCallbacks != null)
+            if (mMeshStatusCallbacks != null) {
                 mMeshStatusCallbacks.onMeshMessageSent(mMeshMessage);
+                //We must update update the mesh network state here for unacknowledged messages
+                //If not the sequence numbers would be invalid for unacknowledged messages and will be dropped by the node.
+                //Mesh network state for acknowledged messages are updated in the DefaultNoOperationState once the status is received.
+                mInternalTransportCallbacks.updateMeshNetwork(mMeshMessage);
+            }
         }
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneStoreUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneStoreUnacknowledgedState.java
@@ -53,8 +53,13 @@ class SceneStoreUnacknowledgedState extends GenericMessageState implements Lower
         Log.v(TAG, "Sending Scene Store acknowledged");
         super.executeSend();
         if (message.getNetworkPdu().size() > 0) {
-            if (mMeshStatusCallbacks != null)
+            if (mMeshStatusCallbacks != null) {
                 mMeshStatusCallbacks.onMeshMessageSent(mMeshMessage);
+                //We must update update the mesh network state here for unacknowledged messages
+                //If not the sequence numbers would be invalid for unacknowledged messages and will be dropped by the node.
+                //Mesh network state for acknowledged messages are updated in the DefaultNoOperationState once the status is received.
+                mInternalTransportCallbacks.updateMeshNetwork(mMeshMessage);
+            }
         }
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageUnackedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageUnackedState.java
@@ -53,8 +53,13 @@ class VendorModelMessageUnackedState extends GenericMessageState {
         Log.v(TAG, "Sending acknowledged vendor model message");
         super.executeSend();
         if (message.getNetworkPdu().size() > 0) {
-            if (mMeshStatusCallbacks != null)
+            if (mMeshStatusCallbacks != null) {
                 mMeshStatusCallbacks.onMeshMessageSent(mMeshMessage);
+                //We must update update the mesh network state here for unacknowledged messages
+                //If not the sequence numbers would be invalid for unacknowledged messages and will be dropped by the node.
+                //Mesh network state for acknowledged messages are updated in the DefaultNoOperationState once the status is received.
+                mInternalTransportCallbacks.updateMeshNetwork(mMeshMessage);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes a bug causing unacknowledged messages to fail due to network state not being updated after sending unacknowledged messages