### PR TITLE
Improvements/remove deprecated apis

### DIFF
--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/BaseModelConfigurationActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/BaseModelConfigurationActivity.java
@@ -505,14 +505,14 @@ public abstract class BaseModelConfigurationActivity extends AppCompatActivity i
             final ConfigModelPublicationStatus status = (ConfigModelPublicationStatus) meshMessage;
             if (!status.isSuccessful()) {
                 DialogFragmentConfigStatus fragmentAppKeyBindStatus = DialogFragmentConfigStatus.
-                        newInstance(getString(R.string.title_publlish_address_status), status.getStatusCodeName());
+                        newInstance(getString(R.string.title_publish_address_status), status.getStatusCodeName());
                 fragmentAppKeyBindStatus.show(getSupportFragmentManager(), DIALOG_FRAGMENT_CONFIGURATION_STATUS);
             }
         } else if (meshMessage instanceof ConfigModelSubscriptionStatus) {
             final ConfigModelSubscriptionStatus status = (ConfigModelSubscriptionStatus) meshMessage;
             if (!status.isSuccessful()) {
                 DialogFragmentConfigStatus fragmentAppKeyBindStatus = DialogFragmentConfigStatus.
-                        newInstance(getString(R.string.title_publlish_address_status), status.getStatusCodeName());
+                        newInstance(getString(R.string.title_publish_address_status), status.getStatusCodeName());
                 fragmentAppKeyBindStatus.show(getSupportFragmentManager(), DIALOG_FRAGMENT_CONFIGURATION_STATUS);
             }
         }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/MeshProvisionerActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/MeshProvisionerActivity.java
@@ -285,7 +285,7 @@ public class MeshProvisionerActivity extends AppCompatActivity implements Inject
 
     @Override
     public void onPinInputComplete(final String pin) {
-        mViewModel.getMeshManagerApi().setProvisioningConfirmation(pin);
+        mViewModel.getMeshManagerApi().setProvisioningAuthentication(pin);
     }
 
     @Override

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/SettingsFragment.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/SettingsFragment.java
@@ -45,13 +45,10 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Locale;
 
 import javax.inject.Inject;
 
-import no.nordicsemi.android.meshprovisioner.transport.ApplicationKey;
 import no.nordicsemi.android.meshprovisioner.transport.NetworkKey;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 import no.nordicsemi.android.nrfmeshprovisioner.di.Injectable;
