### PR TITLE
Bugfix/save sequence number for all outgoing messsages #113

### DIFF
--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/InternalTransportCallbacks.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/InternalTransportCallbacks.java
@@ -41,16 +41,16 @@ public interface InternalTransportCallbacks {
 
     /**
      * Send mesh pdu
-     *
      * @param meshNode mesh node to send to
      * @param pdu      mesh pdu to be sent
      */
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
     void sendMeshPdu(final ProvisionedMeshNode meshNode, final byte[] pdu);
 
     /**
-     * Update mesh node
+     * Update mesh network
      *
-     * @param message
+     * @param message mesh message
      */
     void updateMeshNetwork(final MeshMessage message);
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelSetUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelSetUnacknowledgedState.java
@@ -57,10 +57,6 @@ class GenericLevelSetUnacknowledgedState extends GenericMessageState {
         if (message.getNetworkPdu().size() > 0) {
             if (mMeshStatusCallbacks != null) {
                 mMeshStatusCallbacks.onMeshMessageSent(mMeshMessage);
-                //We must update update the mesh network state here for unacknowledged messages
-                //If not the sequence numbers would be invalid for unacknowledged messages and will be dropped by the node.
-                //Mesh network state for acknowledged messages are updated in the DefaultNoOperationState once the status is received.
-                mInternalTransportCallbacks.updateMeshNetwork(mMeshMessage);
             }
         }
     }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffSetUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffSetUnacknowledgedState.java
@@ -56,10 +56,6 @@ class GenericOnOffSetUnacknowledgedState extends GenericMessageState {
         if (message.getNetworkPdu().size() > 0) {
             if (mMeshStatusCallbacks != null) {
                 mMeshStatusCallbacks.onMeshMessageSent(mMeshMessage);
-                //We must update update the mesh network state here for unacknowledged messages
-                //If not the sequence numbers would be invalid for unacknowledged messages and will be dropped by the node.
-                //Mesh network state for acknowledged messages are updated in the DefaultNoOperationState once the status is received.
-                mInternalTransportCallbacks.updateMeshNetwork(mMeshMessage);
             }
         }
     }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlSetUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlSetUnacknowledgedState.java
@@ -56,10 +56,6 @@ class LightCtlSetUnacknowledgedState extends GenericMessageState implements Lowe
         if (message.getNetworkPdu().size() > 0) {
             if (mMeshStatusCallbacks != null) {
                 mMeshStatusCallbacks.onMeshMessageSent(mMeshMessage);
-                //We must update update the mesh network state here for unacknowledged messages
-                //If not the sequence numbers would be invalid for unacknowledged messages and will be dropped by the node.
-                //Mesh network state for acknowledged messages are updated in the DefaultNoOperationState once the status is received.
-                mInternalTransportCallbacks.updateMeshNetwork(mMeshMessage);
             }
         }
     }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslSetUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslSetUnacknowledgedState.java
@@ -56,10 +56,6 @@ class LightHslSetUnacknowledgedState extends GenericMessageState implements Lowe
         if (message.getNetworkPdu().size() > 0) {
             if (mMeshStatusCallbacks != null) {
                 mMeshStatusCallbacks.onMeshMessageSent(mMeshMessage);
-                //We must update update the mesh network state here for unacknowledged messages
-                //If not the sequence numbers would be invalid for unacknowledged messages and will be dropped by the node.
-                //Mesh network state for acknowledged messages are updated in the DefaultNoOperationState once the status is received.
-                mInternalTransportCallbacks.updateMeshNetwork(mMeshMessage);
             }
         }
     }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessSetUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessSetUnacknowledgedState.java
@@ -56,10 +56,6 @@ class LightLightnessSetUnacknowledgedState extends GenericMessageState implement
         if (message.getNetworkPdu().size() > 0) {
             if (mMeshStatusCallbacks != null) {
                 mMeshStatusCallbacks.onMeshMessageSent(mMeshMessage);
-                //We must update update the mesh network state here for unacknowledged messages
-                //If not the sequence numbers would be invalid for unacknowledged messages and will be dropped by the node.
-                //Mesh network state for acknowledged messages are updated in the DefaultNoOperationState once the status is received.
-                mInternalTransportCallbacks.updateMeshNetwork(mMeshMessage);
             }
         }
     }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneDeleteUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneDeleteUnacknowledgedState.java
@@ -55,10 +55,6 @@ class SceneDeleteUnacknowledgedState extends GenericMessageState implements Lowe
         if (message.getNetworkPdu().size() > 0) {
             if (mMeshStatusCallbacks != null) {
                 mMeshStatusCallbacks.onMeshMessageSent(mMeshMessage);
-                //We must update update the mesh network state here for unacknowledged messages
-                //If not the sequence numbers would be invalid for unacknowledged messages and will be dropped by the node.
-                //Mesh network state for acknowledged messages are updated in the DefaultNoOperationState once the status is received.
-                mInternalTransportCallbacks.updateMeshNetwork(mMeshMessage);
             }
         }
     }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRecallUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRecallUnacknowledgedState.java
@@ -55,10 +55,6 @@ class SceneRecallUnacknowledgedState extends GenericMessageState implements Lowe
         if (message.getNetworkPdu().size() > 0) {
             if (mMeshStatusCallbacks != null) {
                 mMeshStatusCallbacks.onMeshMessageSent(mMeshMessage);
-                //We must update update the mesh network state here for unacknowledged messages
-                //If not the sequence numbers would be invalid for unacknowledged messages and will be dropped by the node.
-                //Mesh network state for acknowledged messages are updated in the DefaultNoOperationState once the status is received.
-                mInternalTransportCallbacks.updateMeshNetwork(mMeshMessage);
             }
         }
     }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneStoreUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneStoreUnacknowledgedState.java
@@ -55,10 +55,6 @@ class SceneStoreUnacknowledgedState extends GenericMessageState implements Lower
         if (message.getNetworkPdu().size() > 0) {
             if (mMeshStatusCallbacks != null) {
                 mMeshStatusCallbacks.onMeshMessageSent(mMeshMessage);
-                //We must update update the mesh network state here for unacknowledged messages
-                //If not the sequence numbers would be invalid for unacknowledged messages and will be dropped by the node.
-                //Mesh network state for acknowledged messages are updated in the DefaultNoOperationState once the status is received.
-                mInternalTransportCallbacks.updateMeshNetwork(mMeshMessage);
             }
         }
     }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageUnackedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageUnackedState.java
@@ -55,10 +55,6 @@ class VendorModelMessageUnackedState extends GenericMessageState {
         if (message.getNetworkPdu().size() > 0) {
             if (mMeshStatusCallbacks != null) {
                 mMeshStatusCallbacks.onMeshMessageSent(mMeshMessage);
-                //We must update update the mesh network state here for unacknowledged messages
-                //If not the sequence numbers would be invalid for unacknowledged messages and will be dropped by the node.
-                //Mesh network state for acknowledged messages are updated in the DefaultNoOperationState once the status is received.
-                mInternalTransportCallbacks.updateMeshNetwork(mMeshMessage);
             }
         }
     }


### PR DESCRIPTION
* Fixes #113 
  - Saves the sequence numbers for every out going messages. Previously the sequence number was saved only for all outgoing unacknowledged messages and all incoming status messages for acknowledged messages. This was causing certain messages to be lost of dropped due to the use of invalid sequence numbers.