### PR TITLE
Add continuous integration with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+  language: java
+  

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,12 @@ install: gradle assemble
 script:
  - gradle check
  - gradle build
+
+jobs:
+  include:
+   # Example build job
+   - name: Build
+     before_install: cd Example/nrf-mesh
+   # Library build job
+   - name: macOS build
+     before_install: cd android-nrf-mesh-library

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ script:
 jobs:
   include:
    # Example build job
-   - name: Build
+   - name: Build Example
      before_install: cd Example/nrf-mesh
    # Library build job
-   - name: macOS build
+   - name: Build Library
      before_install: cd android-nrf-mesh-library

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,8 @@
-  language: java
-  
+language: java
+dist: xenial  
+
+install: gradle assemble
+
+script:
+ - gradle check
+ - gradle build


### PR DESCRIPTION
Adds continuous integration with Travis. Executes two jobs, one that builds the example and on that builds the library.

The Library currently fails on:
```
> :meshprovisioner<=============> 100% CONFIGURING [46s]FAILURE: Build failed with an exception.
* What went wrong:
A problem occurred configuring project ':meshprovisioner'.
> SDK location not found. Define location with sdk.dir in the local.properties file or with an ANDROID_HOME environment variable.
* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
* Get more help at https://help.gradle.org
BUILD FAILED in 51s
```
While the Example currently fails on:
```
> :app<========-----> 66% CONFIGURING [46s]FAILURE: Build failed with an exception.
* What went wrong:
A problem occurred configuring project ':app'.
> SDK location not found. Define location with sdk.dir in the local.properties file or with an ANDROID_HOME environment variable.
* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
* Get more help at https://help.gradle.org
BUILD FAILED in 51s
```