@@ -216,7 +213,7 @@ DialogFragmentPermissionRationale.StoragePermissionListener {
         final View containerAbout = rootView.findViewById(R.id.container_version);
         containerAbout.findViewById(R.id.image).setBackground(ContextCompat.getDrawable(getContext(), R.drawable.ic_puzzle));
         final TextView versionTitle = containerAbout.findViewById(R.id.title);
-        versionTitle.setText(R.string.summary_verion);
+        versionTitle.setText(R.string.summary_version);
         final TextView version = containerAbout.findViewById(R.id.text);
         try {
             version.setText(getContext().getPackageManager().getPackageInfo(getContext().getPackageName(), 0).versionName);
@@ -291,6 +288,7 @@ DialogFragmentPermissionRationale.StoragePermissionListener {
         return false;
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Override
     public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
         super.onActivityResult(requestCode, resultCode, data);

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentPublicationResolution.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentPublicationResolution.java
@@ -9,6 +9,7 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.DialogFragment;
 
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
+import no.nordicsemi.android.meshprovisioner.utils.PublicationSettings;
 import no.nordicsemi.android.nrfmeshprovisioner.R;
 
 public class DialogFragmentPublicationResolution extends DialogFragment {
@@ -42,10 +43,10 @@ public class DialogFragmentPublicationResolution extends DialogFragment {
                 .setSingleChoiceItems(R.array.arr_publication_resolution, mPublicationResolution, null)
                 .setPositiveButton(R.string.ok, (dialog, which) -> {
                     final int index = ((AlertDialog) dialog).getListView().getCheckedItemPosition();
-                    ((DialogFragmentPublicationResolutionListener) getActivity()).setPublicationResolution(getResolution(index)); })
+                    ((DialogFragmentPublicationResolutionListener) requireActivity()).setPublicationResolution(getResolution(index));})
                 .setNegativeButton(R.string.cancel, (dialog, which) -> {
                     final int index = ((AlertDialog) dialog).getListView().getCheckedItemPosition();
-                    ((DialogFragmentPublicationResolutionListener) getActivity()).setPublicationResolution(getResolution(index));
+                    ((DialogFragmentPublicationResolutionListener) requireActivity()).setPublicationResolution(getResolution(index));
                 });
 
         return alertDialogBuilder.create();

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/NrfMeshRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/NrfMeshRepository.java
@@ -716,6 +716,18 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
     }
 
     @Override
+    public void onBlockAcknowledgementReceived(final int src, @NonNull final ControlMessage message) {
+        final ProvisionedMeshNode node = mMeshNetwork.getProvisionedNode(src);
+        if (node != null) {
+            mProvisionedMeshNode = node;
+            if (mSetupProvisionedNode) {
+                mProvisionedMeshNodeLiveData.postValue(node);
+                mProvisioningStateLiveData.onMeshNodeStateUpdated(ProvisioningState.States.BLOCK_ACKNOWLEDGEMENT_RECEIVED);
+            }
+        }
+    }
+
+    @Override
     public void onMeshMessageSent(final int dst, final MeshMessage meshMessage) {
         //Deprecated
     }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/NrfMeshRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/NrfMeshRepository.java
@@ -316,7 +316,7 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
      * @param device bluetooth device
      */
     void connect(final Context context, final ExtendedBluetoothDevice device, final boolean connectToNetwork) {
-        mMeshNetworkLiveData.getValue().setNodeName(device.getName());
+        mMeshNetworkLiveData.setNodeName(device.getName());
         mIsProvisioningComplete = false;
         mIsCompositionDataReceived = false;
         mIsAppKeyAddCompleted = false;
@@ -414,11 +414,6 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
      */
     void setSelectedMeshNode(final ProvisionedMeshNode node) {
         mExtendedMeshNode.postValue(node);
-        /*if (mExtendedMeshNode == null) {
-            mExtendedMeshNode = new ExtendedMeshNode(node);
-        } else {
-            mExtendedMeshNode.updateMeshNode(node);
-        }*/
     }
 
     /**
@@ -692,27 +687,10 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
     }
 
     @Override
-    public void onTransactionFailed(final byte[] dst, final boolean hasIncompleteTimerExpired) {
-        mProvisionedMeshNode = mMeshNetwork.getProvisionedNode(dst);
-        if (mTransactionFailedLiveData.hasActiveObservers()) {
-            mTransactionFailedLiveData.onTransactionFailed(dst, hasIncompleteTimerExpired);
-        }
-    }
-
-    @Override
     public void onTransactionFailed(final int dst, final boolean hasIncompleteTimerExpired) {
         mProvisionedMeshNode = mMeshNetwork.getProvisionedNode(dst);
         if (mTransactionFailedLiveData.hasActiveObservers()) {
             mTransactionFailedLiveData.onTransactionFailed(dst, hasIncompleteTimerExpired);
-        }
-    }
-
-    @Override
-    public void onUnknownPduReceived(final byte[] src, final byte[] accessPayload) {
-        final ProvisionedMeshNode node = mMeshNetwork.getProvisionedNode(src);
-        if (node != null) {
-            mProvisionedMeshNode = node;
-            updateNode(node);
         }
     }
 
@@ -722,20 +700,6 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
         if (node != null) {
             mProvisionedMeshNode = node;
             updateNode(node);
-        }
-    }
-
-    @Override
-    public void onBlockAcknowledgementSent(final byte[] dst) {
-        if (dst != null) {
-            final ProvisionedMeshNode node = mMeshNetwork.getProvisionedNode(dst);
-            if (node != null) {
-                mProvisionedMeshNode = node;
-                if (mSetupProvisionedNode) {
-                    mProvisionedMeshNodeLiveData.postValue(mProvisionedMeshNode);
-                    mProvisioningStateLiveData.onMeshNodeStateUpdated(ProvisioningState.States.SENDING_BLOCK_ACKNOWLEDGEMENT);
-                }
-            }
         }
     }
 
@@ -752,18 +716,6 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
     }
 
     @Override
-    public void onBlockAcknowledgementReceived(final byte[] src) {
-        final ProvisionedMeshNode node = mMeshNetwork.getProvisionedNode(src);
-        if (node != null) {
-            mProvisionedMeshNode = node;
-            if (mSetupProvisionedNode) {
-                mProvisionedMeshNodeLiveData.postValue(node);
-                mProvisioningStateLiveData.onMeshNodeStateUpdated(ProvisioningState.States.BLOCK_ACKNOWLEDGEMENT_RECEIVED);
-            }
-        }
-    }
-
-    @Override
     public void onBlockAcknowledgementReceived(final int src) {
         final ProvisionedMeshNode node = mMeshNetwork.getProvisionedNode(src);
         if (node != null) {
@@ -773,10 +725,6 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
                 mProvisioningStateLiveData.onMeshNodeStateUpdated(ProvisioningState.States.BLOCK_ACKNOWLEDGEMENT_RECEIVED);
             }
         }
-    }
-
-    @Override
-    public void onMeshMessageSent(final byte[] dst, final MeshMessage meshMessage) {
     }
 
     @Override
@@ -796,10 +744,6 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
                 }
             }
         }
-    }
-
-    @Override
-    public void onMeshMessageReceived(final byte[] src, final MeshMessage meshMessage) {
     }
 
     @Override

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/NrfMeshRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/NrfMeshRepository.java
@@ -452,12 +452,13 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
     @Override
     public void onDeviceDisconnected(final BluetoothDevice device) {
         Log.v(TAG, "Disconnected");
+        mConnectionState.postValue("");
         if (mIsReconnectingFlag) {
             mIsReconnectingFlag = false;
             mIsReconnecting.postValue(false);
             mIsConnected.postValue(false);
+            mIsConnectedToProxy.postValue(false);
         } else {
-            mConnectionState.postValue("");
             mIsConnected.postValue(false);
             mIsConnectedToProxy.postValue(false);
             if (mConnectedMeshNodeAddress.getValue() != null) {

--- a/Example/nrf-mesh/app/src/main/res/layout/info_no_devices.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/info_no_devices.xml
@@ -43,13 +43,13 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="center_horizontal"
-        android:text="@string/blinky_guide_title"/>
+        android:text="@string/unprovisioned_node_guide_title"/>
 
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/activity_vertical_margin"
-        android:text="@string/blinky_guide_info"/>
+        android:text="@string/unprovisioned_node_guide_info"/>
 
     <LinearLayout
         android:id="@+id/no_location"
@@ -62,7 +62,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/activity_vertical_margin"
-            android:text="@string/blinky_guide_location_info"/>
+            android:text="@string/unprovisioned_node_guide_location_info"/>
 
         <Button
             android:id="@+id/action_enable_location"
@@ -70,6 +70,6 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
-            android:text="@string/blinky_guide_location_action"/>
+            android:text="@string/unprovisioned_node_guide_location_action"/>
     </LinearLayout>
 </LinearLayout>

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -33,7 +33,8 @@
 
     <string name="location_permission_title">LOCATION PERMISSION REQUIRED</string>
     <string name="location_permission_info">From Android 6.0 Marshmallow onwards the application requires Location permission in order to scan for Bluetooth Low Energy devices.
-      \n\nThis is because Bluetooth LE beacons, for example iBeacons or Eddystone, may be used to determine the phone\'s and user\'s location. <b>nRF Mesh Provisioner</b> will not use this information in any way.</string>
+      \n\nThis is because Bluetooth LE beacons, for example iBeacons or Eddystone, may be used to determine the phone\'s and user\'s location.
+        <b>nRF Mesh Provisioner</b> will not use this information in any way.</string>
     <string name="location_permission_action">Grant permission</string>
     <string name="location_permission_settings">Settings</string>
 
@@ -41,12 +42,12 @@
     <string name="bluetooth_disabled_info">The Bluetooth adapter is turned off. Click the button below to enable it.</string>
     <string name="bluetooth_disabled_action">Enable</string>
 
-    <string name="blinky_guide_title">CAN\'T SEE YOUR NODE?</string>
-    <string name="blinky_guide_info">1. Make sure the DK is <b>turned on</b> and is connected to a power source using a micro USB cable or a coin cell is plugged in.
+    <string name="unprovisioned_node_guide_title">CAN\'T SEE YOUR NODE?</string>
+    <string name="unprovisioned_node_guide_info">1. Make sure the DK is <b>turned on</b> and is connected to a power source using a micro USB cable or a coin cell is plugged in.
         \n\n2. Make sure the <b>relevant</b> firmware and SoftDevice are flashed.</string>
-    <string name="blinky_guide_location_info">3. Location is turned off. Some Android phones require it enabled in order to scan for Bluetooth LE devices.
-		If you are sure your Blinky is advertising and it doesn\'t show up here, click the button below to enable Location.</string>
-    <string name="blinky_guide_location_action">Enable</string>
+    <string name="unprovisioned_node_guide_location_info">3. Location is turned off. Some Android phones require it enabled in order to scan for Bluetooth LE devices.
+		If you are sure your Node is advertising and it doesn\'t show up here, click the button below to enable Location.</string>
+    <string name="unprovisioned_node_guide_location_action">Enable</string>
 
     <string name="state_connecting">Connecting…</string>
 
@@ -248,7 +249,8 @@
     <string name="title_app_key_index">Key Index</string>
     <string name="title_bound_app_keys">Bound App Keys</string>
 
-    <string name="no_elements_guide_info">No elements were found! \n\nTry configuring the node again to see what elements are available on this node. You may do this by going back to the main screen and connecting to the node.</string>
+    <string name="no_elements_guide_info">No elements were found! \n\nTry configuring the node again to see what elements are available on this node.
+        You may do this by going back to the main screen and connecting to the node.</string>
     <string name="no_elements_guide_composition_data">No elements were found! \nGet composition data to see what elements are on this node.</string>
     <string name="action_connect">CONNECT</string>
     <string name="action_disconnect">Disconnect</string>
@@ -256,7 +258,7 @@
     <string name="dialog_summary_publish_address">Publish address for this model.</string>
     <string name="hint_publish_address">Publish Address</string>
     <string name="error_empty_publish_address">Publish Address cannot be empty!</string>
-    <string name="title_publlish_address_status">Publish Address Status</string>
+    <string name="title_publish_address_status">Publish Address Status</string>
     <string name="hex_format">0x%s</string>
     <string name="hex_prefix">0x</string>
     <string name="invalid_hex_value">Invalid hex value</string>
@@ -273,7 +275,7 @@
     <string name="action_add">ADD</string>
     <string name="action_clear">CLEAR</string>
     <string name="title_about">About</string>
-    <string name="summary_verion">App Version</string>
+    <string name="summary_version">App Version</string>
     <string name="title_node_configuration">Node Configuration</string>
     <string name="title_added_app_keys">Added App Keys</string>
 
@@ -351,7 +353,7 @@
     <string name="public_key_type_title">Public Key Type</string>
     <string name="static_oob_type_title">Static OOB Type</string>
     <string name="output_oob_size_title">Output OOB Size</string>
-    <string name="supported_output_oob_actions_title">Supported Ouput OOB Actions</string>
+    <string name="supported_output_oob_actions_title">Supported Output OOB Actions</string>
     <string name="supported_input_oob_actions_title">Supported Input OOB Actions</string>
     <string name="input_oob_size_title">Input OOB Size</string>
     <string name="unknown">Unknown</string>

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/AllocatedGroupRange.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/AllocatedGroupRange.java
@@ -9,8 +9,6 @@ import android.arch.persistence.room.PrimaryKey;
 
 import com.google.gson.annotations.Expose;
 
-import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
-
 import static android.arch.persistence.room.ForeignKey.CASCADE;
 
 
@@ -44,19 +42,6 @@ public class AllocatedGroupRange {
     @Ignore
     public AllocatedGroupRange() {
 
-    }
-
-    /**
-     * Constructs {@link AllocatedGroupRange} for provisioner
-     *
-     * @param lowAddress  low address of group range
-     * @param highAddress high address of group range
-     */
-    @Deprecated
-    @Ignore
-    public AllocatedGroupRange(final byte[] lowAddress, final byte[] highAddress) {
-        this.lowAddress = MeshParserUtils.unsignedBytesToInt(lowAddress[1], lowAddress[0]);
-        this.highAddress = MeshParserUtils.unsignedBytesToInt(highAddress[1], highAddress[0]);
     }
 
     /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/AllocatedUnicastRange.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/AllocatedUnicastRange.java
@@ -9,8 +9,6 @@ import android.arch.persistence.room.PrimaryKey;
 
 import com.google.gson.annotations.Expose;
 
-import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
-
 import static android.arch.persistence.room.ForeignKey.CASCADE;
 
 /**
@@ -44,19 +42,6 @@ public class AllocatedUnicastRange {
     @Ignore
     public AllocatedUnicastRange() {
 
-    }
-
-    /**
-     * Constructs {@link AllocatedUnicastRange} for provisioner
-     *
-     * @param lowAddress  low address of unicast range
-     * @param highAddress high address of unicast range
-     */
-    @Deprecated
-    @Ignore
-    public AllocatedUnicastRange(final byte[] lowAddress, final byte[] highAddress) {
-        this.lowAddress = MeshParserUtils.unsignedBytesToInt(lowAddress[1], lowAddress[0]);
-        this.highAddress = MeshParserUtils.unsignedBytesToInt(highAddress[1], highAddress[0]);
     }
 
     /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/DataMigrator.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/DataMigrator.java
@@ -174,9 +174,9 @@ class DataMigrator {
                 provisioner.setProvisionerUuid(UUID.randomUUID().toString().toUpperCase(Locale.US));
             }
 
-            final AllocatedGroupRange groupRange = new AllocatedGroupRange(new byte[]{(byte) 0xC0, 0x00}, new byte[]{(byte) 0xFE, (byte) 0xFF});
+            final AllocatedGroupRange groupRange = new AllocatedGroupRange(0xC000, 0xFEFF);
             groupRange.setProvisionerUuid(provisioner.getProvisionerUuid());
-            final AllocatedUnicastRange unicastRange = new AllocatedUnicastRange(new byte[]{(byte) 0x00, 0x00}, new byte[]{(byte) 0x7F, (byte) 0xFF});
+            final AllocatedUnicastRange unicastRange = new AllocatedUnicastRange(0x0000, 0x7FFF);
             unicastRange.setProvisionerUuid(provisioner.getProvisionerUuid());
             final AllocatedSceneRange sceneRange = new AllocatedSceneRange(0, 0);
             sceneRange.setProvisionerUuid(provisioner.getProvisionerUuid());

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/InternalTransportCallbacks.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/InternalTransportCallbacks.java
@@ -35,14 +35,6 @@ public interface InternalTransportCallbacks {
      * Returns the node with the corresponding unicast address
      *
      * @param unicast unicast address
-     * @deprecated in favour of {@link #getProvisionedNode(int)}
-     */
-    ProvisionedMeshNode getProvisionedNode(final byte[] unicast);
-
-    /**
-     * Returns the node with the corresponding unicast address
-     *
-     * @param unicast unicast address
      */
     ProvisionedMeshNode getProvisionedNode(final int unicast);
 
@@ -53,17 +45,6 @@ public interface InternalTransportCallbacks {
      * @param pdu      mesh pdu to be sent
      */
     void sendProvisioningPdu(final UnprovisionedMeshNode meshNode, final byte[] pdu);
-
-    /**
-     * Send mesh pdu
-     *
-     * @param dst Destination address to be sent
-     * @param pdu mesh pdu to be sent
-     * @deprecated in favour of {@link #sendMeshPdu(int, byte[])}
-     */
-    @Deprecated
-    @RestrictTo(RestrictTo.Scope.LIBRARY)
-    void sendMeshPdu(final byte[] dst, final byte[] pdu);
 
     /**
      * Send mesh pdu

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/InternalTransportCallbacks.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/InternalTransportCallbacks.java
@@ -47,13 +47,13 @@ public interface InternalTransportCallbacks {
     void sendProvisioningPdu(final UnprovisionedMeshNode meshNode, final byte[] pdu);
 
     /**
-     * Send mesh pdu
+     * Callback that is invoked when a mesh pdu is created
      *
      * @param dst Destination address to be sent
      * @param pdu mesh pdu to be sent
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY)
-    void sendMeshPdu(final int dst, final byte[] pdu);
+    void onMeshPduCreated(final int dst, final byte[] pdu);
 
     /**
      * Update mesh network

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
@@ -348,28 +348,23 @@ public class MeshManagerApi implements MeshMngrApi {
      */
     private void handleWriteCallbacks(final byte[] data) {
         switch (data[0]) {
-            case PDU_TYPE_NETWORK:
-                //MeshNetwork PDU
+            case PDU_TYPE_NETWORK: // MeshNetwork PDU
                 Log.v(TAG, "MeshNetwork pdu sent: " + MeshParserUtils.bytesToHex(data, true));
-                //mMeshMessageHandler.handleNetworkPDUWriteCallbacks(data);
                 break;
-            case PDU_TYPE_MESH_BEACON:
-                //Mesh beacon
+            case PDU_TYPE_MESH_BEACON: // MESH BEACON
                 Log.v(TAG, "Mesh beacon pdu sent: " + MeshParserUtils.bytesToHex(data, true));
                 break;
-            case PDU_TYPE_PROXY_CONFIGURATION:
-                //Proxy configuration
+            case PDU_TYPE_PROXY_CONFIGURATION: // Proxy configuration
                 Log.v(TAG, "Proxy configuration pdu sent: " + MeshParserUtils.bytesToHex(data, true));
-                //mMeshMessageHandler.handleProxyPDUWriteCallbacks(data);
                 break;
-            case PDU_TYPE_PROVISIONING:
-                //Provisioning PDU
+            case PDU_TYPE_PROVISIONING: // Provisioning PDU
                 Log.v(TAG, "Provisioning pdu sent: " + MeshParserUtils.bytesToHex(data, true));
                 mMeshProvisioningHandler.handleProvisioningWriteCallbacks();
                 break;
         }
     }
 
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     private boolean shouldWaitForMoreData(final byte[] pdu) {
         final int gattSar = (pdu[0] & GATT_SAR_MASK) >> SAR_BIT_OFFSET;
         switch (gattSar) {
@@ -540,11 +535,6 @@ public class MeshManagerApi implements MeshMngrApi {
     @Override
     public void startProvisioningWithInputOOB(@NonNull final UnprovisionedMeshNode unprovisionedMeshNode, @NonNull final InputOOBAction oobAction) throws IllegalArgumentException {
         mMeshProvisioningHandler.startProvisioningWithInputOOB(unprovisionedMeshNode, oobAction);
-    }
-
-    @Override
-    public final void setProvisioningConfirmation(@NonNull final String authentication) {
-        setProvisioningAuthentication(authentication);
     }
 
     @Override
@@ -782,11 +772,6 @@ public class MeshManagerApi implements MeshMngrApi {
     }
 
     @Override
-    public final void sendMeshMessage(@NonNull final byte[] dst, @NonNull final MeshMessage meshMessage) {
-        mMeshMessageHandler.sendMeshMessage(mMeshNetwork.getSelectedProvisioner().getProvisionerAddress(), AddressUtils.getUnicastAddressInt(dst), meshMessage);
-    }
-
-    @Override
     public void sendMeshMessage(final int dst, @NonNull final MeshMessage meshMessage) {
         if (!MeshAddress.isAddressInRange(dst)) {
             throw new IllegalArgumentException("Invalid address, destination address must be a valid 16-bit value!");
@@ -823,10 +808,6 @@ public class MeshManagerApi implements MeshMngrApi {
 
     @SuppressWarnings("FieldCanBeLocal")
     private final InternalTransportCallbacks internalTransportCallbacks = new InternalTransportCallbacks() {
-        @Override
-        public ProvisionedMeshNode getProvisionedNode(final byte[] unicast) {
-            return getMeshNode(AddressUtils.getUnicastAddressInt(unicast));
-        }
 
         @Override
         public ProvisionedMeshNode getProvisionedNode(final int unicast) {
@@ -840,18 +821,9 @@ public class MeshManagerApi implements MeshMngrApi {
         }
 
         @Override
-        public void sendMeshPdu(final byte[] dst, final byte[] pdu) {
+        public void sendMeshPdu(final int dst, final byte[] pdu) {
             //We must save the mesh network state for every message that is being sent out.
             //This will specifically save the sequence number for every message sent.
-            final int dstAddress = AddressUtils.getUnicastAddressInt(dst);
-            final ProvisionedMeshNode meshNode = mMeshNetwork.getProvisionedNode(dstAddress);
-            updateNetwork(meshNode);
-            final int mtu = mTransportCallbacks.getMtu();
-            mTransportCallbacks.sendMeshPdu(applySegmentation(mtu, pdu));
-        }
-
-        @Override
-        public void sendMeshPdu(final int dst, final byte[] pdu) {
             final ProvisionedMeshNode meshNode = mMeshNetwork.getProvisionedNode(dst);
             updateNetwork(meshNode);
             final int mtu = mTransportCallbacks.getMtu();

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
@@ -780,6 +780,14 @@ public class MeshManagerApi implements MeshMngrApi {
     }
 
     @Override
+    public void createdMeshPdu(final int dst, @NonNull final MeshMessage meshMessage) throws IllegalArgumentException {
+        if (!MeshAddress.isAddressInRange(dst)) {
+            throw new IllegalArgumentException("Invalid address, destination address must be a valid 16-bit value!");
+        }
+        mMeshMessageHandler.sendMeshMessage(mMeshNetwork.getSelectedProvisioner().getProvisionerAddress(), dst, meshMessage);
+    }
+
+    @Override
     public void exportMeshNetwork(@NonNull final String path) {
         final MeshNetwork meshNetwork = mMeshNetwork;
         if (meshNetwork != null) {
@@ -821,13 +829,13 @@ public class MeshManagerApi implements MeshMngrApi {
         }
 
         @Override
-        public void sendMeshPdu(final int dst, final byte[] pdu) {
+        public void onMeshPduCreated(final int dst, final byte[] pdu) {
             //We must save the mesh network state for every message that is being sent out.
             //This will specifically save the sequence number for every message sent.
             final ProvisionedMeshNode meshNode = mMeshNetwork.getProvisionedNode(dst);
             updateNetwork(meshNode);
             final int mtu = mTransportCallbacks.getMtu();
-            mTransportCallbacks.sendMeshPdu(applySegmentation(mtu, pdu));
+            mTransportCallbacks.onMeshPduCreated(applySegmentation(mtu, pdu));
         }
 
         @Override

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerCallbacks.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerCallbacks.java
@@ -100,9 +100,19 @@ public interface MeshManagerCallbacks {
     /**
      * Send mesh pdu
      *
-     * @param pdu      mesh pdu to be sent
+     * @param pdu mesh pdu to be sent
+     * @deperecated in favour of {{@link #onMeshPduCreated(byte[])}}.
+     * This API was renamed because the mesh library only prepares/parses mesh messages to be sent or received
      */
+    @Deprecated
     void sendMeshPdu(final byte[] pdu);
+
+    /**
+     * Send mesh pdu
+     *
+     * @param pdu mesh pdu to be sent
+     */
+    void onMeshPduCreated(final byte[] pdu);
 
     /**
      * Get mtu size supported by the peripheral node

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshMngrApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshMngrApi.java
@@ -209,8 +209,19 @@ interface MeshMngrApi {
      *
      * @param dst         destination address
      * @param meshMessage {@link MeshMessage} Mesh message containing the message opcode and message parameters
+     * @deperecated in favour of {{@link #createdMeshPdu(int, MeshMessage)}} as sendMeshMessage method,
+     * do not really send a mesh message but creates on instead to be sent by the user
      */
+    @Deprecated
     void sendMeshMessage(final int dst, @NonNull final MeshMessage meshMessage) throws IllegalArgumentException;
+
+    /**
+     * Sends the specified  mesh message specified within the {@link MeshMessage} object
+     *
+     * @param dst         destination address
+     * @param meshMessage {@link MeshMessage} Mesh message containing the message opcode and message parameters
+     */
+    void createdMeshPdu(final int dst, @NonNull final MeshMessage meshMessage) throws IllegalArgumentException;
 
     /**
      * Loads the mesh network from the local database.

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshMngrApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshMngrApi.java
@@ -37,23 +37,6 @@ interface MeshMngrApi {
     void setMeshStatusCallbacks(@NonNull final MeshStatusCallbacks callbacks);
 
     /**
-     * Loads the mesh network from the local database.
-     * <p>
-     * This will start an AsyncTask that will load the network from the database.
-     * {@link MeshManagerCallbacks#onNetworkLoaded(MeshNetwork) will return the mesh network
-     * </p>
-     */
-    void loadMeshNetwork();
-
-    /**
-     * Returns an already loaded mesh network, make sure to call {@link #loadMeshNetwork()} before calling this
-     *
-     * @return {@link MeshNetwork}
-     */
-    @Nullable
-    MeshNetwork getMeshNetwork();
-
-    /**
      * Handles notifications received by the client.
      * <p>
      * This method will check if the library should wait for more data in case of a gatt layer segmentation.
@@ -144,15 +127,6 @@ interface MeshMngrApi {
      * Set the provisioning confirmation
      *
      * @param authentication confirmation pin
-     * @deprecated in favour of {@link #setProvisioningAuthentication(String)}
-     */
-    @Deprecated
-    void setProvisioningConfirmation(@NonNull final String authentication);
-
-    /**
-     * Set the provisioning confirmation
-     *
-     * @param authentication confirmation pin
      */
     void setProvisioningAuthentication(@NonNull final String authentication);
 
@@ -235,24 +209,30 @@ interface MeshMngrApi {
      *
      * @param dst         destination address
      * @param meshMessage {@link MeshMessage} Mesh message containing the message opcode and message parameters
-     * @deprecated This method has been deprecated in favour of {@link #sendMeshMessage(int, MeshMessage)}
-     */
-    @Deprecated
-    void sendMeshMessage(@NonNull final byte[] dst, @NonNull final MeshMessage meshMessage);
-
-    /**
-     * Sends the specified  mesh message specified within the {@link MeshMessage} object
-     *
-     * @param dst         destination address
-     * @param meshMessage {@link MeshMessage} Mesh message containing the message opcode and message parameters
      */
     void sendMeshMessage(final int dst, @NonNull final MeshMessage meshMessage) throws IllegalArgumentException;
+
+    /**
+     * Loads the mesh network from the local database.
+     * <p>
+     * This will start an AsyncTask that will load the network from the database.
+     * {@link MeshManagerCallbacks#onNetworkLoaded(MeshNetwork) will return the mesh network
+     * </p>
+     */
+    void loadMeshNetwork();
+
+    /**
+     * Returns an already loaded mesh network, make sure to call {@link #loadMeshNetwork()} before calling this
+     *
+     * @return {@link MeshNetwork}
+     */
+    @Nullable
+    MeshNetwork getMeshNetwork();
 
     /**
      * Exports mesh network to a json file
      */
     void exportMeshNetwork(@NonNull final String path);
-
 
     /**
      * Starts an asynchronous task that imports a network from the mesh configuration db json

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshStatusCallbacks.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshStatusCallbacks.java
@@ -63,19 +63,33 @@ public interface MeshStatusCallbacks {
     void onBlockAcknowledgementSent(final int dst);
 
     /**
-     * Notifies when a block acknowledgement was processed
+     * Notifies when a block acknowledgement has been processed
+     *
+     * <p>
+     * This callback is invoked after {@link MeshManagerCallbacks#onMeshPduCreated(byte[])} where a mesh pdu is created.
+     * </p>
      *
      * @param dst     Destination address to which the block ack was sent
-     * @param message Control message
+     * @param message Control message containing the block acknowledgement
      */
     void onBlockAcknowledgementProcessed(final int dst, @NonNull final ControlMessage message);
 
     /**
      * Notifies if a block acknowledgement was received
      *
-     * @param src source address from which the block ack was received
+     * @param src Source address from which the block ack was received
+     * @deperecated in favour of {{@link #onBlockAcknowledgementReceived(int, ControlMessage)}}
      */
+    @Deprecated
     void onBlockAcknowledgementReceived(final int src);
+
+    /**
+     * Notifies if a block acknowledgement was received
+     *
+     * @param src     Source address from which the block ack was received
+     * @param message Control message containing the block acknowledgement
+     */
+    void onBlockAcknowledgementReceived(final int src, @NonNull final ControlMessage message);
 
     /**
      * Callback to notify the mesh message has been sent
@@ -89,7 +103,11 @@ public interface MeshStatusCallbacks {
     void onMeshMessageSent(final int dst, final MeshMessage meshMessage);
 
     /**
-     * Callback to notify the mesh message has processed
+     * Callback to notify the mesh message has been processed
+     *
+     * <p>
+     * This callback is invoked after {@link MeshManagerCallbacks#onMeshPduCreated(byte[])} where a mesh pdu is created.
+     * </p>
      *
      * @param dst         Destination address to be sent
      * @param meshMessage {@link MeshMessage} containing the message that was sent

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshStatusCallbacks.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshStatusCallbacks.java
@@ -22,6 +22,9 @@
 
 package no.nordicsemi.android.meshprovisioner;
 
+import android.support.annotation.NonNull;
+
+import no.nordicsemi.android.meshprovisioner.transport.ControlMessage;
 import no.nordicsemi.android.meshprovisioner.transport.MeshMessage;
 
 /**
@@ -37,25 +40,35 @@ public interface MeshStatusCallbacks {
      * If all segments are not received during this period, that transaction shall be considered as failed.
      * </p>
      *
-     * @param dst                       unique dst address of the device
-     * @param hasIncompleteTimerExpired flag that notifies if the incomplete timer had expired
+     * @param dst                       Unique dst address of the device
+     * @param hasIncompleteTimerExpired Flag that notifies if the incomplete timer had expired
      */
     void onTransactionFailed(final int dst, final boolean hasIncompleteTimerExpired);
 
     /**
      * Notifies if an unknown pdu was received
      *
-     * @param src           address where the message originated from
-     * @param accessPayload access payload of the message
+     * @param src           Address where the message originated from
+     * @param accessPayload Access payload of the message
      */
     void onUnknownPduReceived(final int src, final byte[] accessPayload);
 
     /**
      * Notifies if a block acknowledgement was sent
      *
-     * @param dst dst address to which the block ack was sent
+     * @param dst Destination address to which the block ack was sent
+     * @deperecated in favour of {{@link #onBlockAcknowledgementProcessed(int, ControlMessage)}}
      */
+    @Deprecated
     void onBlockAcknowledgementSent(final int dst);
+
+    /**
+     * Notifies when a block acknowledgement was processed
+     *
+     * @param dst     Destination address to which the block ack was sent
+     * @param message Control message
+     */
+    void onBlockAcknowledgementProcessed(final int dst, @NonNull final ControlMessage message);
 
     /**
      * Notifies if a block acknowledgement was received
@@ -69,16 +82,27 @@ public interface MeshStatusCallbacks {
      *
      * @param dst         Destination address to be sent
      * @param meshMessage {@link MeshMessage} containing the message that was sent
+     * @deperecated in favour of {{@link #onMeshMessageProcessed(int, MeshMessage)}} as the mesh library does not send messages
+     * but only generates messages to be sent over gatt
      */
+    @Deprecated
     void onMeshMessageSent(final int dst, final MeshMessage meshMessage);
+
+    /**
+     * Callback to notify the mesh message has processed
+     *
+     * @param dst         Destination address to be sent
+     * @param meshMessage {@link MeshMessage} containing the message that was sent
+     */
+    void onMeshMessageProcessed(final int dst, @NonNull final MeshMessage meshMessage);
 
     /**
      * Callback to notify that a mesh status message was received
      *
-     * @param src         source address where the message originated from
+     * @param src         Source address where the message originated from
      * @param meshMessage {@link MeshMessage} containing the message that was received
      */
-    void onMeshMessageReceived(final int src, final MeshMessage meshMessage);
+    void onMeshMessageReceived(final int src, @NonNull final MeshMessage meshMessage);
 
     /**
      * Callback to notify if the decryption failed of a received mesh message

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshStatusCallbacks.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshStatusCallbacks.java
@@ -39,33 +39,8 @@ public interface MeshStatusCallbacks {
      *
      * @param dst                       unique dst address of the device
      * @param hasIncompleteTimerExpired flag that notifies if the incomplete timer had expired
-     * @deprecated in favor of {@link #onTransactionFailed(int, boolean)}
-     */
-    @Deprecated
-    void onTransactionFailed(final byte[] dst, final boolean hasIncompleteTimerExpired);
-
-    /**
-     * Notifies if a transaction has failed
-     * <p>
-     * As of now this is only triggered if the incomplete timer has expired for a given segmented message.
-     * The incomplete timer will wait for a minimum of 10 seconds on receiving a segmented message.
-     * If all segments are not received during this period, that transaction shall be considered as failed.
-     * </p>
-     *
-     * @param dst                       unique dst address of the device
-     * @param hasIncompleteTimerExpired flag that notifies if the incomplete timer had expired
      */
     void onTransactionFailed(final int dst, final boolean hasIncompleteTimerExpired);
-
-    /**
-     * Notifies if an unknown pdu was received
-     *
-     * @param src           address where the message originated from
-     * @param accessPayload access payload of the message
-     * @deprecated in favor of {@link #onUnknownPduReceived(int, byte[])}
-     */
-    @Deprecated
-    void onUnknownPduReceived(final byte[] src, final byte[] accessPayload);
 
     /**
      * Notifies if an unknown pdu was received
@@ -79,26 +54,8 @@ public interface MeshStatusCallbacks {
      * Notifies if a block acknowledgement was sent
      *
      * @param dst dst address to which the block ack was sent
-     * @deprecated in favour of {@link #onBlockAcknowledgementSent(int)}
-     */
-    @Deprecated
-    void onBlockAcknowledgementSent(final byte[] dst);
-
-    /**
-     * Notifies if a block acknowledgement was sent
-     *
-     * @param dst dst address to which the block ack was sent
      */
     void onBlockAcknowledgementSent(final int dst);
-
-    /**
-     * Notifies if a block acknowledgement was received
-     *
-     * @param src source address from which the block ack was received
-     * @deprecated in favour of {@link #onBlockAcknowledgementSent(int)}
-     */
-    @Deprecated
-    void onBlockAcknowledgementReceived(final byte[] src);
 
     /**
      * Notifies if a block acknowledgement was received
@@ -112,28 +69,8 @@ public interface MeshStatusCallbacks {
      *
      * @param dst         Destination address to be sent
      * @param meshMessage {@link MeshMessage} containing the message that was sent
-     * @deprecated in favour of {@link #onMeshMessageSent(int, MeshMessage)}
-     */
-    @Deprecated
-    void onMeshMessageSent(final byte[] dst, final MeshMessage meshMessage);
-
-    /**
-     * Callback to notify the mesh message has been sent
-     *
-     * @param dst         Destination address to be sent
-     * @param meshMessage {@link MeshMessage} containing the message that was sent
      */
     void onMeshMessageSent(final int dst, final MeshMessage meshMessage);
-
-    /**
-     * Callback to notify that a mesh status message was received
-     *
-     * @param src         source address where the message originated from
-     * @param meshMessage {@link MeshMessage} containing the message that was received
-     * @deprecated in favour of {@link #onMeshMessageSent(int, MeshMessage)}
-     */
-    @Deprecated
-    void onMeshMessageReceived(final byte[] src, final MeshMessage meshMessage);
 
     /**
      * Callback to notify that a mesh status message was received

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/BaseMeshMessageHandler.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/BaseMeshMessageHandler.java
@@ -34,7 +34,6 @@ import java.nio.ByteOrder;
 import no.nordicsemi.android.meshprovisioner.InternalTransportCallbacks;
 import no.nordicsemi.android.meshprovisioner.MeshNetwork;
 import no.nordicsemi.android.meshprovisioner.MeshStatusCallbacks;
-import no.nordicsemi.android.meshprovisioner.utils.AddressUtils;
 import no.nordicsemi.android.meshprovisioner.utils.MeshAddress;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
@@ -173,19 +172,6 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
     public void resetState(final int address) {
         stateSparseArray.remove(address);
         transportSparseArray.remove(address);
-    }
-
-    @Override
-    public void sendMeshMessage(@NonNull final byte[] src, @NonNull final byte[] dst, @NonNull final MeshMessage meshMessage) {
-        final int srcAddress = AddressUtils.getUnicastAddressInt(src);
-        final int dstAddress = AddressUtils.getUnicastAddressInt(dst);
-        if (meshMessage instanceof ProxyConfigMessage) {
-            sendProxyConfigMeshMessage(srcAddress, dstAddress, (ProxyConfigMessage) meshMessage);
-        } else if (meshMessage instanceof ConfigMessage) {
-            sendConfigMeshMessage(srcAddress, dstAddress, (ConfigMessage) meshMessage);
-        } else if (meshMessage instanceof GenericMessage) {
-            sendAppMeshMessage(srcAddress, dstAddress, (GenericMessage) meshMessage);
-        }
     }
 
     @Override

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/BaseMeshMessageHandler.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/BaseMeshMessageHandler.java
@@ -244,7 +244,7 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
      * De-obfuscates the network header
      *
      * @param pdu received from the node
-     * @return obfuscted network header
+     * @return obfuscated network header
      */
     private byte[] deObfuscateNetworkHeader(@NonNull final byte[] pdu, @NonNull final NetworkKey key, @NonNull final byte[] ivIndex) {
         final SecureUtils.K2Output k2Output = SecureUtils.calculateK2(key.getKey(), SecureUtils.K2_MASTER_INPUT);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/BaseMeshMessageHandler.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/BaseMeshMessageHandler.java
@@ -126,7 +126,7 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
      * @param meshMessage Mesh message
      */
     private DefaultNoOperationMessageState toggleState(@NonNull final MeshTransport transport, @Nullable final MeshMessage meshMessage) {
-        final DefaultNoOperationMessageState state = new DefaultNoOperationMessageState(mContext, meshMessage, transport, this);
+        final DefaultNoOperationMessageState state = new DefaultNoOperationMessageState(meshMessage, transport, this);
         state.setTransportCallbacks(mInternalTransportCallbacks);
         state.setStatusCallbacks(mStatusCallbacks);
         return state;
@@ -140,7 +140,7 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
     protected MeshMessageState getState(final int address) {
         MeshMessageState state = stateSparseArray.get(address);
         if (state == null) {
-            state = new DefaultNoOperationMessageState(mContext, null, getTransport(address), this);
+            state = new DefaultNoOperationMessageState(null, getTransport(address), this);
             state.setTransportCallbacks(mInternalTransportCallbacks);
             state.setStatusCallbacks(mStatusCallbacks);
             stateSparseArray.put(address, state);
@@ -191,7 +191,7 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
      * @param configurationMessage {@link ProxyConfigMessage} Mesh message containing the message opcode and message parameters
      */
     private void sendProxyConfigMeshMessage(final int src, final int dst, @NonNull final ProxyConfigMessage configurationMessage) {
-        final ProxyConfigMessageState currentState = new ProxyConfigMessageState(mContext, src, dst, configurationMessage, getTransport(dst), this);
+        final ProxyConfigMessageState currentState = new ProxyConfigMessageState(src, dst, configurationMessage, getTransport(dst), this);
         currentState.setTransportCallbacks(mInternalTransportCallbacks);
         currentState.setStatusCallbacks(mStatusCallbacks);
         stateSparseArray.put(dst, toggleState(currentState.getMeshTransport(), configurationMessage));
@@ -209,7 +209,7 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
             return;
         }
 
-        final ConfigMessageState currentState = new ConfigMessageState(mContext, src, dst, node.getDeviceKey(), configurationMessage, getTransport(dst), this);
+        final ConfigMessageState currentState = new ConfigMessageState(src, dst, node.getDeviceKey(), configurationMessage, getTransport(dst), this);
         currentState.setTransportCallbacks(mInternalTransportCallbacks);
         currentState.setStatusCallbacks(mStatusCallbacks);
         if (MeshAddress.isValidUnicastAddress(dst)) {
@@ -231,7 +231,7 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
      * @param genericMessage Mesh message containing the message opcode and message parameters.
      */
     private void sendAppMeshMessage(final int src, final int dst, @NonNull final GenericMessage genericMessage) {
-        final GenericMessageState currentState = new GenericMessageState(mContext, src, dst, genericMessage, getTransport(dst), this);
+        final GenericMessageState currentState = new GenericMessageState(src, dst, genericMessage, getTransport(dst), this);
         currentState.setTransportCallbacks(mInternalTransportCallbacks);
         currentState.setStatusCallbacks(mStatusCallbacks);
         if (MeshAddress.isValidUnicastAddress(dst)) {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigMessageState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigMessageState.java
@@ -22,7 +22,6 @@
 
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
 
 /**
@@ -35,7 +34,6 @@ class ConfigMessageState extends MeshMessageState {
     /**
      * Constructs the ConfigMessageState
      *
-     * @param context       Context
      * @param src           Source address
      * @param dst           Destination address
      * @param deviceKey     Device key
@@ -43,14 +41,13 @@ class ConfigMessageState extends MeshMessageState {
      * @param meshTransport {@link MeshTransport} Mesh transport
      * @param callbacks     {@link InternalMeshMsgHandlerCallbacks} callbacks
      */
-    ConfigMessageState(@NonNull final Context context,
-                       final int src,
+    ConfigMessageState(final int src,
                        final int dst,
                        @NonNull final byte[] deviceKey,
                        @NonNull final MeshMessage meshMessage,
                        @NonNull final MeshTransport meshTransport,
                        @NonNull final InternalMeshMsgHandlerCallbacks callbacks) {
-        super(context, meshMessage, meshTransport, callbacks);
+        super(meshMessage, meshTransport, callbacks);
         this.mSrc = src;
         this.mDst = dst;
         this.mDeviceKey = deviceKey;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelAppBind.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelAppBind.java
@@ -22,13 +22,10 @@
 
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
-
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 import no.nordicsemi.android.meshprovisioner.opcodes.ConfigMessageOpCodes;
-import no.nordicsemi.android.meshprovisioner.utils.AddressUtils;
 import no.nordicsemi.android.meshprovisioner.utils.MeshAddress;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 
@@ -44,31 +41,15 @@ public final class ConfigModelAppBind extends ConfigMessage {
     private static final int SIG_MODEL_APP_KEY_BIND_PARAMS_LENGTH = 6;
     private static final int VENDOR_MODEL_APP_KEY_BIND_PARAMS_LENGTH = 8;
 
-
     private final int mElementAddress;
     private final int mModelIdentifier;
     private final int mAppKeyIndex;
-
+    
     /**
      * Constructs ConfigModelAppBind message.
      *
-     * @param elementAddress  element address
-     * @param modelIdentifier model id
-     * @param appKeyIndex     Application key index of this message
-     * @throws IllegalArgumentException if any illegal arguments are passed
-     * @deprecated in favour of {@link #ConfigModelAppBind(int, int, int)}
-     */
-    @Deprecated
-    public ConfigModelAppBind(@NonNull final byte[] elementAddress,
-                              final int modelIdentifier,
-                              final int appKeyIndex) throws IllegalArgumentException {
-        this(AddressUtils.getUnicastAddressInt(elementAddress), modelIdentifier, appKeyIndex);
-    }
-    /**
-     * Constructs ConfigModelAppBind message.
-     *
-     * @param elementAddress  element address
-     * @param modelIdentifier model id
+     * @param elementAddress  Element address
+     * @param modelIdentifier Model id
      * @param appKeyIndex     Application key index of this message
      * @throws IllegalArgumentException if any illegal arguments are passed
      */

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelAppUnbind.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelAppUnbind.java
@@ -22,13 +22,10 @@
 
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
-
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 import no.nordicsemi.android.meshprovisioner.opcodes.ConfigMessageOpCodes;
-import no.nordicsemi.android.meshprovisioner.utils.AddressUtils;
 import no.nordicsemi.android.meshprovisioner.utils.MeshAddress;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 
@@ -47,22 +44,6 @@ public final class ConfigModelAppUnbind extends ConfigMessage {
     private final int mElementAddress;
     private final int mModelIdentifier;
     private final int mAppKeyIndex;
-
-    /**
-     * Constructs ConfigModelAppUnbind message.
-     *
-     * @param elementAddress  Address of the element to which the model belongs to
-     * @param modelIdentifier Model from which the key must be unbound from
-     * @param appKeyIndex     Global app key index of the key to be unbound
-     * @throws IllegalArgumentException if any illegal arguments are passed
-     * @deprecated in favour of {@link #ConfigModelAppUnbind(int, int, int)}
-     */
-    @Deprecated
-    public ConfigModelAppUnbind(@NonNull final byte[] elementAddress,
-                                final int modelIdentifier,
-                                final int appKeyIndex) throws IllegalArgumentException {
-        this(AddressUtils.getUnicastAddressInt(elementAddress), modelIdentifier, appKeyIndex);
-    }
 
     /**
      * Constructs ConfigModelAppUnbind message.

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelPublicationGet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelPublicationGet.java
@@ -22,7 +22,6 @@
 
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
 import android.util.Log;
 
 import java.nio.ByteBuffer;
@@ -31,7 +30,6 @@ import java.nio.ByteOrder;
 import no.nordicsemi.android.meshprovisioner.opcodes.ConfigMessageOpCodes;
 import no.nordicsemi.android.meshprovisioner.utils.CompositionDataParser;
 import no.nordicsemi.android.meshprovisioner.utils.MeshAddress;
-import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 
 /**
  * To be used as a wrapper class to create a ConfigModelPublicationSet message.
@@ -47,19 +45,6 @@ public class ConfigModelPublicationGet extends ConfigMessage {
 
     private final int elementAddress;
     private final int modelIdentifier;
-
-    /**
-     * Constructs a ConfigModelPublicationGet message
-     *
-     * @param elementAddress                 Element address that should publish
-     * @param modelIdentifier                identifier for this model that will do publication
-     * @throws IllegalArgumentException for invalid arguments
-     */
-    @Deprecated
-    public ConfigModelPublicationGet(@NonNull final byte[] elementAddress,
-                                     final int modelIdentifier) throws IllegalArgumentException {
-        this(MeshParserUtils.bytesToInt(elementAddress), modelIdentifier);
-    }
 
     /**
      * Constructs a ConfigModelPublicationGet message

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelPublicationSet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelPublicationSet.java
@@ -120,8 +120,8 @@ public class ConfigModelPublicationSet extends ConfigMessage {
         Log.v(TAG, "Model: " + MeshParserUtils.bytesToHex(AddressUtils.getUnicastAddressBytes(modelIdentifier), false));
 
         final int rfu = 0; // We ignore the rfu here
-        final int octet5 = ((applicationKeyIndex[0] << 4)) | (credentialFlag ? 1 : 0);
-        final int publishPeriod = ((publicationSteps << 6) | publicationResolution);
+        final int octet5 = ((applicationKeyIndex[0] << 4)) | ((credentialFlag ? 0b01 : 0b00) << 3);
+        final byte publishPeriod = (byte) ((publicationResolution << 6) | (publicationSteps & 0x3F));
         final int octet8 = (publishRetransmitCount << 5) | (publishRetransmitIntervalSteps & 0x1F);
         //We check if the model identifier value is within the range of a 16-bit value here. If it is then it is a sig model
         if (modelIdentifier >= Short.MIN_VALUE && modelIdentifier <= Short.MAX_VALUE) {
@@ -131,7 +131,7 @@ public class ConfigModelPublicationSet extends ConfigMessage {
             paramsBuffer.put(applicationKeyIndex[1]);
             paramsBuffer.put((byte) octet5);
             paramsBuffer.put((byte) publishTtl);
-            paramsBuffer.put((byte) publishPeriod);
+            paramsBuffer.put(publishPeriod);
             paramsBuffer.put((byte) octet8);
             paramsBuffer.putShort((short) modelIdentifier);
             mParameters = paramsBuffer.array();
@@ -142,7 +142,7 @@ public class ConfigModelPublicationSet extends ConfigMessage {
             paramsBuffer.put(applicationKeyIndex[1]);
             paramsBuffer.put((byte) octet5);
             paramsBuffer.put((byte) publishTtl);
-            paramsBuffer.put((byte) publishPeriod);
+            paramsBuffer.put(publishPeriod);
             paramsBuffer.put((byte) octet8);
             final byte[] modelIdentifier = new byte[]{(byte) ((this.modelIdentifier >> 24) & 0xFF), (byte) ((this.modelIdentifier >> 16) & 0xFF), (byte) ((this.modelIdentifier >> 8) & 0xFF), (byte) (this.modelIdentifier & 0xFF)};
             paramsBuffer.put(modelIdentifier[1]);
@@ -151,6 +151,7 @@ public class ConfigModelPublicationSet extends ConfigMessage {
             paramsBuffer.put(modelIdentifier[2]);
             mParameters = paramsBuffer.array();
         }
+        Log.v(TAG, "Publication set: " + MeshParserUtils.bytesToHex(mParameters, false));
     }
 
     /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelPublicationSet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelPublicationSet.java
@@ -22,7 +22,6 @@
 
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
 import android.util.Log;
 
 import java.nio.ByteBuffer;
@@ -55,46 +54,6 @@ public class ConfigModelPublicationSet extends ConfigMessage {
     private final int publishRetransmitCount;
     private final int publishRetransmitIntervalSteps;
     private final int modelIdentifier;
-
-    /**
-     * Constructs a ConfigModelPublicationSet message
-     *
-     * @param elementAddress                 Element address that should publish
-     * @param publishAddress                 Address to which the element must publish
-     * @param appKeyIndex                    Index of the application key
-     * @param credentialFlag                 Credentials flag define which credentials to be used, set true to use friendship credentials and false for master credentials.
-     *                                       Currently supports only master credentials
-     * @param publishTtl                     Publication ttl
-     * @param publicationSteps               Publication steps for the publication period
-     * @param publicationResolution          Publication resolution of the publication period
-     * @param publishRetransmitCount         Number of publication retransmits
-     * @param publishRetransmitIntervalSteps Publish retransmit interval steps
-     * @param modelIdentifier                identifier for this model that will do publication
-     * @throws IllegalArgumentException for invalid arguments
-     * @deprecated in favour of {@link #ConfigModelPublicationSet(int, int, int, boolean, int, int, int, int, int, int)}
-     */
-    @Deprecated
-    public ConfigModelPublicationSet(@NonNull final byte[] elementAddress,
-                                     @NonNull final byte[] publishAddress,
-                                     final int appKeyIndex,
-                                     final boolean credentialFlag,
-                                     final int publishTtl,
-                                     final int publicationSteps,
-                                     final int publicationResolution,
-                                     final int publishRetransmitCount,
-                                     final int publishRetransmitIntervalSteps,
-                                     final int modelIdentifier) throws IllegalArgumentException {
-        this(MeshParserUtils.bytesToInt(elementAddress),
-                MeshParserUtils.bytesToInt(publishAddress),
-                appKeyIndex,
-                credentialFlag,
-                publishTtl,
-                publicationSteps,
-                publicationResolution,
-                publishRetransmitCount,
-                publishRetransmitIntervalSteps,
-                modelIdentifier);
-    }
 
     /**
      * Constructs a ConfigModelPublicationSet message

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelPublicationStatus.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelPublicationStatus.java
@@ -83,7 +83,6 @@ public class ConfigModelPublicationStatus extends ConfigStatusMessage implements
     @Override
     final void parseStatusParameters() {
         final AccessMessage message = (AccessMessage) mMessage;
-        final ByteBuffer buffer = ByteBuffer.wrap(message.getParameters()).order(ByteOrder.LITTLE_ENDIAN);
         mStatusCode = mParameters[0];
         mStatusCodeName = getStatusCodeName(mStatusCode);
         mElementAddress = MeshParserUtils.unsignedBytesToInt(mParameters[1], mParameters[2]);
@@ -93,8 +92,8 @@ public class ConfigModelPublicationStatus extends ConfigStatusMessage implements
         credentialFlag = (mParameters[6] & 0xF0) >> 4 == 1;
         publishTtl = MeshParserUtils.unsignedByteToInt(mParameters[7]);
         final int publishPeriod = MeshParserUtils.unsignedByteToInt(mParameters[8]);
-        publicationSteps = publishPeriod >> 6;
-        publicationResolution = publishPeriod & 0x03;
+        publicationSteps = publishPeriod & 0x3F;
+        publicationResolution = publishPeriod >> 6;
         final int publishRetransmission = MeshParserUtils.unsignedByteToInt(mParameters[9]);
         publishRetransmitCount = publishRetransmission >> 5;
         publishRetransmitIntervalSteps = publishRetransmission & 0x1F;
@@ -114,10 +113,11 @@ public class ConfigModelPublicationStatus extends ConfigStatusMessage implements
         Log.v(TAG, "App key index: " + MeshParserUtils.bytesToHex(appKeyIndex, false));
         Log.v(TAG, "Credential Flag: " + credentialFlag);
         Log.v(TAG, "Publish TTL: " + publishTtl);
-        Log.v(TAG, "Publish Period: " + publishPeriod);
+        Log.v(TAG, "Publish Period: " + publishPeriod + " where steps: " + publicationSteps + " and resolution: " + publicationResolution);
         Log.v(TAG, "Publish Retransmit Count: " + publishRetransmitCount);
         Log.v(TAG, "Publish Publish Interval Steps: " + publishRetransmitIntervalSteps);
         Log.v(TAG, "Model Identifier: " + Integer.toHexString(mModelIdentifier));
+        Log.v(TAG, "Publication status: " + MeshParserUtils.bytesToHex(mParameters, false));
     }
 
     @Override

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelSubscriptionAdd.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelSubscriptionAdd.java
@@ -22,8 +22,6 @@
 
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
-
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -46,22 +44,6 @@ public final class ConfigModelSubscriptionAdd extends ConfigMessage {
     private final int elementAddress;
     private final int mSubscriptionAddress;
     private final int mModelIdentifier;
-
-    /**
-     * Constructs ConfigModelSubscriptionDelete message.
-     *
-     * @param elementAddress      Address of the element to which the model belongs to.
-     * @param subscriptionAddress Address to whic the element should subscribe.
-     * @param modelIdentifier     identifier of the model, 16-bit for Sig model and 32-bit model id for vendor models.
-     * @throws IllegalArgumentException if any illegal arguments are passed
-     * @deprecated in favour of {@link #ConfigModelSubscriptionAdd(int, int, int)}
-     */
-    @Deprecated
-    public ConfigModelSubscriptionAdd(@NonNull final byte[] elementAddress,
-                                      @NonNull final byte[] subscriptionAddress,
-                                      final int modelIdentifier) throws IllegalArgumentException {
-        this(AddressUtils.getUnicastAddressInt(elementAddress), AddressUtils.getUnicastAddressInt(subscriptionAddress), modelIdentifier);
-    }
 
     /**
      * Constructs ConfigModelSubscriptionDelete message.

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelSubscriptionDelete.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ConfigModelSubscriptionDelete.java
@@ -22,8 +22,6 @@
 
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.support.annotation.NonNull;
-
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
@@ -46,21 +44,6 @@ public final class ConfigModelSubscriptionDelete extends ConfigMessage {
     private final int mElementAddress;
     private final int mSubscriptionAddress;
     private final int mModelIdentifier;
-
-    /**
-     * Constructs ConfigModelSubscriptionDelete message.
-     *
-     * @param elementAddress      Address of the element to which the model belongs to.
-     * @param subscriptionAddress Address to unsubscribe from or deleted.
-     * @param modelIdentifier     identifier of the model, 16-bit for Sig model and 32-bit model id for vendor models.
-     * @throws IllegalArgumentException if any illegal arguments are passed
-     */
-    @Deprecated
-    public ConfigModelSubscriptionDelete(@NonNull final byte[] elementAddress,
-                                         @NonNull final byte[] subscriptionAddress,
-                                         final int modelIdentifier) throws IllegalArgumentException {
-        this(AddressUtils.getUnicastAddressInt(elementAddress), AddressUtils.getUnicastAddressInt(subscriptionAddress), modelIdentifier);
-    }
 
     /**
      * Constructs ConfigModelSubscriptionDelete message.

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/DefaultNoOperationMessageState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/DefaultNoOperationMessageState.java
@@ -1,6 +1,5 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
@@ -27,11 +26,17 @@ class DefaultNoOperationMessageState extends MeshMessageState {
 
     private static final String TAG = DefaultNoOperationMessageState.class.getSimpleName();
 
-    DefaultNoOperationMessageState(@NonNull final Context context,
-                                   @Nullable final MeshMessage meshMessage,
+    /**
+     * Constructs the DefaultNoOperationMessageState
+     *
+     * @param meshMessage   {@link MeshMessage} Mesh message to be sent
+     * @param meshTransport {@link MeshTransport} Mesh transport
+     * @param callbacks     {@link InternalMeshMsgHandlerCallbacks} callbacks
+     */
+    DefaultNoOperationMessageState(@Nullable final MeshMessage meshMessage,
                                    @NonNull final MeshTransport meshTransport,
                                    @NonNull final InternalMeshMsgHandlerCallbacks callbacks) {
-        super(context, meshMessage, meshTransport, callbacks);
+        super(meshMessage, meshTransport, callbacks);
     }
 
     @Override
@@ -111,9 +116,9 @@ class DefaultNoOperationMessageState extends MeshMessageState {
                     final ConfigModelPublicationStatus status = new ConfigModelPublicationStatus(message);
                     if (status.isSuccessful()) {
                         final Element element = node.getElements().get(status.getElementAddress());
-                        if(element != null) {
+                        if (element != null) {
                             final MeshModel model = element.getMeshModels().get(status.getModelIdentifier());
-                            if(model != null) {
+                            if (model != null) {
                                 model.setPublicationStatus(status);
                             }
                         }
@@ -126,9 +131,9 @@ class DefaultNoOperationMessageState extends MeshMessageState {
 
                     if (status.isSuccessful()) {
                         final Element element = node.getElements().get(status.getElementAddress());
-                        if(element != null) {
+                        if (element != null) {
                             final MeshModel model = element.getMeshModels().get(status.getModelIdentifier());
-                            if(model != null) {
+                            if (model != null) {
                                 if (mMeshMessage instanceof ConfigModelSubscriptionAdd) {
                                     model.addSubscriptionAddress(status.getSubscriptionAddress());
                                 } else if (mMeshMessage instanceof ConfigModelSubscriptionDelete) {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/DefaultNoOperationMessageState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/DefaultNoOperationMessageState.java
@@ -228,7 +228,7 @@ class DefaultNoOperationMessageState extends MeshMessageState {
                 case LOWER_TRANSPORT_BLOCK_ACKNOWLEDGEMENT:
                     Log.v(TAG, "Acknowledgement payload: " + MeshParserUtils.bytesToHex(controlMessage.getTransportControlPdu(), false));
                     final ArrayList<Integer> retransmitPduIndexes = BlockAcknowledgementMessage.getSegmentsToBeRetransmitted(controlMessage.getTransportControlPdu(), segmentCount);
-                    mMeshStatusCallbacks.onBlockAcknowledgementReceived(controlMessage.getSrc());
+                    mMeshStatusCallbacks.onBlockAcknowledgementReceived(controlMessage.getSrc(), controlMessage);
                     executeResend(retransmitPduIndexes);
                     break;
                 default:

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/Element.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/Element.java
@@ -37,7 +37,6 @@ import java.util.Set;
 
 import no.nordicsemi.android.meshprovisioner.models.SigModel;
 import no.nordicsemi.android.meshprovisioner.models.VendorModel;
-import no.nordicsemi.android.meshprovisioner.utils.AddressUtils;
 
 @SuppressWarnings({"WeakerAccess", "unused"})
 public final class Element implements Parcelable {
@@ -64,18 +63,11 @@ public final class Element implements Parcelable {
 
     /**
      * Constructs an element within a node
-     * @param elementAddress element address
+     *
+     * @param elementAddress     element address
      * @param locationDescriptor location descriptor
-     * @param models models belonging to this element
-     * @deprecated in favour of {@link #Element(int, int, Map)}
+     * @param models             models belonging to this element
      */
-    @Deprecated
-    Element(@NonNull final byte[] elementAddress, final int locationDescriptor, final Map<Integer, MeshModel> models) {
-        this.elementAddress = AddressUtils.getUnicastAddressInt(elementAddress);
-        this.locationDescriptor = locationDescriptor;
-        this.meshModels = models;
-    }
-
     Element(final int elementAddress, final int locationDescriptor, final Map<Integer, MeshModel> models) {
         this.elementAddress = elementAddress;
         this.locationDescriptor = locationDescriptor;
@@ -128,7 +120,7 @@ public final class Element implements Parcelable {
         return locationDescriptor;
     }
 
-    public void setLocationDescriptor(final int locationDescriptor){
+    public void setLocationDescriptor(final int locationDescriptor) {
         this.locationDescriptor = locationDescriptor;
     }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericMessageState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericMessageState.java
@@ -1,6 +1,5 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
 
 import no.nordicsemi.android.meshprovisioner.utils.MeshAddress;
@@ -10,13 +9,12 @@ import no.nordicsemi.android.meshprovisioner.utils.MeshAddress;
  */
 class GenericMessageState extends MeshMessageState {
 
-    GenericMessageState(@NonNull final Context context,
-                        final int src,
+    GenericMessageState(final int src,
                         final int dst,
                         @NonNull final MeshMessage meshMessage,
                         @NonNull final MeshTransport meshTransport,
                         @NonNull final InternalMeshMsgHandlerCallbacks callbacks) throws IllegalArgumentException {
-        super(context, meshMessage, meshTransport, callbacks);
+        super(meshMessage, meshTransport, callbacks);
         this.mSrc = src;
         if (!MeshAddress.isAddressInRange(src)) {
             throw new IllegalArgumentException("Invalid address, a source address must be a valid 16-bit value!");

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshMessageHandlerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshMessageHandlerApi.java
@@ -13,13 +13,5 @@ interface MeshMessageHandlerApi {
      *
      * @param meshMessage {@link MeshMessage} Mesh message containing the message opcode and message parameters
      */
-    @Deprecated
-    void sendMeshMessage(@NonNull final byte[] src, @NonNull final byte[] dst, @NonNull final MeshMessage meshMessage);
-
-    /**
-     * Sends a mesh message specified within the {@link MeshMessage} object
-     *
-     * @param meshMessage {@link MeshMessage} Mesh message containing the message opcode and message parameters
-     */
     void sendMeshMessage(final int src, final int dst, @NonNull final MeshMessage meshMessage);
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshMessageState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshMessageState.java
@@ -1,6 +1,5 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
@@ -23,7 +22,6 @@ abstract class MeshMessageState implements LowerTransportLayerCallbacks {
 
     private static final String TAG = MeshMessageState.class.getSimpleName();
 
-    protected final Context mContext;
     final MeshTransport mMeshTransport;
     private final InternalMeshMsgHandlerCallbacks meshMessageHandlerCallbacks;
     MeshMessage mMeshMessage;
@@ -36,16 +34,13 @@ abstract class MeshMessageState implements LowerTransportLayerCallbacks {
     /**
      * Constructs the base mesh message state class
      *
-     * @param context       Context
      * @param meshMessage   {@link MeshMessage} Mesh message
      * @param meshTransport {@link MeshTransport} Mesh transport
      * @param callbacks     {@link InternalMeshMsgHandlerCallbacks} Internal mesh message handler callbacks
      */
-    MeshMessageState(@NonNull final Context context,
-                     @Nullable final MeshMessage meshMessage,
+    MeshMessageState(@Nullable final MeshMessage meshMessage,
                      @NonNull final MeshTransport meshTransport,
                      @NonNull final InternalMeshMsgHandlerCallbacks callbacks) {
-        this.mContext = context;
         this.mMeshMessage = meshMessage;
         if (meshMessage != null) {
             this.message = meshMessage.getMessage();
@@ -76,7 +71,7 @@ abstract class MeshMessageState implements LowerTransportLayerCallbacks {
     /**
      * Returns the current mesh state
      */
-    public abstract MessageState getState();
+    abstract MessageState getState();
 
     /**
      * Returns the mesh transport
@@ -109,6 +104,8 @@ abstract class MeshMessageState implements LowerTransportLayerCallbacks {
 
     /**
      * Re-sends the mesh pdu segments that were lost in flight
+     *
+     * @param retransmitPduIndexes list of indexes of the messages to be
      */
     final void executeResend(final List<Integer> retransmitPduIndexes) {
         if (message.getNetworkPdu().size() > 0 && !retransmitPduIndexes.isEmpty()) {
@@ -138,7 +135,7 @@ abstract class MeshMessageState implements LowerTransportLayerCallbacks {
 
     @Override
     public void sendSegmentAcknowledgementMessage(final ControlMessage controlMessage) {
-        //We don't send acks here
+        //We don't send acknowledgements here
         final ControlMessage message = mMeshTransport.createSegmentBlockAcknowledgementMessage(controlMessage);
         Log.v(TAG, "Sending acknowledgement: " + MeshParserUtils.bytesToHex(message.getNetworkPdu().get(0), false));
         mInternalTransportCallbacks.onMeshPduCreated(message.getDst(), message.getNetworkPdu().get(0));
@@ -155,7 +152,6 @@ abstract class MeshMessageState implements LowerTransportLayerCallbacks {
 
         //Application message States
         GENERIC_MESSAGE_STATE(502),
-
         VENDOR_MODEL_ACKNOWLEDGED_STATE(1000),
         VENDOR_MODEL_UNACKNOWLEDGED_STATE(1001);
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NetworkLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NetworkLayer.java
@@ -153,7 +153,6 @@ abstract class NetworkLayer extends LowerTransportLayer {
             //Next we create the PECB
             final byte[] pecb = createPECB(message.getIvIndex(), privacyRandom, privacyKey);
 
-
             final byte[] header = obfuscateNetworkHeader(ctlTTL, sequenceNumbers.get(i), src, pecb);
             final byte[] networkPdu = ByteBuffer.allocate(1 + 1 + header.length + encryptedPayload.length).order(ByteOrder.BIG_ENDIAN)
                     .put((byte) pduType)

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NetworkLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NetworkLayer.java
@@ -231,10 +231,10 @@ abstract class NetworkLayer extends LowerTransportLayer {
     /**
      * Encrypts the network payload of a network pdu
      *
-     * @param message           mesh message containing network layer pdu
-     * @param lowerTransportPdu lower transport pdu to be encrypted
-     * @param encryptionKey     key used to encrypt the payload.
-     * @return encrypted payload
+     * @param message           Mesh message containing network layer pdu
+     * @param lowerTransportPdu Lower transport pdu to be encrypted
+     * @param encryptionKey     Key used to encrypt the payload.
+     * @return Encrypted payload
      */
     private byte[] encryptNetworkPduPayload(@NonNull final Message message,
                                             @NonNull final byte[] sequenceNumber,
@@ -259,7 +259,7 @@ abstract class NetworkLayer extends LowerTransportLayer {
      * @param message           Mesh message containing network layer pdu
      * @param lowerTransportPdu Lower transport pdu to be encrypted
      * @param encryptionKey     Key used to encrypt the payload
-     * @return encrypted payload
+     * @return Encrypted payload
      */
     private byte[] encryptProxyConfigurationPduPayload(@NonNull final Message message,
                                                        @NonNull final byte[] lowerTransportPdu,
@@ -280,11 +280,11 @@ abstract class NetworkLayer extends LowerTransportLayer {
     /**
      * Obfuscates the network header
      *
-     * @param ctlTTL         message type and ttl bit
-     * @param sequenceNumber sequence number of the message
-     * @param src            source address
-     * @param pecb           value derived from the privacy random
-     * @return obfuscated network header
+     * @param ctlTTL         Message type and ttl bit
+     * @param sequenceNumber Sequence number of the message
+     * @param src            Source address
+     * @param pecb           Value derived from the privacy random
+     * @return Obfuscated network header
      */
     private byte[] obfuscateNetworkHeader(final byte ctlTTL, @NonNull final byte[] sequenceNumber, final int src, @NonNull final byte[] pecb) {
 
@@ -308,8 +308,8 @@ abstract class NetworkLayer extends LowerTransportLayer {
     /**
      * De-obfuscates the network header
      *
-     * @param pdu received from the node
-     * @return obfuscated network header
+     * @param pdu Received from the node
+     * @return Obfuscated network header
      */
     private byte[] deObfuscateNetworkHeader(@NonNull final byte[] pdu) {
         final byte[] privacyKey = getK2Output().getPrivacyKey();
@@ -335,7 +335,7 @@ abstract class NetworkLayer extends LowerTransportLayer {
     /**
      * Creates the privacy random.
      *
-     * @param encryptedUpperTransportPDU encrypted transport pdu
+     * @param encryptedUpperTransportPDU Encrypted transport pdu
      * @return Privacy random
      */
     private byte[] createPrivacyRandom(@NonNull final byte[] encryptedUpperTransportPDU) {
@@ -369,9 +369,9 @@ abstract class NetworkLayer extends LowerTransportLayer {
     /**
      * Creates the network nonce
      *
-     * @param ctlTTL         combined ctl and ttl value
-     * @param sequenceNumber sequence number of the message
-     * @param src            source address
+     * @param ctlTTL         Combined ctl and ttl value
+     * @param sequenceNumber Sequence number of the message
+     * @param src            Source address
      * @return Network nonce
      */
     private byte[] createNetworkNonce(final byte ctlTTL, @NonNull final byte[] sequenceNumber, final int src, @NonNull final byte[] ivIndex) {
@@ -388,8 +388,8 @@ abstract class NetworkLayer extends LowerTransportLayer {
     /**
      * Creates the proxy nonce
      *
-     * @param sequenceNumber sequence number of the message
-     * @param src            source address
+     * @param sequenceNumber Sequence number of the message
+     * @param src            Source address
      * @return Proxy nonce
      */
     private byte[] createProxyNonce(@NonNull final byte[] sequenceNumber, final int src, @NonNull final byte[] ivIndex) {
@@ -409,7 +409,7 @@ abstract class NetworkLayer extends LowerTransportLayer {
      * This method will drop messages with an invalid sequence number as all mesh messages are supposed to have a sequence
      * </p>
      *
-     * @param data pdu received from the mesh node
+     * @param data PDU received from the mesh node
      * @return complete {@link Message} that was successfully parsed or null otherwise
      */
     final Message parseMeshMessage(@NonNull final byte[] data) throws ExtendedInvalidCipherTextException {
@@ -467,12 +467,12 @@ abstract class NetworkLayer extends LowerTransportLayer {
     /**
      * Parses access message
      *
-     * @param data           received from the node
-     * @param networkHeader  de-obfuscated network header
-     * @param networkNonce   network nonce
-     * @param src            source address
-     * @param sequenceNumber sequence number of the received message
-     * @param micLength      network mic length of the received message
+     * @param data           Received from the node
+     * @param networkHeader  De-obfuscated network header
+     * @param networkNonce   Network nonce
+     * @param src            Source address
+     * @param sequenceNumber Sequence number of the received message
+     * @param micLength      Network mic length of the received message
      * @return access message
      */
     @VisibleForTesting

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NetworkLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NetworkLayer.java
@@ -257,9 +257,9 @@ abstract class NetworkLayer extends LowerTransportLayer {
     /**
      * Encrypts the network of a proxy configuration pdu.
      *
-     * @param message           mesh message containing network layer pdu
-     * @param lowerTransportPdu lower transport pdu to be encrypted
-     * @param encryptionKey     key used to encrypt the payload
+     * @param message           Mesh message containing network layer pdu
+     * @param lowerTransportPdu Lower transport pdu to be encrypted
+     * @param encryptionKey     Key used to encrypt the payload
      * @return encrypted payload
      */
     private byte[] encryptProxyConfigurationPduPayload(@NonNull final Message message,
@@ -285,7 +285,7 @@ abstract class NetworkLayer extends LowerTransportLayer {
      * @param sequenceNumber sequence number of the message
      * @param src            source address
      * @param pecb           value derived from the privacy random
-     * @return obfuscted network header
+     * @return obfuscated network header
      */
     private byte[] obfuscateNetworkHeader(final byte ctlTTL, @NonNull final byte[] sequenceNumber, final int src, @NonNull final byte[] pecb) {
 
@@ -310,7 +310,7 @@ abstract class NetworkLayer extends LowerTransportLayer {
      * De-obfuscates the network header
      *
      * @param pdu received from the node
-     * @return obfuscted network header
+     * @return obfuscated network header
      */
     private byte[] deObfuscateNetworkHeader(@NonNull final byte[] pdu) {
         final byte[] privacyKey = getK2Output().getPrivacyKey();

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProvisionedBaseMeshNode.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProvisionedBaseMeshNode.java
@@ -78,7 +78,7 @@ abstract class ProvisionedBaseMeshNode implements Parcelable {
     @Expose(serialize = false)
     protected byte[] networkKey;
     /**
-     * @deprecated IV Index is a network property hence movec to {@link MeshNetwork}
+     * @deprecated IV Index is a network property hence moved to {@link MeshNetwork}
      */
     @Deprecated
     @Ignore

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProxyConfigMessageState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProxyConfigMessageState.java
@@ -39,20 +39,18 @@ class ProxyConfigMessageState extends MeshMessageState {
     /**
      * Constructs the ProxyConfigMessageState for sending/receiving proxy configuration messages
      *
-     * @param context       Context
      * @param src           Source address
      * @param dst           Destination address
      * @param meshMessage   {@link MeshMessage} Mesh proxy config message
      * @param meshTransport {@link MeshTransport} Mesh transport
      * @param callbacks     {@link InternalMeshMsgHandlerCallbacks} Internal callbacks
      */
-    ProxyConfigMessageState(@NonNull final Context context,
-                            final int src,
+    ProxyConfigMessageState(final int src,
                             final int dst,
                             @NonNull final MeshMessage meshMessage,
                             @NonNull final MeshTransport meshTransport,
                             @NonNull final InternalMeshMsgHandlerCallbacks callbacks) {
-        super(context, meshMessage, meshTransport, callbacks);
+        super(meshMessage, meshTransport, callbacks);
         this.mSrc = src;
         this.mDst = dst;
         createControlMessage();

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageAckedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageAckedState.java
@@ -1,6 +1,5 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
@@ -15,20 +14,18 @@ class VendorModelMessageAckedState extends GenericMessageState {
     /**
      * Constructs {@link VendorModelMessageAckedState}
      *
-     * @param context                 Context of the application
      * @param src                     Source address
      * @param dst                     Destination address to which the message must be sent to
      * @param vendorModelMessageAcked Wrapper class {@link VendorModelMessageStatus} containing the opcode and parameters for {@link VendorModelMessageStatus} message
      * @param callbacks               {@link InternalMeshMsgHandlerCallbacks} for internal callbacks
      * @throws IllegalArgumentException exception for invalid arguments
      */
-    VendorModelMessageAckedState(@NonNull final Context context,
-                                 final int src,
+    VendorModelMessageAckedState(final int src,
                                  final int dst,
                                  @NonNull final VendorModelMessageAcked vendorModelMessageAcked,
                                  @NonNull final MeshTransport meshTransport,
                                  @NonNull final InternalMeshMsgHandlerCallbacks callbacks) throws IllegalArgumentException {
-        super(context, src, dst, vendorModelMessageAcked, meshTransport, callbacks);
+        super(src, dst, vendorModelMessageAcked, meshTransport, callbacks);
         this.mSrc = src;
         this.mDst = dst;
         createAccessMessage();

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageAckedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageAckedState.java
@@ -4,8 +4,6 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
-import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
-
 /**
  * State class for handling VendorModelMessageAckedState messages.
  */
@@ -13,26 +11,6 @@ import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 class VendorModelMessageAckedState extends GenericMessageState {
 
     private static final String TAG = VendorModelMessageAckedState.class.getSimpleName();
-
-    /**
-     * Constructs {@link VendorModelMessageAckedState}
-     *
-     * @param context                 Context of the application
-     * @param src                     Source address
-     * @param dst                     Destination address to which the message must be sent to
-     * @param vendorModelMessageAcked Wrapper class {@link VendorModelMessageStatus} containing the opcode and parameters for {@link VendorModelMessageStatus} message
-     * @param callbacks               {@link InternalMeshMsgHandlerCallbacks} for internal callbacks
-     * @throws IllegalArgumentException exception for invalid arguments
-     */
-    @Deprecated
-    VendorModelMessageAckedState(@NonNull final Context context,
-                                 @NonNull final byte[] src,
-                                 @NonNull final byte[] dst,
-                                 @NonNull final VendorModelMessageAcked vendorModelMessageAcked,
-                                 @NonNull final MeshTransport meshTransport,
-                                 @NonNull final InternalMeshMsgHandlerCallbacks callbacks) throws IllegalArgumentException {
-        this(context, MeshParserUtils.bytesToInt(src), MeshParserUtils.bytesToInt(dst), vendorModelMessageAcked, meshTransport, callbacks);
-    }
 
     /**
      * Constructs {@link VendorModelMessageAckedState}

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageUnackedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageUnackedState.java
@@ -1,6 +1,5 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import android.content.Context;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
@@ -12,20 +11,18 @@ class VendorModelMessageUnackedState extends GenericMessageState {
     /**
      * Constructs {@link VendorModelMessageAckedState}
      *
-     * @param context                   Context of the application
      * @param src                       Source address
      * @param dst                       Destination address to which the message must be sent to
      * @param vendorModelMessageUnacked Wrapper class {@link VendorModelMessageStatus} containing the opcode and parameters for {@link VendorModelMessageStatus} message
      * @param callbacks                 {@link InternalMeshMsgHandlerCallbacks} for internal callbacks
      * @throws IllegalArgumentException exception for invalid arguments
      */
-    VendorModelMessageUnackedState(@NonNull final Context context,
-                                   final int src,
+    VendorModelMessageUnackedState(final int src,
                                    final int dst,
                                    @NonNull final VendorModelMessageUnacked vendorModelMessageUnacked,
                                    @NonNull final MeshTransport meshTransport,
                                    @NonNull final InternalMeshMsgHandlerCallbacks callbacks) throws IllegalArgumentException {
-        super(context, src, dst, vendorModelMessageUnacked, meshTransport, callbacks);
+        super(src, dst, vendorModelMessageUnacked, meshTransport, callbacks);
         this.mSrc = src;
         this.mDst = dst;
         createAccessMessage();

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageUnackedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageUnackedState.java
@@ -4,33 +4,10 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.util.Log;
 
-import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
-
-@SuppressWarnings("WeakerAccess")
+@SuppressWarnings({"WeakerAccess", "unused"})
 class VendorModelMessageUnackedState extends GenericMessageState {
 
     private static final String TAG = VendorModelMessageUnackedState.class.getSimpleName();
-
-    /**
-     * Constructs {@link VendorModelMessageAckedState}
-     *
-     * @param context                   Context of the application
-     * @param src                       Source address
-     * @param dst                       Destination address to which the message must be sent to
-     * @param vendorModelMessageUnacked Wrapper class {@link VendorModelMessageStatus} containing the opcode and parameters for {@link VendorModelMessageStatus} message
-     * @param callbacks                 {@link InternalMeshMsgHandlerCallbacks} for internal callbacks
-     * @throws IllegalArgumentException exception for invalid arguments
-     * @deprecated in favour of {@link #VendorModelMessageUnackedState(Context, int, int, VendorModelMessageUnacked, MeshTransport, InternalMeshMsgHandlerCallbacks)}
-     */
-    @Deprecated
-    VendorModelMessageUnackedState(@NonNull final Context context,
-                                   @NonNull final byte[] src,
-                                   @NonNull final byte[] dst,
-                                   @NonNull final VendorModelMessageUnacked vendorModelMessageUnacked,
-                                   @NonNull final MeshTransport meshTransport,
-                                   @NonNull final InternalMeshMsgHandlerCallbacks callbacks) throws IllegalArgumentException {
-        this(context, MeshParserUtils.bytesToInt(src), MeshParserUtils.bytesToInt(dst), vendorModelMessageUnacked, meshTransport, callbacks);
-    }
 
     /**
      * Constructs {@link VendorModelMessageAckedState}

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/PublicationSettings.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/PublicationSettings.java
@@ -44,33 +44,7 @@ public class PublicationSettings implements Parcelable {
     @Expose
     private int publishRetransmitIntervalSteps = DEFAULT_PUBLICATION_RETRANSMIT_INTERVAL_STEPS;
 
-    public PublicationSettings() {
-
-    }
-
-    /**
-     * Constructs a ConfigModelPublicationSet message
-     *
-     * @param publishAddress                 Address to which the element must publish
-     * @param appKeyIndex                    Index of the application key
-     * @param credentialFlag                 Credentials flag define which credentials to be used, set true to use friendship credentials and false for master credentials. Currently supports only master credentials
-     * @param publishRetransmitCount         Number of publication retransmits
-     * @param publishRetransmitIntervalSteps Publish retransmit interval steps
-     * @deprecated in favour of {@link #PublicationSettings(int, int, boolean, int, int)}
-     */
-    @Deprecated
-    public PublicationSettings(final byte[] publishAddress,
-                               final int appKeyIndex,
-                               final boolean credentialFlag,
-                               final int publishRetransmitCount,
-                               final int publishRetransmitIntervalSteps) {
-        this(AddressUtils.getUnicastAddressInt(publishAddress), appKeyIndex, credentialFlag,
-                DEFAULT_PUBLISH_TTL,
-                DEFAULT_PUBLICATION_STEPS,
-                DEFAULT_PUBLICATION_RESOLUTION,
-                DEFAULT_PUBLICATION_RETRANSMIT_COUNT,
-                DEFAULT_PUBLICATION_RETRANSMIT_INTERVAL_STEPS);
-    }
+    public PublicationSettings() {}
 
     /**
      * Constructs a ConfigModelPublicationSet message
@@ -105,32 +79,6 @@ public class PublicationSettings implements Parcelable {
      * @param publicationResolution          Publication resolution of the publication period
      * @param publishRetransmitCount         Number of publication retransmits
      * @param publishRetransmitIntervalSteps Publish retransmit interval steps
-     * @deprecated in favour of {@link #PublicationSettings(int, int, boolean, int, int, int, int, int)}
-     */
-    @Deprecated
-    public PublicationSettings(final byte[] publishAddress,
-                               final int appKeyIndex,
-                               final boolean credentialFlag,
-                               final int publishTtl,
-                               final int publicationSteps,
-                               final int publicationResolution,
-                               final int publishRetransmitCount,
-                               final int publishRetransmitIntervalSteps) {
-        this(AddressUtils.getUnicastAddressInt(publishAddress), appKeyIndex, credentialFlag,
-                publishTtl, publicationSteps, publicationResolution, publishRetransmitCount, publishRetransmitIntervalSteps);
-    }
-
-    /**
-     * Constructs a ConfigModelPublicationSet message
-     *
-     * @param publishAddress                 Address to which the element must publish
-     * @param appKeyIndex                    Index of the application key
-     * @param credentialFlag                 Credentials flag define which credentials to be used, set true to use friendship credentials and false for master credentials. Currently supports only master credentials
-     * @param publishTtl                     Publication ttl
-     * @param publicationSteps               Publication steps for the publication period
-     * @param publicationResolution          Publication resolution of the publication period
-     * @param publishRetransmitCount         Number of publication retransmits
-     * @param publishRetransmitIntervalSteps Publish retransmit interval steps
      */
     public PublicationSettings(final int publishAddress,
                                final int appKeyIndex,
@@ -148,32 +96,6 @@ public class PublicationSettings implements Parcelable {
         this.publicationResolution = publicationResolution;
         this.publishRetransmitCount = publishRetransmitCount;
         this.publishRetransmitIntervalSteps = publishRetransmitIntervalSteps;
-    }
-
-    /**
-     * Constructs a ConfigModelPublicationSet message
-     *
-     * @param publishAddress                 Address to which the element must publish
-     * @param appKeyIndex                    Index of the application key
-     * @param credentialFlag                 Credentials flag define which credentials to be used, set true to use friendship credentials and false for master credentials. Currently supports only master credentials
-     * @param publishTtl                     Publication ttl
-     * @param publicationSteps               Publication steps for the publication period
-     * @param publicationResolution          Publication resolution of the publication period
-     * @param publishRetransmitCount         Number of publication retransmits
-     * @param publishRetransmitIntervalSteps Publish retransmit interval steps
-     * @deprecated in favour of {@link #PublicationSettings(int, byte[], int, int, int, int, int, int)}
-     */
-    @Deprecated
-    public PublicationSettings(final byte[] publishAddress,
-                               final byte[] appKeyIndex,
-                               final int credentialFlag,
-                               final int publishTtl,
-                               final int publicationSteps,
-                               final int publicationResolution,
-                               final int publishRetransmitCount,
-                               final int publishRetransmitIntervalSteps) {
-        this(AddressUtils.getUnicastAddressInt(publishAddress), appKeyIndex, credentialFlag,
-                publishTtl, publicationSteps, publicationResolution, publishRetransmitCount, publishRetransmitIntervalSteps);
     }
 
     /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/SecureUtils.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/SecureUtils.java
@@ -43,7 +43,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.security.SecureRandom;
-import java.security.Security;
 
 @SuppressWarnings("WeakerAccess")
 public class SecureUtils {


### PR DESCRIPTION
* Removed some of the APIs that was deprecated in prior to version 1.2.0.
* Renamed some API names to be more meaningful.
  - `sendMeshMessage(final int dst, @NonNull final MeshMessage meshMessage)` to `createdMeshPdu(final int dst, @NonNull final MeshMessage meshMessage)`. The mesh only generates mesh messages to be sent by the user.
  - `onBlockAcknowledgementSent(final int dst)` to `onBlockAcknowledgementProcessed(final int dst, @NonNull final ControlMessage message)`. The library has no control if the mesh messages were sent or not apart from that it had been generated to be sent.
  - `onMeshMessageSent(final int dst, final MeshMessage meshMessage)` to `onMeshMessageProcessed(final int dst, @NonNull final MeshMessage meshMessage)`. The library has no control if the mesh messages were sent or not apart from that it had been generated to be sent.
* Fixed a bug with ConfigModelPublicationSet.

