### PR TITLE
Bugfix/config relay set params #115

### DIFF
--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ConfigurationServerActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ConfigurationServerActivity.java
@@ -195,7 +195,7 @@ public class ConfigurationServerActivity extends BaseModelConfigurationActivity 
                     relaySettings.getRelayTransmitCount(),
                     relaySettings.getTotalTransmissionsCount()));
             mRelayRetransmitIntervalStepsText.setText(getString(R.string.text_network_transmit_interval_steps,
-                    relaySettings.getRelayIntervalSteps()));
+                    relaySettings.getRetransmissionIntervals()));
         } else {
             mActionSetRelayState.setEnabled(false);
             mRelayRetransmitCountText.setText(getResources().getString(R.string.unknown));

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigRelaySet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigRelaySet.java
@@ -77,7 +77,7 @@ public final class ConfigRelaySet extends ConfigMessage {
     @Override
     final void assembleMessageParameters() {
         mParameters = new byte[]{(byte) mRelay,
-                (byte) (((mRelayRetransmitIntervalSteps << 3) & 0xFF) | (mRelayRetransmitCount & 0xFF))};
+                (byte) (((mRelayRetransmitCount << 3) & 0xFF) | (mRelayRetransmitIntervalSteps & 0xFF))};
     }
 
     @Override

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigRelayStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigRelayStatus.java
@@ -26,6 +26,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
+import android.util.Log;
 
 import no.nordicsemi.android.meshprovisioner.opcodes.ConfigMessageOpCodes;
 import no.nordicsemi.android.meshprovisioner.utils.RelaySettings;
@@ -82,6 +83,9 @@ public final class ConfigRelayStatus extends ConfigStatusMessage implements Parc
         mRelay = payload[2];
         mRelayRetransmitCount = payload[3] & 0b111;
         mRelayRetransmitIntervalSteps = (payload[3] >> 3) & 0b11111;
+        Log.d(TAG, "Relay: " + mRelay);
+        Log.d(TAG, "Retransmit count: " + mRelayRetransmitCount);
+        Log.d(TAG, "Retransmit Interval steps: " + mRelayRetransmitIntervalSteps);
     }
 
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NodeDeserializer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NodeDeserializer.java
@@ -58,10 +58,10 @@ public final class NodeDeserializer implements JsonSerializer<List<ProvisionedMe
 
             if (jsonObject.has("features")) {
                 final JsonObject featuresJson = jsonObject.get("features").getAsJsonObject();
-                node.nodeFeatures = new Features(featuresJson.get("relay").getAsInt(),
-                        featuresJson.get("proxy").getAsInt(),
-                        featuresJson.get("friend").getAsInt(),
-                        featuresJson.get("lowPower").getAsInt());
+                node.nodeFeatures = new Features(featuresJson.get("friend").getAsInt(),
+                        featuresJson.get("lowPower").getAsInt(),
+                        featuresJson.get("relay").getAsInt(),
+                        featuresJson.get("proxy").getAsInt());
             }
 
             if (jsonObject.has("secureNetworkBeacon")) {
@@ -89,7 +89,7 @@ public final class NodeDeserializer implements JsonSerializer<List<ProvisionedMe
             if (jsonObject.has("appKeys"))
                 node.mAddedAppKeyIndexes = deserializeAppKeyIndexes(jsonObject.get("appKeys").getAsJsonArray());
 
-            if(jsonObject.has("elements")) {
+            if (jsonObject.has("elements")) {
                 final List<Element> elements = deserializeElements(context, jsonObject);
                 final Map<Integer, Element> elementMap = populateElements(unicastAddress, elements);
                 node.mElements.clear();


### PR DESCRIPTION
* Fixes #115 
  - Fixes a bug causing the ConfigRelaySet to send retransmission count and interval steps to be swapped
  - Fixes a bug in the ConfigurationServerModel UI displaying interval steps
* Fixes an additional issue causing the node features to be parsed incorrectly