### PR TITLE
(fix) renamed function not updated in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See example projects in this repository.
 To start using the library in your own project take a look at the followign snippet.
 ```java
         MeshManagerApi mMeshManagerApi = new MeshManagerApi(context);
-        mMeshManagerApi.setProvisionerManagerTransportCallbacks(this);
+        mMeshManagerApi.setMeshManagerCallbacks(this);
         mMeshManagerApi.setProvisioningStatusCallbacks(this);
         mMeshManagerApi.setMeshStatusCallbacks(this);
         mMeshManagerApi.loadMeshNetwork();

--- a/android-nrf-mesh-library/meshprovisioner/build.gradle
+++ b/android-nrf-mesh-library/meshprovisioner/build.gradle
@@ -60,15 +60,15 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.6.3'
     androidTestImplementation 'org.mockito:mockito-android:2.6.3'
-    implementation 'com.android.support:support-annotations:28.0.0'
+    implementation 'androidx.annotation:annotation:1.0.0-beta01'
     api 'no.nordicsemi.android:log:2.1.1'
     // Spongycastle - Android implementation of Bouncy Castle
     implementation 'com.madgag.spongycastle:core:1.56.0.0'
     implementation 'com.madgag.spongycastle:prov:1.56.0.0'
     implementation 'com.google.code.gson:gson:2.8.5'
 
-    implementation "android.arch.persistence.room:runtime:1.1.1"
-    annotationProcessor "android.arch.persistence.room:compiler:1.1.1"
-    androidTestImplementation "android.arch.persistence.room:testing:1.1.1"
+    implementation 'androidx.room:room-runtime:2.0.0-beta01'
+    annotationProcessor 'androidx.room:room-compiler:2.0.0-beta01'
+    androidTestImplementation 'androidx.room:room-testing:2.0.0-beta01'
 
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/AllocatedGroupRange.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/AllocatedGroupRange.java
@@ -1,15 +1,15 @@
 package no.nordicsemi.android.meshprovisioner;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.ForeignKey;
-import android.arch.persistence.room.Ignore;
-import android.arch.persistence.room.Index;
-import android.arch.persistence.room.PrimaryKey;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.ForeignKey;
+import androidx.room.Ignore;
+import androidx.room.Index;
+import androidx.room.PrimaryKey;
 
 import com.google.gson.annotations.Expose;
 
-import static android.arch.persistence.room.ForeignKey.CASCADE;
+import static androidx.room.ForeignKey.CASCADE;
 
 /**
  * Class definition for allocating group range for provisioners.

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/AllocatedSceneRange.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/AllocatedSceneRange.java
@@ -1,15 +1,15 @@
 package no.nordicsemi.android.meshprovisioner;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.ForeignKey;
-import android.arch.persistence.room.Ignore;
-import android.arch.persistence.room.Index;
-import android.arch.persistence.room.PrimaryKey;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.ForeignKey;
+import androidx.room.Ignore;
+import androidx.room.Index;
+import androidx.room.PrimaryKey;
 
 import com.google.gson.annotations.Expose;
 
-import static android.arch.persistence.room.ForeignKey.CASCADE;
+import static androidx.room.ForeignKey.CASCADE;
 
 /**
  * Class definition for allocating group range for provisioners.

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/AllocatedUnicastRange.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/AllocatedUnicastRange.java
@@ -1,15 +1,15 @@
 package no.nordicsemi.android.meshprovisioner;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.ForeignKey;
-import android.arch.persistence.room.Ignore;
-import android.arch.persistence.room.Index;
-import android.arch.persistence.room.PrimaryKey;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.ForeignKey;
+import androidx.room.Ignore;
+import androidx.room.Index;
+import androidx.room.PrimaryKey;
 
 import com.google.gson.annotations.Expose;
 
-import static android.arch.persistence.room.ForeignKey.CASCADE;
+import static androidx.room.ForeignKey.CASCADE;
 
 /**
  * Class definition for allocating unicast range for provisioners.

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNetwork.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNetwork.java
@@ -1,11 +1,11 @@
 package no.nordicsemi.android.meshprovisioner;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Ignore;
-import android.arch.persistence.room.PrimaryKey;
-import android.support.annotation.IntDef;
-import android.support.annotation.NonNull;
-import android.support.annotation.RestrictTo;
+import androidx.room.ColumnInfo;
+import androidx.room.Ignore;
+import androidx.room.PrimaryKey;
+import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/Features.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/Features.java
@@ -3,7 +3,7 @@ package no.nordicsemi.android.meshprovisioner;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.IntDef;
+import androidx.annotation.IntDef;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/Group.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/Group.java
@@ -1,20 +1,20 @@
 package no.nordicsemi.android.meshprovisioner;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.ForeignKey;
-import android.arch.persistence.room.Index;
-import android.arch.persistence.room.PrimaryKey;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.RestrictTo;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.ForeignKey;
+import androidx.room.Index;
+import androidx.room.PrimaryKey;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
 
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
 import java.util.Arrays;
 
-import static android.arch.persistence.room.ForeignKey.CASCADE;
+import static androidx.room.ForeignKey.CASCADE;
 
 /**
  * Defines a group in a mesh network

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/InternalProvisioningCallbacks.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/InternalProvisioningCallbacks.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner;
 
-import android.support.annotation.RestrictTo;
+import androidx.annotation.RestrictTo;
 
 /**
  * Internal provisioning callbacks

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/InternalTransportCallbacks.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/InternalTransportCallbacks.java
@@ -22,7 +22,7 @@
 
 package no.nordicsemi.android.meshprovisioner;
 
-import android.support.annotation.RestrictTo;
+import androidx.annotation.RestrictTo;
 
 import no.nordicsemi.android.meshprovisioner.provisionerstates.UnprovisionedMeshNode;
 import no.nordicsemi.android.meshprovisioner.transport.MeshMessage;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshBeacon.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshBeacon.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner;
 
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Abstract class containing mesh beacon information

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
@@ -25,8 +25,8 @@ package no.nordicsemi.android.meshprovisioner;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Handler;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import com.google.gson.Gson;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshMngrApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshMngrApi.java
@@ -1,22 +1,14 @@
 package no.nordicsemi.android.meshprovisioner;
 
 import android.net.Uri;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import java.util.UUID;
 
 import no.nordicsemi.android.meshprovisioner.provisionerstates.UnprovisionedMeshNode;
-import no.nordicsemi.android.meshprovisioner.transport.GenericLevelGet;
-import no.nordicsemi.android.meshprovisioner.transport.GenericLevelSet;
-import no.nordicsemi.android.meshprovisioner.transport.GenericLevelSetUnacknowledged;
-import no.nordicsemi.android.meshprovisioner.transport.GenericOnOffGet;
-import no.nordicsemi.android.meshprovisioner.transport.GenericOnOffSet;
-import no.nordicsemi.android.meshprovisioner.transport.GenericOnOffSetUnacknowledged;
 import no.nordicsemi.android.meshprovisioner.transport.MeshMessage;
 import no.nordicsemi.android.meshprovisioner.transport.ProvisionedMeshNode;
-import no.nordicsemi.android.meshprovisioner.transport.VendorModelMessageAcked;
-import no.nordicsemi.android.meshprovisioner.transport.VendorModelMessageUnacked;
 
 @SuppressWarnings("unused")
 interface MeshMngrApi {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshNetwork.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshNetwork.java
@@ -1,10 +1,9 @@
 
 package no.nordicsemi.android.meshprovisioner;
 
-import android.arch.persistence.room.Entity;
-import android.support.annotation.RestrictTo;
+import androidx.room.Entity;
+import androidx.annotation.RestrictTo;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshNetworkDb.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshNetworkDb.java
@@ -1,18 +1,16 @@
 package no.nordicsemi.android.meshprovisioner;
 
-import android.arch.persistence.db.SupportSQLiteDatabase;
-import android.arch.persistence.room.Database;
-import android.arch.persistence.room.Room;
-import android.arch.persistence.room.RoomDatabase;
+import androidx.sqlite.db.SupportSQLiteDatabase;
+import androidx.room.Database;
+import androidx.room.Room;
+import androidx.room.RoomDatabase;
 import android.content.Context;
 import android.os.AsyncTask;
-import android.support.annotation.NonNull;
-import android.support.annotation.RestrictTo;
+import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Locale;
-import java.util.UUID;
 
 import no.nordicsemi.android.meshprovisioner.data.ApplicationKeyDao;
 import no.nordicsemi.android.meshprovisioner.data.GroupDao;
@@ -27,7 +25,6 @@ import no.nordicsemi.android.meshprovisioner.data.ScenesDao;
 import no.nordicsemi.android.meshprovisioner.transport.ApplicationKey;
 import no.nordicsemi.android.meshprovisioner.transport.NetworkKey;
 import no.nordicsemi.android.meshprovisioner.transport.ProvisionedMeshNode;
-import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 @SuppressWarnings("unused")

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshProvisioningHandler.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshProvisioningHandler.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.meshprovisioner;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 import java.util.UUID;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/Provisioner.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/Provisioner.java
@@ -1,15 +1,15 @@
 package no.nordicsemi.android.meshprovisioner;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.ForeignKey;
-import android.arch.persistence.room.Ignore;
-import android.arch.persistence.room.Index;
-import android.arch.persistence.room.PrimaryKey;
-import android.arch.persistence.room.TypeConverters;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.RestrictTo;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.ForeignKey;
+import androidx.room.Ignore;
+import androidx.room.Index;
+import androidx.room.PrimaryKey;
+import androidx.room.TypeConverters;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
 
 import com.google.gson.annotations.Expose;
 
@@ -17,7 +17,7 @@ import java.util.List;
 
 import no.nordicsemi.android.meshprovisioner.utils.MeshTypeConverters;
 
-import static android.arch.persistence.room.ForeignKey.CASCADE;
+import static androidx.room.ForeignKey.CASCADE;
 
 /**
  * Class definition of a Provisioner of mesh network

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/Scene.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/Scene.java
@@ -1,24 +1,19 @@
 package no.nordicsemi.android.meshprovisioner;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Embedded;
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.ForeignKey;
-import android.arch.persistence.room.Ignore;
-import android.arch.persistence.room.Index;
-import android.arch.persistence.room.PrimaryKey;
-import android.arch.persistence.room.TypeConverter;
-import android.arch.persistence.room.TypeConverters;
-import android.support.annotation.RestrictTo;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.ForeignKey;
+import androidx.room.Index;
+import androidx.room.PrimaryKey;
+import androidx.room.TypeConverters;
 
 import com.google.gson.annotations.Expose;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import no.nordicsemi.android.meshprovisioner.utils.MeshTypeConverters;
 
-import static android.arch.persistence.room.ForeignKey.CASCADE;
+import static androidx.room.ForeignKey.CASCADE;
 
 /**
  * Class definitions for creating scenes in a mesh network

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/SecureNetworkBeacon.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/SecureNetworkBeacon.java
@@ -2,7 +2,7 @@ package no.nordicsemi.android.meshprovisioner;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/UnprovisionedBeacon.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/UnprovisionedBeacon.java
@@ -2,7 +2,7 @@ package no.nordicsemi.android.meshprovisioner;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 import java.util.UUID;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/ApplicationKeyDao.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/ApplicationKeyDao.java
@@ -1,12 +1,12 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Delete;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.OnConflictStrategy;
-import android.arch.persistence.room.Query;
-import android.arch.persistence.room.Update;
-import android.support.annotation.RestrictTo;
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+import androidx.room.Update;
+import androidx.annotation.RestrictTo;
 
 import java.util.List;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/ApplicationKeys.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/ApplicationKeys.java
@@ -1,12 +1,11 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Relation;
+import androidx.room.Relation;
 
 import java.util.List;
 
 import no.nordicsemi.android.meshprovisioner.MeshNetwork;
 import no.nordicsemi.android.meshprovisioner.transport.ApplicationKey;
-import no.nordicsemi.android.meshprovisioner.transport.NetworkKey;
 
 @SuppressWarnings("unused")
 class ApplicationKeys {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/ApplicationKeysDao.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/ApplicationKeysDao.java
@@ -1,8 +1,8 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Query;
-import android.support.annotation.RestrictTo;
+import androidx.room.Dao;
+import androidx.room.Query;
+import androidx.annotation.RestrictTo;
 
 import java.util.List;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/GroupDao.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/GroupDao.java
@@ -1,12 +1,12 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Delete;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.OnConflictStrategy;
-import android.arch.persistence.room.Query;
-import android.arch.persistence.room.Update;
-import android.support.annotation.RestrictTo;
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+import androidx.room.Update;
+import androidx.annotation.RestrictTo;
 
 import java.util.List;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/Groups.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/Groups.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Relation;
+import androidx.room.Relation;
 
 import java.util.List;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/GroupsDao.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/GroupsDao.java
@@ -1,9 +1,8 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.Query;
-import android.support.annotation.RestrictTo;
+import androidx.room.Dao;
+import androidx.room.Query;
+import androidx.annotation.RestrictTo;
 
 import java.util.List;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/MeshNetworkDao.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/MeshNetworkDao.java
@@ -1,12 +1,12 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Delete;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.OnConflictStrategy;
-import android.arch.persistence.room.Query;
-import android.arch.persistence.room.Update;
-import android.support.annotation.RestrictTo;
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+import androidx.room.Update;
+import androidx.annotation.RestrictTo;
 
 import java.util.List;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/NetworKeysDao.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/NetworKeysDao.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Query;
-import android.support.annotation.RestrictTo;
+import androidx.room.Query;
+import androidx.annotation.RestrictTo;
 
 import java.util.List;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/NetworkKeyDao.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/NetworkKeyDao.java
@@ -1,11 +1,11 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Delete;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.OnConflictStrategy;
-import android.arch.persistence.room.Query;
-import android.arch.persistence.room.Update;
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+import androidx.room.Update;
 
 import java.util.List;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/NetworkKeys.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/NetworkKeys.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Relation;
+import androidx.room.Relation;
 
 import java.util.List;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/ProvisionedMeshNodeDao.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/ProvisionedMeshNodeDao.java
@@ -1,16 +1,15 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Delete;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.OnConflictStrategy;
-import android.arch.persistence.room.Query;
-import android.arch.persistence.room.Update;
-import android.support.annotation.RestrictTo;
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+import androidx.room.Update;
+import androidx.annotation.RestrictTo;
 
 import java.util.List;
 
-import no.nordicsemi.android.meshprovisioner.MeshNetwork;
 import no.nordicsemi.android.meshprovisioner.transport.ProvisionedMeshNode;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/ProvisionedMeshNodes.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/ProvisionedMeshNodes.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Relation;
+import androidx.room.Relation;
 
 import java.util.List;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/ProvisionedMeshNodesDao.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/ProvisionedMeshNodesDao.java
@@ -1,9 +1,8 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.Query;
-import android.support.annotation.RestrictTo;
+import androidx.room.Dao;
+import androidx.room.Query;
+import androidx.annotation.RestrictTo;
 
 import java.util.List;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/ProvisionerDao.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/ProvisionerDao.java
@@ -1,17 +1,16 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Delete;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.OnConflictStrategy;
-import android.arch.persistence.room.Query;
-import android.arch.persistence.room.Update;
-import android.support.annotation.RestrictTo;
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+import androidx.room.Update;
+import androidx.annotation.RestrictTo;
 
 import java.util.List;
 
 import no.nordicsemi.android.meshprovisioner.Provisioner;
-import no.nordicsemi.android.meshprovisioner.transport.ProvisionedMeshNode;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 @SuppressWarnings("unused")

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/Provisioners.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/Provisioners.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Relation;
+import androidx.room.Relation;
 
 import java.util.List;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/ProvisionersDao.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/ProvisionersDao.java
@@ -1,8 +1,8 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Query;
-import android.support.annotation.RestrictTo;
+import androidx.room.Dao;
+import androidx.room.Query;
+import androidx.annotation.RestrictTo;
 
 import java.util.List;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/SceneDao.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/SceneDao.java
@@ -1,12 +1,12 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Delete;
-import android.arch.persistence.room.Insert;
-import android.arch.persistence.room.OnConflictStrategy;
-import android.arch.persistence.room.Query;
-import android.arch.persistence.room.Update;
-import android.support.annotation.RestrictTo;
+import androidx.room.Dao;
+import androidx.room.Delete;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+import androidx.room.Update;
+import androidx.annotation.RestrictTo;
 
 import java.util.List;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/Scenes.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/Scenes.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Relation;
+import androidx.room.Relation;
 
 import java.util.List;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/ScenesDao.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/data/ScenesDao.java
@@ -1,8 +1,8 @@
 package no.nordicsemi.android.meshprovisioner.data;
 
-import android.arch.persistence.room.Dao;
-import android.arch.persistence.room.Query;
-import android.support.annotation.RestrictTo;
+import androidx.room.Dao;
+import androidx.room.Query;
+import androidx.annotation.RestrictTo;
 
 import java.util.List;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/AccessLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/AccessLayer.java
@@ -24,7 +24,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
 import android.os.Handler;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.VisibleForTesting;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ApplicationKey.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ApplicationKey.java
@@ -1,20 +1,20 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.ForeignKey;
-import android.arch.persistence.room.Index;
-import android.arch.persistence.room.PrimaryKey;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.ForeignKey;
+import androidx.room.Index;
+import androidx.room.PrimaryKey;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
-import android.support.annotation.RestrictTo;
+import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
 
 import com.google.gson.annotations.Expose;
 
 import no.nordicsemi.android.meshprovisioner.MeshNetwork;
 
-import static android.arch.persistence.room.ForeignKey.CASCADE;
+import static androidx.room.ForeignKey.CASCADE;
 
 /**
  * Wrapper class for application key

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/BaseMeshMessageHandler.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/BaseMeshMessageHandler.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import no.nordicsemi.android.meshprovisioner.InternalTransportCallbacks;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigAppKeyAdd.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigAppKeyAdd.java
@@ -22,7 +22,7 @@
 
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigAppKeyAddState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigAppKeyAddState.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigAppKeyStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigAppKeyStatus.java
@@ -24,7 +24,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigCompositionDataGetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigCompositionDataGetState.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 class ConfigCompositionDataGetState extends ConfigMessageState {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigCompositionDataStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigCompositionDataStatus.java
@@ -24,7 +24,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigMessageState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigMessageState.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 abstract class ConfigMessageState extends MeshMessageState {
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelAppBind.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelAppBind.java
@@ -22,7 +22,7 @@
 
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelAppBindState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelAppBindState.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelAppStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelAppStatus.java
@@ -24,7 +24,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelAppUnbindState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelAppUnbindState.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelPublicationSet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelPublicationSet.java
@@ -22,7 +22,7 @@
 
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelPublicationSetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelPublicationSetState.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelPublicationStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelPublicationStatus.java
@@ -24,7 +24,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelSubscriptionAdd.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelSubscriptionAdd.java
@@ -22,7 +22,7 @@
 
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelSubscriptionAddState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelSubscriptionAddState.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelSubscriptionDelete.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelSubscriptionDelete.java
@@ -22,7 +22,7 @@
 
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelSubscriptionDeleteState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelSubscriptionDeleteState.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelSubscriptionStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelSubscriptionStatus.java
@@ -24,7 +24,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigNetworkTransmitGetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigNetworkTransmitGetState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 public final class ConfigNetworkTransmitGetState extends ConfigMessageState {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigNetworkTransmitSetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigNetworkTransmitSetState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigNetworkTransmitStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigNetworkTransmitStatus.java
@@ -25,7 +25,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import no.nordicsemi.android.meshprovisioner.opcodes.ConfigMessageOpCodes;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigNodeResetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigNodeResetState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigNodeResetStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigNodeResetStatus.java
@@ -24,7 +24,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import no.nordicsemi.android.meshprovisioner.opcodes.ConfigMessageOpCodes;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigProxyGetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigProxyGetState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigProxySet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigProxySet.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 
-import android.support.annotation.IntDef;
+import androidx.annotation.IntDef;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigProxySetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigProxySetState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigProxyStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigProxyStatus.java
@@ -25,7 +25,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import no.nordicsemi.android.meshprovisioner.opcodes.ConfigMessageOpCodes;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigRelayGetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigRelayGetState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigRelaySetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigRelaySetState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigRelayStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigRelayStatus.java
@@ -25,7 +25,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import no.nordicsemi.android.meshprovisioner.opcodes.ConfigMessageOpCodes;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigStatusMessage.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigStatusMessage.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import static no.nordicsemi.android.meshprovisioner.transport.ConfigStatusMessage.StatusCodeNames.fromStatusCode;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/DefaultNoOperationMessageState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/DefaultNoOperationMessageState.java
@@ -1,11 +1,9 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
-
-import org.spongycastle.crypto.InvalidCipherTextException;
 
 import java.util.ArrayList;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/Element.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/Element.java
@@ -24,7 +24,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.google.gson.annotations.Expose;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelGet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelGet.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import no.nordicsemi.android.meshprovisioner.opcodes.ApplicationMessageOpCodes;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelGetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelGetState.java
@@ -2,7 +2,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelSet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelSet.java
@@ -1,8 +1,8 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelSetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelSetState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelSetUnacknowledged.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelSetUnacknowledged.java
@@ -1,8 +1,8 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelSetUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelSetUnacknowledgedState.java
@@ -2,7 +2,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelStatus.java
@@ -24,7 +24,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericMessage.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericMessage.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 abstract class GenericMessage extends MeshMessage {
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericMessageState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericMessageState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Abstract state class that handles Generic Message States

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffGet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffGet.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import no.nordicsemi.android.meshprovisioner.opcodes.ApplicationMessageOpCodes;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffGetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffGetState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffSet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffSet.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffSetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffSetState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffSetUnacknowledged.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffSetUnacknowledged.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffSetUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffSetUnacknowledgedState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffStatus.java
@@ -24,7 +24,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericStatusMessage.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericStatusMessage.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlGet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlGet.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import no.nordicsemi.android.meshprovisioner.opcodes.ApplicationMessageOpCodes;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlGetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlGetState.java
@@ -2,7 +2,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlSet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlSet.java
@@ -1,8 +1,8 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlSetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlSetState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlSetUnacknowledged.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlSetUnacknowledged.java
@@ -1,8 +1,8 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlSetUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlSetUnacknowledgedState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlStatus.java
@@ -24,7 +24,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslGet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslGet.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import no.nordicsemi.android.meshprovisioner.opcodes.ApplicationMessageOpCodes;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslGetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslGetState.java
@@ -2,7 +2,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslSet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslSet.java
@@ -1,8 +1,8 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslSetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslSetState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslSetUnacknowledged.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslSetUnacknowledged.java
@@ -1,8 +1,8 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslSetUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslSetUnacknowledgedState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslStatus.java
@@ -24,7 +24,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessGet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessGet.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import no.nordicsemi.android.meshprovisioner.opcodes.ApplicationMessageOpCodes;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessGetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessGetState.java
@@ -2,7 +2,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessSet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessSet.java
@@ -1,8 +1,8 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessSetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessSetState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessSetUnacknowledged.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessSetUnacknowledged.java
@@ -1,8 +1,8 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessSetUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessSetUnacknowledgedState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessStatus.java
@@ -24,7 +24,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LowerTransportLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LowerTransportLayer.java
@@ -22,7 +22,7 @@
 
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.VisibleForTesting;
 import android.util.Log;
 import android.util.SparseArray;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshMessage.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshMessage.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Abstract wrapper class for mesh message.

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshMessageHandlerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshMessageHandlerApi.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * Mesh message handler api

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshMessageState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshMessageState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 import android.util.SparseArray;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshTransport.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshTransport.java
@@ -24,10 +24,8 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
 import android.os.Handler;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.VisibleForTesting;
 import android.util.Log;
-
-import org.spongycastle.crypto.InvalidCipherTextException;
 
 import no.nordicsemi.android.meshprovisioner.MeshManagerApi;
 import no.nordicsemi.android.meshprovisioner.Provisioner;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NetworkKey.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NetworkKey.java
@@ -1,15 +1,15 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.ForeignKey;
-import android.arch.persistence.room.Index;
-import android.arch.persistence.room.PrimaryKey;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.ForeignKey;
+import androidx.room.Index;
+import androidx.room.PrimaryKey;
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.IntDef;
-import android.support.annotation.NonNull;
-import android.support.annotation.RestrictTo;
+import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
 
 import com.google.gson.annotations.Expose;
 
@@ -18,7 +18,7 @@ import java.lang.annotation.RetentionPolicy;
 
 import no.nordicsemi.android.meshprovisioner.MeshNetwork;
 
-import static android.arch.persistence.room.ForeignKey.CASCADE;
+import static androidx.room.ForeignKey.CASCADE;
 
 /**
  * Wrapper class for network key

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NetworkLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NetworkLayer.java
@@ -21,7 +21,7 @@
  */
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.VisibleForTesting;
 import android.util.Log;
 import android.util.SparseArray;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NodeDeserializer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NodeDeserializer.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.RestrictTo;
+import androidx.annotation.RestrictTo;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonDeserializationContext;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProvisionedBaseMeshNode.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProvisionedBaseMeshNode.java
@@ -22,17 +22,17 @@
 
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.arch.persistence.room.ColumnInfo;
-import android.arch.persistence.room.Embedded;
-import android.arch.persistence.room.Ignore;
-import android.arch.persistence.room.PrimaryKey;
-import android.arch.persistence.room.TypeConverters;
+import androidx.room.ColumnInfo;
+import androidx.room.Embedded;
+import androidx.room.Ignore;
+import androidx.room.PrimaryKey;
+import androidx.room.TypeConverters;
 import android.os.Parcelable;
-import android.support.annotation.IntDef;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
-import android.support.annotation.RestrictTo;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
+import androidx.annotation.VisibleForTesting;
 import android.text.TextUtils;
 
 import com.google.gson.annotations.Expose;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProvisionedMeshNode.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProvisionedMeshNode.java
@@ -22,14 +22,14 @@
 
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.arch.persistence.room.Entity;
-import android.arch.persistence.room.ForeignKey;
-import android.arch.persistence.room.Ignore;
-import android.arch.persistence.room.Index;
+import androidx.room.Entity;
+import androidx.room.ForeignKey;
+import androidx.room.Ignore;
+import androidx.room.Index;
 import android.os.Parcel;
-import android.support.annotation.NonNull;
-import android.support.annotation.RestrictTo;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
+import androidx.annotation.VisibleForTesting;
 
 import com.google.gson.annotations.Expose;
 
@@ -51,7 +51,7 @@ import no.nordicsemi.android.meshprovisioner.utils.RelaySettings;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
 import no.nordicsemi.android.meshprovisioner.utils.SparseIntArrayParcelable;
 
-import static android.arch.persistence.room.ForeignKey.CASCADE;
+import static androidx.room.ForeignKey.CASCADE;
 
 @SuppressWarnings({"WeakerAccess", "unused", "deprecation"})
 @Entity(tableName = "nodes",

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProxyConfigAddAddressState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProxyConfigAddAddressState.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProxyConfigAddAddressToFilter.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProxyConfigAddAddressToFilter.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProxyConfigFilterStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProxyConfigFilterStatus.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import no.nordicsemi.android.meshprovisioner.opcodes.ProxyConfigMessageOpCodes;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProxyConfigMessageState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProxyConfigMessageState.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 /**
  * This generic state class handles the proxy configuration messages received or sent.

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProxyConfigRemoveAddressState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProxyConfigRemoveAddressState.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProxyConfigSetFilterTypeState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProxyConfigSetFilterTypeState.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProxyConfigStatusMessage.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProxyConfigStatusMessage.java
@@ -1,10 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
-
-import no.nordicsemi.android.meshprovisioner.opcodes.ProxyConfigMessageOpCodes;
-
-import static no.nordicsemi.android.meshprovisioner.transport.ConfigStatusMessage.StatusCodeNames.fromStatusCode;
+import androidx.annotation.NonNull;
 
 /**
  * Abstract wrapper class for mesh message.

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneDelete.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneDelete.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneDeleteState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneDeleteState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneDeleteUnacknowledged.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneDeleteUnacknowledged.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneDeleteUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneDeleteUnacknowledgedState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneGet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneGet.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import no.nordicsemi.android.meshprovisioner.opcodes.ApplicationMessageOpCodes;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneGetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneGetState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRecall.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRecall.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRecallState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRecallState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRecallUnacknowledged.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRecallUnacknowledged.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRecallUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRecallUnacknowledgedState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRegisterGet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRegisterGet.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import no.nordicsemi.android.meshprovisioner.opcodes.ApplicationMessageOpCodes;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRegisterGetState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRegisterGetState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRegisterStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRegisterStatus.java
@@ -24,7 +24,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneStatus.java
@@ -24,7 +24,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneStore.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneStore.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneStoreState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneStoreState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneStoreUnacknowledged.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneStoreUnacknowledged.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.nio.ByteBuffer;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneStoreUnacknowledgedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneStoreUnacknowledgedState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/UpperTransportLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/UpperTransportLayer.java
@@ -22,8 +22,8 @@
 
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.VisibleForTesting;
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
 import android.util.Log;
 
 import org.spongycastle.crypto.InvalidCipherTextException;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageAcked.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageAcked.java
@@ -1,6 +1,6 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageAckedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageAckedState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageStatus.java
@@ -24,7 +24,7 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageUnacked.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageUnacked.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageUnackedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageUnackedState.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 class VendorModelMessageUnackedState extends GenericMessageState {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/ConfigModelPublicationSetParams.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/ConfigModelPublicationSetParams.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.utils;
 
 
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import no.nordicsemi.android.meshprovisioner.transport.ProvisionedMeshNode;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
@@ -22,7 +22,7 @@
 package no.nordicsemi.android.meshprovisioner.utils;
 
 import android.content.Context;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.text.TextUtils;
 import android.util.SparseArray;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshTypeConverters.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshTypeConverters.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.meshprovisioner.utils;
 
-import android.arch.persistence.room.TypeConverter;
-import android.support.annotation.RestrictTo;
+import androidx.room.TypeConverter;
+import androidx.annotation.RestrictTo;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/ProxyFilter.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/ProxyFilter.java
@@ -2,7 +2,7 @@ package no.nordicsemi.android.meshprovisioner.utils;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/ProxyFilterType.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/ProxyFilterType.java
@@ -2,7 +2,7 @@ package no.nordicsemi.android.meshprovisioner.utils;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.IntDef;
+import androidx.annotation.IntDef;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/RelaySettings.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/RelaySettings.java
@@ -2,12 +2,11 @@ package no.nordicsemi.android.meshprovisioner.utils;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.IntDef;
+import androidx.annotation.IntDef;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 
-import no.nordicsemi.android.meshprovisioner.transport.ConfigRelaySet;
 import no.nordicsemi.android.meshprovisioner.transport.ProvisionedMeshNode;
 
 /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/SecureUtils.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/SecureUtils.java
@@ -24,7 +24,7 @@ package no.nordicsemi.android.meshprovisioner.utils;
 
 import android.os.Parcel;
 import android.os.Parcelable;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 import android.util.Log;
 
 import com.google.gson.annotations.Expose;


### PR DESCRIPTION
The function setProvisionerManagerTransportCallbacks has been renamed here :
https://github.com/NordicSemiconductor/Android-nRF-Mesh-Library/commit/3008411774deb06aa43d8bd8a4685639b44f931d#diff-6d08543303f34c8618b9b9b00a0922ddR177

But the README was not updated to use setMeshManagerCallbacks.