### PR TITLE
(fix) renamed function not updated in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ See example projects in this repository.
 To start using the library in your own project take a look at the followign snippet.
 ```java
         MeshManagerApi mMeshManagerApi = new MeshManagerApi(context);
-        mMeshManagerApi.setProvisionerManagerTransportCallbacks(this);
+        mMeshManagerApi.setMeshManagerCallbacks(this);
         mMeshManagerApi.setProvisioningStatusCallbacks(this);
         mMeshManagerApi.setMeshStatusCallbacks(this);
         mMeshManagerApi.loadMeshNetwork();


### PR DESCRIPTION
The function setProvisionerManagerTransportCallbacks has been renamed here :
[3008411#diff-6d08543303f34c8618b9b9b00a0922ddR177](https://github.com/NordicSemiconductor/Android-nRF-Mesh-Library/commit/3008411774deb06aa43d8bd8a4685639b44f931d#diff-6d08543303f34c8618b9b9b00a0922ddR177)

But the README was not updated to use setMeshManagerCallbacks.