### PR TITLE
Improvement/use app key bound net key index for encryption

### DIFF
--- a/Example/nrf-mesh/app/build.gradle
+++ b/Example/nrf-mesh/app/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
 
     implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation 'com.google.android.material:material:1.1.0-alpha04'
+    implementation 'com.google.android.material:material:1.1.0-alpha05'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
@@ -79,7 +79,7 @@ dependencies {
     // Log Bluetooth LE events in nRF Logger
     implementation 'androidx.multidex:multidex:2.0.1'
     // Lifecycle extensions
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0-alpha03'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0-alpha04'
 
     implementation 'com.google.dagger:dagger:2.21'
     implementation 'com.google.dagger:dagger-android:2.21'

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/GenericLevelServerActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/GenericLevelServerActivity.java
@@ -13,6 +13,7 @@ import android.widget.Toast;
 import javax.inject.Inject;
 
 import no.nordicsemi.android.meshprovisioner.models.GenericLevelServerModel;
+import no.nordicsemi.android.meshprovisioner.transport.ApplicationKey;
 import no.nordicsemi.android.meshprovisioner.transport.Element;
 import no.nordicsemi.android.meshprovisioner.transport.GenericLevelGet;
 import no.nordicsemi.android.meshprovisioner.transport.GenericLevelSet;
@@ -218,7 +219,7 @@ public class GenericLevelServerActivity extends BaseModelConfigurationActivity {
             if (model != null) {
                 if (!model.getBoundAppKeyIndexes().isEmpty()) {
                     final int appKeyIndex = model.getBoundAppKeyIndexes().get(0);
-                    final byte[] appKey = model.getBoundAppKey(appKeyIndex).getKey();
+                    final ApplicationKey appKey = model.getBoundAppKey(appKeyIndex);
 
                     final int address = element.getElementAddress();
                     Log.v(TAG, "Sending message to element's unicast address: " + MeshAddress.formatAddress(address, true));
@@ -247,7 +248,7 @@ public class GenericLevelServerActivity extends BaseModelConfigurationActivity {
                 if (model != null) {
                     if (!model.getBoundAppKeyIndexes().isEmpty()) {
                         final int appKeyIndex = model.getBoundAppKeyIndexes().get(0);
-                        final byte[] appKey = model.getBoundAppKey(appKeyIndex).getKey();
+                        final ApplicationKey appKey = model.getBoundAppKey(appKeyIndex);
                         final int address = element.getElementAddress();
                         Log.v(TAG, "No subscription addresses found for model: " + CompositionDataParser.formatModelIdentifier(model.getModelId(), true)
                                 + ". Sending message to element's unicast address: " + MeshAddress.formatAddress(address, true));

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/GenericOnOffServerActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/GenericOnOffServerActivity.java
@@ -14,6 +14,7 @@ import android.widget.Toast;
 import javax.inject.Inject;
 
 import no.nordicsemi.android.meshprovisioner.models.GenericOnOffServerModel;
+import no.nordicsemi.android.meshprovisioner.transport.ApplicationKey;
 import no.nordicsemi.android.meshprovisioner.transport.Element;
 import no.nordicsemi.android.meshprovisioner.transport.GenericOnOffGet;
 import no.nordicsemi.android.meshprovisioner.transport.GenericOnOffSet;
@@ -206,7 +207,7 @@ public class GenericOnOffServerActivity extends BaseModelConfigurationActivity {
             if (model != null) {
                 if (!model.getBoundAppKeyIndexes().isEmpty()) {
                     final int appKeyIndex = model.getBoundAppKeyIndexes().get(0);
-                    final byte[] appKey = model.getBoundAppKey(appKeyIndex).getKey();
+                    final ApplicationKey appKey = model.getBoundAppKey(appKeyIndex);
 
                     final int address = element.getElementAddress();
                     Log.v(TAG, "Sending message to element's unicast address: " + MeshAddress.formatAddress(address, true));
@@ -236,7 +237,7 @@ public class GenericOnOffServerActivity extends BaseModelConfigurationActivity {
                 if (model != null) {
                     if (!model.getBoundAppKeyIndexes().isEmpty()) {
                         final int appKeyIndex = model.getBoundAppKeyIndexes().get(0);
-                        final byte[] appKey = model.getBoundAppKey(appKeyIndex).getKey();
+                        final ApplicationKey appKey = model.getBoundAppKey(appKeyIndex);
                         final int address = element.getElementAddress();
                         Log.v(TAG, "No subscription addresses found for model: " + CompositionDataParser.formatModelIdentifier(model.getModelId(), true)
                                 + ". Sending message to element's unicast address: " + MeshAddress.formatAddress(address, true));

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/VendorModelActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/VendorModelActivity.java
@@ -19,6 +19,7 @@ import android.widget.Toast;
 import javax.inject.Inject;
 
 import no.nordicsemi.android.meshprovisioner.models.VendorModel;
+import no.nordicsemi.android.meshprovisioner.transport.ApplicationKey;
 import no.nordicsemi.android.meshprovisioner.transport.Element;
 import no.nordicsemi.android.meshprovisioner.transport.MeshMessage;
 import no.nordicsemi.android.meshprovisioner.transport.MeshModel;
@@ -96,8 +97,8 @@ public class VendorModelActivity extends BaseModelConfigurationActivity {
             actionSend.setOnClickListener(v -> {
                 messageContainer.setVisibility(View.GONE);
                 receivedMessage.setText("");
-                final String opCode = opCodeEditText.getText().toString().trim();
-                final String parameters = parametersEditText.getText().toString().trim();
+                final String opCode = opCodeEditText.getEditableText().toString().trim();
+                final String parameters = parametersEditText.getEditableText().toString().trim();
 
                 if (!validateOpcode(opCode, opCodeLayout))
                     return;
@@ -212,7 +213,7 @@ public class VendorModelActivity extends BaseModelConfigurationActivity {
             final VendorModel model = (VendorModel) mViewModel.getSelectedModel().getValue();
             if (model != null) {
                 final int appKeyIndex = model.getBoundAppKeyIndexes().get(0);
-                final byte[] appKey = model.getBoundAppKey(appKeyIndex).getKey();
+                final ApplicationKey appKey = model.getBoundAppKey(appKeyIndex);
                 final MeshMessage message;
                 if (acknowledged) {
                     message = new VendorModelMessageAcked(appKey, model.getModelId(), model.getCompanyIdentifier(), opcode, parameters);

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/NrfMeshRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/NrfMeshRepository.java
@@ -1018,7 +1018,7 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
         }
 
         @Override
-        public void onBatchScanResults(final List<ScanResult> results) {
+        public void onBatchScanResults(@NonNull final List<ScanResult> results) {
             // Batch scan is disabled (report delay = 0)
         }
 

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/NrfMeshRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/NrfMeshRepository.java
@@ -804,7 +804,6 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
                         }, 2500);
                         mIsAppKeyAddCompleted = true;
                     }
-
                     mProvisioningStateLiveData.onMeshNodeStateUpdated(ProvisioningState.States.APP_KEY_STATUS_RECEIVED);
                 } else {
                     updateNode(node);

--- a/Example/nrf-mesh/build.gradle
+++ b/Example/nrf-mesh/build.gradle
@@ -29,7 +29,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.2'
+        classpath 'com.android.tools.build:gradle:3.4.0'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/Example/nrf-mesh/gradle/wrapper/gradle-wrapper.properties
+++ b/Example/nrf-mesh/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jan 15 08:16:42 CET 2019
+#Tue May 07 08:55:45 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/android-nrf-mesh-library/meshprovisioner/build.gradle
+++ b/android-nrf-mesh-library/meshprovisioner/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.6.3'
     androidTestImplementation 'org.mockito:mockito-android:2.6.3'
-    implementation 'androidx.annotation:annotation:1.1.0-alpha02'
+    implementation 'androidx.annotation:annotation:1.1.0-beta01'
     api 'no.nordicsemi.android:log:2.1.1'
     // Spongycastle - Android implementation of Bouncy Castle
     implementation 'com.madgag.spongycastle:core:1.56.0.0'

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
@@ -59,6 +59,7 @@ import no.nordicsemi.android.meshprovisioner.transport.NetworkLayerCallbacks;
 import no.nordicsemi.android.meshprovisioner.transport.ProvisionedMeshNode;
 import no.nordicsemi.android.meshprovisioner.transport.UpperTransportLayerCallbacks;
 import no.nordicsemi.android.meshprovisioner.utils.AddressUtils;
+import no.nordicsemi.android.meshprovisioner.utils.ExtendedInvalidCipherTextException;
 import no.nordicsemi.android.meshprovisioner.utils.InputOOBAction;
 import no.nordicsemi.android.meshprovisioner.utils.MeshAddress;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
@@ -296,32 +297,36 @@ public class MeshManagerApi implements MeshMngrApi {
      * @param unsegmentedPdu pdu received by the client.
      */
     private void parseNotifications(final byte[] unsegmentedPdu) {
-        switch (unsegmentedPdu[0]) {
-            case PDU_TYPE_NETWORK:
-                //MeshNetwork PDU
-                Log.v(TAG, "Received network pdu: " + MeshParserUtils.bytesToHex(unsegmentedPdu, true));
-                mMeshMessageHandler.parseNetworkPduNotifications(unsegmentedPdu, mMeshNetwork);
-                break;
-            case PDU_TYPE_MESH_BEACON:
-                //Mesh beacon
-                final byte[] n = mMeshNetwork.getPrimaryNetworkKey().getKey();
-                final byte[] flags = {(byte) mMeshNetwork.getProvisioningFlags()};
-                final byte[] networkId = SecureUtils.calculateK3(n);
-                final byte[] ivIndex = ByteBuffer.allocate(4).putInt(mMeshNetwork.getIvIndex()).array();
-                Log.v(TAG, "Generated mesh beacon: " +
-                        MeshParserUtils.bytesToHex(SecureUtils.calculateSecureNetworkBeacon(n, 1, flags, networkId, ivIndex), true));
-                Log.v(TAG, "Received mesh beacon: " + MeshParserUtils.bytesToHex(unsegmentedPdu, true));
-                break;
-            case PDU_TYPE_PROXY_CONFIGURATION:
-                //Proxy configuration
-                Log.v(TAG, "Received proxy configuration message: " + MeshParserUtils.bytesToHex(unsegmentedPdu, true));
-                mMeshMessageHandler.parseProxyPduNotifications(unsegmentedPdu);
-                break;
-            case PDU_TYPE_PROVISIONING:
-                //Provisioning PDU
-                Log.v(TAG, "Received provisioning message: " + MeshParserUtils.bytesToHex(unsegmentedPdu, true));
-                mMeshProvisioningHandler.parseProvisioningNotifications(unsegmentedPdu);
-                break;
+        try {
+            switch (unsegmentedPdu[0]) {
+                case PDU_TYPE_NETWORK:
+                    //MeshNetwork PDU
+                    Log.v(TAG, "Received network pdu: " + MeshParserUtils.bytesToHex(unsegmentedPdu, true));
+                    mMeshMessageHandler.parseMeshPduNotifications(unsegmentedPdu, mMeshNetwork);
+                    break;
+                case PDU_TYPE_MESH_BEACON:
+                    //Mesh beacon
+                    final byte[] n = mMeshNetwork.getPrimaryNetworkKey().getKey();
+                    final byte[] flags = {(byte) mMeshNetwork.getProvisioningFlags()};
+                    final byte[] networkId = SecureUtils.calculateK3(n);
+                    final byte[] ivIndex = ByteBuffer.allocate(4).putInt(mMeshNetwork.getIvIndex()).array();
+                    Log.v(TAG, "Generated mesh beacon: " +
+                            MeshParserUtils.bytesToHex(SecureUtils.calculateSecureNetworkBeacon(n, 1, flags, networkId, ivIndex), true));
+                    Log.v(TAG, "Received mesh beacon: " + MeshParserUtils.bytesToHex(unsegmentedPdu, true));
+                    break;
+                case PDU_TYPE_PROXY_CONFIGURATION:
+                    //Proxy configuration
+                    Log.v(TAG, "Received proxy configuration message: " + MeshParserUtils.bytesToHex(unsegmentedPdu, true));
+                    mMeshMessageHandler.parseMeshPduNotifications(unsegmentedPdu, mMeshNetwork);
+                    break;
+                case PDU_TYPE_PROVISIONING:
+                    //Provisioning PDU
+                    Log.v(TAG, "Received provisioning message: " + MeshParserUtils.bytesToHex(unsegmentedPdu, true));
+                    mMeshProvisioningHandler.parseProvisioningNotifications(unsegmentedPdu);
+                    break;
+            }
+        } catch (ExtendedInvalidCipherTextException ex) {
+            //TODO handle decryption failure
         }
     }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
@@ -894,7 +894,6 @@ public class MeshManagerApi implements MeshMngrApi {
                     break;
                 }
             }
-
             mMeshNetwork.nodes.add(meshNode);
         }
     };

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshMessageHandler.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshMessageHandler.java
@@ -28,6 +28,7 @@ import androidx.annotation.NonNull;
 import no.nordicsemi.android.meshprovisioner.transport.BaseMeshMessageHandler;
 import no.nordicsemi.android.meshprovisioner.transport.NetworkLayerCallbacks;
 import no.nordicsemi.android.meshprovisioner.transport.UpperTransportLayerCallbacks;
+import no.nordicsemi.android.meshprovisioner.utils.ExtendedInvalidCipherTextException;
 
 /**
  * MeshMessageHandler class for handling mesh
@@ -56,12 +57,7 @@ final class MeshMessageHandler extends BaseMeshMessageHandler {
 
 
     @Override
-    protected final void parseNetworkPduNotifications(@NonNull final byte[] pdu, @NonNull final MeshNetwork network) {
-        super.parseNetworkPduNotifications(pdu, network);
-    }
-
-    @Override
-    protected final void parseProxyPduNotifications(@NonNull final byte[] pdu) {
-        super.parseProxyPduNotifications(pdu);
+    protected final void parseMeshPduNotifications(@NonNull final byte[] pdu, @NonNull final MeshNetwork network) throws ExtendedInvalidCipherTextException {
+        super.parseMeshPduNotifications(pdu, network);
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ApplicationKey.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ApplicationKey.java
@@ -29,17 +29,6 @@ import static androidx.room.ForeignKey.CASCADE;
         indices = @Index("mesh_uuid"))
 public final class ApplicationKey implements Parcelable {
 
-    public static final Creator<ApplicationKey> CREATOR = new Creator<ApplicationKey>() {
-        @Override
-        public ApplicationKey createFromParcel(Parcel in) {
-            return new ApplicationKey(in);
-        }
-
-        @Override
-        public ApplicationKey[] newArray(int size) {
-            return new ApplicationKey[size];
-        }
-    };
     @PrimaryKey(autoGenerate = true)
     int id;
     @ColumnInfo(name = "mesh_uuid")
@@ -60,6 +49,18 @@ public final class ApplicationKey implements Parcelable {
     @ColumnInfo(name = "old_key")
     @Expose
     private byte[] oldKey;
+
+    public static final Creator<ApplicationKey> CREATOR = new Creator<ApplicationKey>() {
+        @Override
+        public ApplicationKey createFromParcel(Parcel in) {
+            return new ApplicationKey(in);
+        }
+
+        @Override
+        public ApplicationKey[] newArray(int size) {
+            return new ApplicationKey[size];
+        }
+    };
 
     /**
      * Constructs a ApplicationKey object with a given key index and network key

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/BaseMeshMessageHandler.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/BaseMeshMessageHandler.java
@@ -126,6 +126,8 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
                             }
                             node.setReceivedSequenceNumber(sequenceNo);
                         }
+                    } else {
+                        return;
                     }
 
                     byte[] nonce;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/DefaultNoOperationMessageState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/DefaultNoOperationMessageState.java
@@ -236,7 +236,7 @@ class DefaultNoOperationMessageState extends MeshMessageState {
      */
     private void parseControlMessage(final ControlMessage controlMessage) {
         //Get the segment count count of the access message
-        final int segmentCount = message.getNetworkPdu().size();
+        final int segmentCount = message.getNetworkLayerPdu().size();
         if (controlMessage.getPduType() == MeshManagerApi.PDU_TYPE_NETWORK) {
             final TransportControlMessage transportControlMessage = controlMessage.getTransportControlMessage();
             switch (transportControlMessage.getState()) {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/DefaultNoOperationMessageState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/DefaultNoOperationMessageState.java
@@ -45,10 +45,10 @@ class DefaultNoOperationMessageState extends MeshMessageState {
         return null;
     }
 
-    void parseMeshPdu(final byte[] pdu) {
+    void parseMeshPdu(@NonNull final ProvisionedMeshNode node, @NonNull final byte[] pdu, @NonNull final byte[] networkHeader, @NonNull final byte[] decryptedNetworkPayload) {
         final Message message;
         try {
-            message = mMeshTransport.parsePdu(pdu);
+            message = mMeshTransport.parsePdu(node, pdu, networkHeader, decryptedNetworkPayload);
             if (message != null) {
                 if (message instanceof AccessMessage) {
                     parseAccessMessage((AccessMessage) message);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelGet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelGet.java
@@ -19,10 +19,10 @@ public class GenericLevelGet extends GenericMessage {
     /**
      * Constructs GenericLevelGet message.
      *
-     * @param appKey application key for this message
+     * @param appKey {@link ApplicationKey} key for this message
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public GenericLevelGet(@NonNull final byte[] appKey) throws IllegalArgumentException {
+    public GenericLevelGet(@NonNull final ApplicationKey appKey) throws IllegalArgumentException {
         super(appKey);
         assembleMessageParameters();
     }
@@ -34,6 +34,6 @@ public class GenericLevelGet extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelSet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelSet.java
@@ -1,13 +1,13 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.util.Log;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import no.nordicsemi.android.meshprovisioner.opcodes.ApplicationMessageOpCodes;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
 
@@ -31,12 +31,12 @@ public class GenericLevelSet extends GenericMessage {
     /**
      * Constructs GenericLevelSet message.
      *
-     * @param appKey application key for this message
-     * @param level  level of the GenericLevelModel
-     * @param tId    transaction id which must be incremented for every message
+     * @param appKey {@link ApplicationKey} key for this message
+     * @param level  Level value
+     * @param tId    Transaction id which must be incremented for every message
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public GenericLevelSet(@NonNull final byte[] appKey,
+    public GenericLevelSet(@NonNull final ApplicationKey appKey,
                            final int level,
                            final int tId) throws IllegalArgumentException {
         this(appKey, null, null, null, level, tId);
@@ -45,16 +45,16 @@ public class GenericLevelSet extends GenericMessage {
     /**
      * Constructs GenericLevelSet message.
      *
-     * @param appKey               application key for this message
-     * @param transitionSteps      transition steps for the level
-     * @param transitionResolution transition resolution for the level
-     * @param delay                delay for this message to be executed 0 - 1275 milliseconds
-     * @param level                level of the GenericLevelModel
-     * @param tId                  transaction id
+     * @param appKey               {@link ApplicationKey} key for this message
+     * @param transitionSteps      Transition steps for the level
+     * @param transitionResolution Transition resolution for the level
+     * @param delay                Delay for this message to be executed 0 - 1275 milliseconds
+     * @param level                Level of the GenericLevelModel
+     * @param tId                  Transaction id
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
     @SuppressWarnings("WeakerAccess")
-    public GenericLevelSet(@NonNull final byte[] appKey,
+    public GenericLevelSet(@NonNull final ApplicationKey appKey,
                            @Nullable final Integer transitionSteps,
                            @Nullable final Integer transitionResolution,
                            @Nullable final Integer delay,
@@ -78,7 +78,7 @@ public class GenericLevelSet extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
         final ByteBuffer paramsBuffer;
         Log.v(TAG, "Level: " + mLevel);
         if (mTransitionSteps == null || mTransitionResolution == null || mDelay == null) {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelSetUnacknowledged.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericLevelSetUnacknowledged.java
@@ -31,12 +31,12 @@ public class GenericLevelSetUnacknowledged extends GenericMessage {
     /**
      * Constructs GenericLevelSetUnacknowledged message.
      *
-     * @param appKey application key for this message
-     * @param level  level of the GenericLevelModel
-     * @param tId    transaction id
+     * @param appKey {@link ApplicationKey} key for this message
+     * @param level  Level of the GenericLevelModel
+     * @param tId    Transaction id
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public GenericLevelSetUnacknowledged(@NonNull final byte[] appKey,
+    public GenericLevelSetUnacknowledged(@NonNull final ApplicationKey appKey,
                                          final int level,
                                          final int tId) throws IllegalArgumentException {
         this(appKey, null, null, null, level, tId);
@@ -45,16 +45,16 @@ public class GenericLevelSetUnacknowledged extends GenericMessage {
     /**
      * Constructs GenericLevelSetUnacknowledged message.
      *
-     * @param appKey               application key for this message
-     * @param transitionSteps      transition steps for the level
-     * @param transitionResolution transition resolution for the level
-     * @param delay                delay for this message to be executed 0 - 1275 milliseconds
-     * @param level                level of the GenericLevelModel
-     * @param tId                  transaction id
+     * @param appKey               {@link ApplicationKey} key for this message
+     * @param transitionSteps      Transition steps for the level
+     * @param transitionResolution Transition resolution for the level
+     * @param delay                Delay for this message to be executed 0 - 1275 milliseconds
+     * @param level                Level of the GenericLevelModel
+     * @param tId                  Transaction id
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
     @SuppressWarnings("WeakerAccess")
-    public GenericLevelSetUnacknowledged(@NonNull final byte[] appKey,
+    public GenericLevelSetUnacknowledged(@NonNull final ApplicationKey appKey,
                                          @Nullable final Integer transitionSteps,
                                          @Nullable final Integer transitionResolution,
                                          @Nullable final Integer delay,
@@ -78,7 +78,7 @@ public class GenericLevelSetUnacknowledged extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
         final ByteBuffer paramsBuffer;
         Log.v(TAG, "Level: " + mLevel);
         if (mTransitionSteps == null || mTransitionResolution == null || mDelay == null) {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericMessage.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericMessage.java
@@ -9,7 +9,7 @@ abstract class GenericMessage extends MeshMessage {
     public static final int GENERIC_TRANSITION_STEP_2 = 2;
     public static final int GENERIC_TRANSITION_STEP_3 = 3;
 
-    final byte[] mAppKey;
+    final ApplicationKey mAppKey;
     byte mAid;
 
     /**
@@ -17,8 +17,8 @@ abstract class GenericMessage extends MeshMessage {
      *
      * @param appKey application key
      */
-    GenericMessage(@NonNull final byte[] appKey) {
-        if (appKey.length != 16)
+    GenericMessage(@NonNull final ApplicationKey appKey) {
+        if (appKey.getKey().length != 16)
             throw new IllegalArgumentException("Application key must be 16 bytes");
         this.mAppKey = appKey;
     }
@@ -38,7 +38,7 @@ abstract class GenericMessage extends MeshMessage {
      *
      * @return app key
      */
-    public final byte[] getAppKey() {
+    public final ApplicationKey getAppKey() {
         return mAppKey;
     }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericMessageState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericMessageState.java
@@ -40,7 +40,7 @@ class GenericMessageState extends MeshMessageState {
      */
     protected void createAccessMessage() {
         final GenericMessage genericMessage = (GenericMessage) mMeshMessage;
-        final byte[] key = genericMessage.getAppKey();
+        final ApplicationKey key = genericMessage.getAppKey();
         final int akf = genericMessage.getAkf();
         final int aid = genericMessage.getAid();
         final int aszmic = genericMessage.getAszmic();

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffGet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffGet.java
@@ -21,7 +21,7 @@ public class GenericOnOffGet extends GenericMessage {
      * @param appKey application key for this message
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public GenericOnOffGet(@NonNull final byte[] appKey) throws IllegalArgumentException {
+    public GenericOnOffGet(@NonNull final ApplicationKey appKey) throws IllegalArgumentException {
         super(appKey);
         assembleMessageParameters();
     }
@@ -33,6 +33,6 @@ public class GenericOnOffGet extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffSet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffSet.java
@@ -1,12 +1,12 @@
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.util.Log;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import no.nordicsemi.android.meshprovisioner.opcodes.ApplicationMessageOpCodes;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
 
@@ -30,12 +30,12 @@ public class GenericOnOffSet extends GenericMessage {
     /**
      * Constructs GenericOnOffSet message.
      *
-     * @param appKey application key for this message
-     * @param state  boolean state of the GenericOnOffModel
-     * @param tId    transaction id
+     * @param appKey {@link ApplicationKey} key for this message
+     * @param state  Boolean state of the GenericOnOffModel
+     * @param tId    Transaction id
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public GenericOnOffSet(@NonNull final byte[] appKey,
+    public GenericOnOffSet(@NonNull final ApplicationKey appKey,
                            final boolean state,
                            final int tId) throws IllegalArgumentException {
         this(appKey, state, tId, null, null, null);
@@ -44,16 +44,16 @@ public class GenericOnOffSet extends GenericMessage {
     /**
      * Constructs GenericOnOffSet message.
      *
-     * @param appKey               application key for this message
-     * @param state                boolean state of the GenericOnOffModel
-     * @param tId                  transaction id
-     * @param transitionSteps      transition steps for the level
-     * @param transitionResolution transition resolution for the level
-     * @param delay                delay for this message to be executed 0 - 1275 milliseconds
+     * @param appKey               {@link ApplicationKey} key for this message
+     * @param state                Boolean state of the GenericOnOffModel
+     * @param tId                  Transaction id
+     * @param transitionSteps      Transition steps for the level
+     * @param transitionResolution Transition resolution for the level
+     * @param delay                Delay for this message to be executed 0 - 1275 milliseconds
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
     @SuppressWarnings("WeakerAccess")
-    public GenericOnOffSet(@NonNull final byte[] appKey,
+    public GenericOnOffSet(@NonNull final ApplicationKey appKey,
                            final boolean state,
                            final int tId,
                            @Nullable final Integer transitionSteps,
@@ -75,7 +75,7 @@ public class GenericOnOffSet extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
         final ByteBuffer paramsBuffer;
         Log.v(TAG, "State: " + (mState ? "ON" : "OFF"));
         if (mTransitionSteps == null || mTransitionResolution == null || mDelay == null) {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffSetUnacknowledged.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/GenericOnOffSetUnacknowledged.java
@@ -30,12 +30,12 @@ public class GenericOnOffSetUnacknowledged extends GenericMessage {
     /**
      * Constructs GenericOnOffSet message.
      *
-     * @param appKey Application key for this message
+     * @param appKey {@link ApplicationKey} key for this message
      * @param state  Boolean state of the GenericOnOffModel
      * @param tId    transaction id
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public GenericOnOffSetUnacknowledged(@NonNull final byte[] appKey,
+    public GenericOnOffSetUnacknowledged(@NonNull final ApplicationKey appKey,
                                          final boolean state,
                                          final int tId) throws IllegalArgumentException {
         this(appKey, state, tId, null, null, null);
@@ -44,7 +44,7 @@ public class GenericOnOffSetUnacknowledged extends GenericMessage {
     /**
      * Constructs GenericOnOffSet message.
      *
-     * @param appKey               Application key for this message
+     * @param appKey               {@link ApplicationKey} key for this message
      * @param state                Boolean state of the GenericOnOffModel
      * @param tId                  transaction id
      * @param transitionSteps      Transition steps for the level
@@ -53,7 +53,7 @@ public class GenericOnOffSetUnacknowledged extends GenericMessage {
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
     @SuppressWarnings("WeakerAccess")
-    public GenericOnOffSetUnacknowledged(@NonNull final byte[] appKey,
+    public GenericOnOffSetUnacknowledged(@NonNull final ApplicationKey appKey,
                                          final boolean state,
                                          final int tId,
                                          @Nullable final Integer transitionSteps,
@@ -75,7 +75,7 @@ public class GenericOnOffSetUnacknowledged extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
         final ByteBuffer paramsBuffer;
         Log.v(TAG, "State: " + (mState ? "ON" : "OFF"));
         if (mTransitionSteps == null || mTransitionResolution == null || mDelay == null) {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlGet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlGet.java
@@ -19,10 +19,10 @@ public class LightCtlGet extends GenericMessage {
     /**
      * Constructs LightCtlGet message.
      *
-     * @param appKey application key for this message
+     * @param appKey {@link ApplicationKey} key for this message
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public LightCtlGet(@NonNull final byte[] appKey) throws IllegalArgumentException {
+    public LightCtlGet(@NonNull final ApplicationKey appKey) throws IllegalArgumentException {
         super(appKey);
         assembleMessageParameters();
     }
@@ -34,6 +34,6 @@ public class LightCtlGet extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlSet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlSet.java
@@ -33,14 +33,14 @@ public class LightCtlSet extends GenericMessage {
     /**
      * Constructs LightCtlSet message.
      *
-     * @param appKey           application key for this message
-     * @param lightLightness   lightLightness of the LightCtlModel
-     * @param lightTemperature temperature of the LightCtlModel
-     * @param lightDeltaUv     delta uv of the LightCtlModel
-     * @param tId              transaction id
+     * @param appKey           {@link ApplicationKey} key for this message
+     * @param lightLightness   LightLightness of the LightCtlModel
+     * @param lightTemperature Temperature of the LightCtlModel
+     * @param lightDeltaUv     Delta uv of the LightCtlModel
+     * @param tId              Transaction id
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public LightCtlSet(@NonNull final byte[] appKey,
+    public LightCtlSet(@NonNull final ApplicationKey appKey,
                        final int lightLightness,
                        final int lightTemperature,
                        final int lightDeltaUv,
@@ -62,7 +62,7 @@ public class LightCtlSet extends GenericMessage {
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
     @SuppressWarnings("WeakerAccess")
-    public LightCtlSet(@NonNull final byte[] appKey,
+    public LightCtlSet(@NonNull final ApplicationKey appKey,
                        @Nullable final Integer transitionSteps,
                        @Nullable final Integer transitionResolution,
                        @Nullable final Integer delay,
@@ -94,7 +94,7 @@ public class LightCtlSet extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
         final ByteBuffer paramsBuffer;
         Log.v(TAG, "Lightness: " + mLightness);
         Log.v(TAG, "Temperature: " + mTemperature);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlSetUnacknowledged.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightCtlSetUnacknowledged.java
@@ -33,14 +33,14 @@ public class LightCtlSetUnacknowledged extends GenericMessage {
     /**
      * Constructs LightCtlSetUnacknowledged message.
      *
-     * @param appKey           application key for this message
-     * @param lightLightness   lightLightness of the LightCtlModel
-     * @param lightTemperature temperature of the LightCtlModel
-     * @param lightDeltaUv     delta uv of the LightCtlModel
-     * @param tId              transaction id
+     * @param appKey           {@link ApplicationKey} key for this message
+     * @param lightLightness   LightLightness of the LightCtlModel
+     * @param lightTemperature Temperature of the LightCtlModel
+     * @param lightDeltaUv     Delta uv of the LightCtlModel
+     * @param tId              Transaction id
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public LightCtlSetUnacknowledged(@NonNull final byte[] appKey,
+    public LightCtlSetUnacknowledged(@NonNull final ApplicationKey appKey,
                                      final int lightLightness,
                                      final int lightTemperature,
                                      final int lightDeltaUv,
@@ -62,7 +62,7 @@ public class LightCtlSetUnacknowledged extends GenericMessage {
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
     @SuppressWarnings("WeakerAccess")
-    public LightCtlSetUnacknowledged(@NonNull final byte[] appKey,
+    public LightCtlSetUnacknowledged(@NonNull final ApplicationKey appKey,
                                      @Nullable final Integer transitionSteps,
                                      @Nullable final Integer transitionResolution,
                                      @Nullable final Integer delay,
@@ -94,7 +94,7 @@ public class LightCtlSetUnacknowledged extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
         final ByteBuffer paramsBuffer;
         Log.v(TAG, "Lightness: " + mLightness);
         Log.v(TAG, "Temperature: " + mTemperature);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslGet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslGet.java
@@ -22,7 +22,7 @@ public class LightHslGet extends GenericMessage {
      * @param appKey application key for this message
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public LightHslGet(@NonNull final byte[] appKey) throws IllegalArgumentException {
+    public LightHslGet(@NonNull final ApplicationKey appKey) throws IllegalArgumentException {
         super(appKey);
         assembleMessageParameters();
     }
@@ -34,6 +34,6 @@ public class LightHslGet extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslSet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslSet.java
@@ -33,14 +33,14 @@ public class LightHslSet extends GenericMessage {
     /**
      * Constructs GenericLevelSet message.
      *
-     * @param appKey          application key for this message
-     * @param lightLightness  lightness of the LightHslModel
-     * @param lightHue        hue of the LightHslModel
-     * @param lightSaturation saturation of the LightHslModel
-     * @param tId             transaction id
+     * @param appKey          {@link ApplicationKey} key for this message
+     * @param lightLightness  Lightness of the LightHslModel
+     * @param lightHue        Hue of the LightHslModel
+     * @param lightSaturation Saturation of the LightHslModel
+     * @param tId             Transaction id
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public LightHslSet(@NonNull final byte[] appKey,
+    public LightHslSet(@NonNull final ApplicationKey appKey,
                        final int lightLightness,
                        final int lightHue,
                        final int lightSaturation,
@@ -51,18 +51,18 @@ public class LightHslSet extends GenericMessage {
     /**
      * Constructs GenericLevelSet message.
      *
-     * @param appKey               application key for this message
-     * @param transitionSteps      transition steps for the lightLightness
-     * @param transitionResolution transition resolution for the lightLightness
-     * @param delay                delay for this message to be executed 0 - 1275 milliseconds
-     * @param lightLightness       lightness of the LightHslModel
-     * @param lightHue             hue of the LightHslModel
-     * @param lightSaturation      saturation of the LightHslModel
-     * @param tId                  transaction id
+     * @param appKey               {@link ApplicationKey} key for this message
+     * @param transitionSteps      Transition steps for the lightLightness
+     * @param transitionResolution Transition resolution for the lightLightness
+     * @param delay                Delay for this message to be executed 0 - 1275 milliseconds
+     * @param lightLightness       Lightness of the LightHslModel
+     * @param lightHue             Hue of the LightHslModel
+     * @param lightSaturation      Saturation of the LightHslModel
+     * @param tId                  Transaction id
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
     @SuppressWarnings("WeakerAccess")
-    public LightHslSet(@NonNull final byte[] appKey,
+    public LightHslSet(@NonNull final ApplicationKey appKey,
                        @Nullable final Integer transitionSteps,
                        @Nullable final Integer transitionResolution,
                        @Nullable final Integer delay,
@@ -94,7 +94,7 @@ public class LightHslSet extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey() );
         final ByteBuffer paramsBuffer;
         Log.v(TAG, "Lightness: " + mLightness);
         Log.v(TAG, "Hue: " + mHue);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslSetUnacknowledged.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightHslSetUnacknowledged.java
@@ -33,14 +33,14 @@ public class LightHslSetUnacknowledged extends GenericMessage {
     /**
      * Constructs GenericLevelSet message.
      *
-     * @param appKey          application key for this message
+     * @param appKey          {@link ApplicationKey} key for this message
      * @param lightLightness  lightness of the LightHslModel
      * @param lightHue        hue of the LightHslModel
      * @param lightSaturation saturation of the LightHslModel
      * @param tId             transaction id
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public LightHslSetUnacknowledged(@NonNull final byte[] appKey,
+    public LightHslSetUnacknowledged(@NonNull final ApplicationKey appKey,
                                      final int lightLightness,
                                      final int lightHue,
                                      final int lightSaturation,
@@ -51,7 +51,7 @@ public class LightHslSetUnacknowledged extends GenericMessage {
     /**
      * Constructs GenericLevelSet message.
      *
-     * @param appKey               application key for this message
+     * @param appKey               {@link ApplicationKey} key for this message
      * @param transitionSteps      transition steps for the lightLightness
      * @param transitionResolution transition resolution for the lightLightness
      * @param delay                delay for this message to be executed 0 - 1275 milliseconds
@@ -62,7 +62,7 @@ public class LightHslSetUnacknowledged extends GenericMessage {
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
     @SuppressWarnings("WeakerAccess")
-    public LightHslSetUnacknowledged(@NonNull final byte[] appKey,
+    public LightHslSetUnacknowledged(@NonNull final ApplicationKey appKey,
                                      @Nullable final Integer transitionSteps,
                                      @Nullable final Integer transitionResolution,
                                      @Nullable final Integer delay,
@@ -94,7 +94,7 @@ public class LightHslSetUnacknowledged extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
         final ByteBuffer paramsBuffer;
         Log.v(TAG, "Lightness: " + mLightness);
         Log.v(TAG, "Hue: " + mHue);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessGet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessGet.java
@@ -19,10 +19,10 @@ public class LightLightnessGet extends GenericMessage {
     /**
      * Constructs LightLightnessGet message.
      *
-     * @param appKey application key for this message
+     * @param appKey {@link ApplicationKey} key for this message
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public LightLightnessGet(@NonNull final byte[] appKey) throws IllegalArgumentException {
+    public LightLightnessGet(@NonNull final ApplicationKey appKey) throws IllegalArgumentException {
         super(appKey);
         assembleMessageParameters();
     }
@@ -34,6 +34,6 @@ public class LightLightnessGet extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessSet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessSet.java
@@ -31,12 +31,12 @@ public class LightLightnessSet extends GenericMessage {
     /**
      * Constructs GenericLevelSet message.
      *
-     * @param appKey         application key for this message
+     * @param appKey         {@link ApplicationKey} key for this message
      * @param lightLightness lightLightness of the LightLightnessModel
      * @param tId            transaction id
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public LightLightnessSet(@NonNull final byte[] appKey,
+    public LightLightnessSet(@NonNull final ApplicationKey appKey,
                              final int lightLightness,
                              final int tId) throws IllegalArgumentException {
         this(appKey, null, null, null, lightLightness, tId);
@@ -54,7 +54,7 @@ public class LightLightnessSet extends GenericMessage {
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
     @SuppressWarnings("WeakerAccess")
-    public LightLightnessSet(@NonNull final byte[] appKey,
+    public LightLightnessSet(@NonNull final ApplicationKey appKey,
                              @Nullable final Integer transitionSteps,
                              @Nullable final Integer transitionResolution,
                              @Nullable final Integer delay,
@@ -78,7 +78,7 @@ public class LightLightnessSet extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
         final ByteBuffer paramsBuffer;
         Log.v(TAG, "Lightness: " + mLightness);
         if (mTransitionSteps == null || mTransitionResolution == null || mDelay == null) {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessSetUnacknowledged.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LightLightnessSetUnacknowledged.java
@@ -31,12 +31,12 @@ public class LightLightnessSetUnacknowledged extends GenericMessage {
     /**
      * Constructs GenericLevelSet message.
      *
-     * @param appKey application key for this message
-     * @param level  level of the GenericLevelModel
-     * @param tId    transaction Id
+     * @param appKey {@link ApplicationKey} key for this message
+     * @param level  Level value
+     * @param tId    Transaction Id
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public LightLightnessSetUnacknowledged(@NonNull final byte[] appKey,
+    public LightLightnessSetUnacknowledged(@NonNull final ApplicationKey appKey,
                                            final int level,
                                            final int tId) throws IllegalArgumentException {
         this(appKey, null, null, null, level, tId);
@@ -45,16 +45,16 @@ public class LightLightnessSetUnacknowledged extends GenericMessage {
     /**
      * Constructs GenericLevelSet message.
      *
-     * @param appKey               application key for this message
-     * @param transitionSteps      transition steps for the level
-     * @param transitionResolution transition resolution for the level
-     * @param delay                delay for this message to be executed 0 - 1275 milliseconds
-     * @param level                level of the GenericLevelModel
-     * @param tId                  transaction Id
+     * @param appKey               {@link ApplicationKey} key for this message
+     * @param transitionSteps      Transition steps for the level
+     * @param transitionResolution Transition resolution for the level
+     * @param delay                Delay for this message to be executed 0 - 1275 milliseconds
+     * @param level                Level of the GenericLevelModel
+     * @param tId                  Transaction Id
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
     @SuppressWarnings("WeakerAccess")
-    public LightLightnessSetUnacknowledged(@NonNull final byte[] appKey,
+    public LightLightnessSetUnacknowledged(@NonNull final ApplicationKey appKey,
                                            @Nullable final Integer transitionSteps,
                                            @Nullable final Integer transitionResolution,
                                            @Nullable final Integer delay,
@@ -78,7 +78,7 @@ public class LightLightnessSetUnacknowledged extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
         final ByteBuffer paramsBuffer;
         Log.v(TAG, "Level: " + mLevel);
         Log.v(TAG, "TID: " + tId);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshMessageState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshMessageState.java
@@ -91,9 +91,9 @@ abstract class MeshMessageState implements LowerTransportLayerCallbacks {
      * Starts sending the mesh pdu
      */
     public void executeSend() {
-        if (message.getNetworkPdu().size() > 0) {
-            for (int i = 0; i < message.getNetworkPdu().size(); i++) {
-                mInternalTransportCallbacks.onMeshPduCreated(mDst, message.getNetworkPdu().get(i));
+        if (message.getNetworkLayerPdu().size() > 0) {
+            for (int i = 0; i < message.getNetworkLayerPdu().size(); i++) {
+                mInternalTransportCallbacks.onMeshPduCreated(mDst, message.getNetworkLayerPdu().get(i));
             }
 
             if (mMeshStatusCallbacks != null) {
@@ -108,14 +108,14 @@ abstract class MeshMessageState implements LowerTransportLayerCallbacks {
      * @param retransmitPduIndexes list of indexes of the messages to be
      */
     final void executeResend(final List<Integer> retransmitPduIndexes) {
-        if (message.getNetworkPdu().size() > 0 && !retransmitPduIndexes.isEmpty()) {
+        if (message.getNetworkLayerPdu().size() > 0 && !retransmitPduIndexes.isEmpty()) {
             for (int i = 0; i < retransmitPduIndexes.size(); i++) {
                 final int segO = retransmitPduIndexes.get(i);
-                if (message.getNetworkPdu().get(segO) != null) {
-                    final byte[] pdu = message.getNetworkPdu().get(segO);
+                if (message.getNetworkLayerPdu().get(segO) != null) {
+                    final byte[] pdu = message.getNetworkLayerPdu().get(segO);
                     Log.v(TAG, "Resending segment " + segO + " : " + MeshParserUtils.bytesToHex(pdu, false));
                     final Message retransmitMeshMessage = mMeshTransport.createRetransmitMeshMessage(message, segO);
-                    mInternalTransportCallbacks.onMeshPduCreated(mDst, retransmitMeshMessage.getNetworkPdu().get(segO));
+                    mInternalTransportCallbacks.onMeshPduCreated(mDst, retransmitMeshMessage.getNetworkLayerPdu().get(segO));
                 }
             }
         }
@@ -137,8 +137,8 @@ abstract class MeshMessageState implements LowerTransportLayerCallbacks {
     public void sendSegmentAcknowledgementMessage(final ControlMessage controlMessage) {
         //We don't send acknowledgements here
         final ControlMessage message = mMeshTransport.createSegmentBlockAcknowledgementMessage(controlMessage);
-        Log.v(TAG, "Sending acknowledgement: " + MeshParserUtils.bytesToHex(message.getNetworkPdu().get(0), false));
-        mInternalTransportCallbacks.onMeshPduCreated(message.getDst(), message.getNetworkPdu().get(0));
+        Log.v(TAG, "Sending acknowledgement: " + MeshParserUtils.bytesToHex(message.getNetworkLayerPdu().get(0), false));
+        mInternalTransportCallbacks.onMeshPduCreated(message.getDst(), message.getNetworkLayerPdu().get(0));
         mMeshStatusCallbacks.onBlockAcknowledgementProcessed(message.getDst(), controlMessage);
     }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshTransport.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshTransport.java
@@ -26,6 +26,9 @@ import android.content.Context;
 import android.os.Handler;
 import android.util.Log;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import no.nordicsemi.android.meshprovisioner.MeshManagerApi;
@@ -33,6 +36,7 @@ import no.nordicsemi.android.meshprovisioner.Provisioner;
 import no.nordicsemi.android.meshprovisioner.utils.ExtendedInvalidCipherTextException;
 import no.nordicsemi.android.meshprovisioner.utils.MeshAddress;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
+import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
 
 /**
  * MeshTransport class is responsible for building the configuration and application layer mesh messages.
@@ -320,7 +324,11 @@ final class MeshTransport extends NetworkLayer {
      * @return Message
      */
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
-    final Message parsePdu(final byte[] pdu) throws ExtendedInvalidCipherTextException {
-        return parseMeshMessage(pdu);
+    final Message parsePdu(@NonNull final ProvisionedMeshNode node,
+                           @NonNull final byte[] pdu,
+                           @NonNull final byte[] networkHeader,
+                           @NonNull final byte[] decryptedNetworkPayload) throws ExtendedInvalidCipherTextException {
+
+        return parseMeshMessage(node, pdu, networkHeader, decryptedNetworkPayload);
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshTransport.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshTransport.java
@@ -128,8 +128,12 @@ final class MeshTransport extends NetworkLayer {
      * @param accessMessageParameters Parameters for the access message.
      * @return access message containing the mesh pdu
      */
-    final AccessMessage createMeshMessage(final int src, final int dst,
-                                          final byte[] key, final int akf, final int aid, final int aszmic,
+    final AccessMessage createMeshMessage(final int src,
+                                          final int dst,
+                                          final byte[] key,
+                                          final int akf,
+                                          final int aid,
+                                          final int aszmic,
                                           final int accessOpCode, final byte[] accessMessageParameters) {
         final int sequenceNumber = incrementSequenceNumber(src);
         final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(sequenceNumber);
@@ -177,9 +181,14 @@ final class MeshTransport extends NetworkLayer {
      * @param accessMessageParameters Parameters for the access message.
      * @return access message containing the mesh pdu
      */
-    final AccessMessage createMeshMessage(final int src, final int dst,
-                                          final ApplicationKey key, final int akf, final int aid, final int aszmic,
-                                          final int accessOpCode, final byte[] accessMessageParameters) {
+    final AccessMessage createMeshMessage(final int src,
+                                          final int dst,
+                                          final ApplicationKey key,
+                                          final int akf,
+                                          final int aid,
+                                          final int aszmic,
+                                          final int accessOpCode,
+                                          final byte[] accessMessageParameters) {
         final int sequenceNumber = incrementSequenceNumber(src);
         final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(sequenceNumber);
 
@@ -226,8 +235,13 @@ final class MeshTransport extends NetworkLayer {
      * @param accessMessageParameters Parameters for the access message.
      * @return access message containing the mesh pdu
      */
-    final AccessMessage createVendorMeshMessage(final int companyIdentifier, final int src, final int dst,
-                                                final ApplicationKey key, final int akf, final int aid, final int aszmic,
+    final AccessMessage createVendorMeshMessage(final int companyIdentifier,
+                                                final int src,
+                                                final int dst,
+                                                final ApplicationKey key,
+                                                final int akf,
+                                                final int aid,
+                                                final int aszmic,
                                                 final int accessOpCode, final byte[] accessMessageParameters) {
         final int sequenceNumber = incrementSequenceNumber(src);
         final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(sequenceNumber);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/Message.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/Message.java
@@ -55,23 +55,25 @@ abstract class Message implements Parcelable {
      **/
     private byte[] mSequenceNumber;
     /**
-     * key, used for encryption in transport layer which could be application key or device key
+     * deviceKey, used for encryption in transport layer which could be application deviceKey or device deviceKey
      **/
-    private byte[] key;
+    private byte[] deviceKey;
+
+    private ApplicationKey applicationKey;
     /**
-     * encryption key, derived from k2 using network key
+     * encryption deviceKey, derived from k2 using network deviceKey
      **/
     private byte[] encryptionKey;
     /**
-     * privacy key, derived from k2 using network key
+     * privacy deviceKey, derived from k2 using network deviceKey
      **/
     private byte[] privacyKey;
     /**
-     * akf if akf = 0 device key to be used for encryption in the transport layer if not use application key
+     * akf if akf = 0 device deviceKey to be used for encryption in the transport layer if not use application deviceKey
      **/
     private int akf;
     /**
-     * aid, if akf = 0 aid is also 0 if not aid is the identifier for the key used for encrytpion
+     * aid, if akf = 0 aid is also 0 if not aid is the identifier for the deviceKey used for encrytpion
      **/
     private int aid;
     /**
@@ -100,7 +102,8 @@ abstract class Message implements Parcelable {
         src = source.readInt();
         dst = source.readInt();
         mSequenceNumber = source.createByteArray();
-        key = source.createByteArray();
+        deviceKey = source.createByteArray();
+        applicationKey = (ApplicationKey) source.readValue(ApplicationKey.class.getClassLoader());
         encryptionKey = source.createByteArray();
         privacyKey = source.createByteArray();
         akf = source.readInt();
@@ -122,7 +125,8 @@ abstract class Message implements Parcelable {
         dest.writeInt(src);
         dest.writeInt(dst);
         dest.writeByteArray(mSequenceNumber);
-        dest.writeByteArray(key);
+        dest.writeByteArray(deviceKey);
+        dest.writeValue(applicationKey);
         dest.writeByteArray(encryptionKey);
         dest.writeByteArray(privacyKey);
         dest.writeInt(akf);
@@ -177,12 +181,20 @@ abstract class Message implements Parcelable {
         this.mSequenceNumber = sequenceNumber;
     }
 
-    public final byte[] getKey() {
-        return key;
+    public final byte[] getDeviceKey() {
+        return deviceKey;
     }
 
-    public final void setKey(final byte[] key) {
-        this.key = key;
+    public final void setDeviceKey(final byte[] deviceKey) {
+        this.deviceKey = deviceKey;
+    }
+
+    public final ApplicationKey getApplicationKey() {
+        return applicationKey;
+    }
+
+    public final void setApplicationKey(final ApplicationKey key) {
+        this.applicationKey = key;
     }
 
     public final byte[] getEncryptionKey() {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/Message.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/Message.java
@@ -29,74 +29,33 @@ import android.util.SparseArray;
 @SuppressWarnings({"WeakerAccess", "unused"})
 abstract class Message implements Parcelable {
 
-    /**
-     * ctl, if ctl = 0 access message and ctl = 1 control message
-     **/
-    protected int ctl;
-    protected SparseArray<byte[]> networkPdu;
-    /**
-     * pdu type
-     **/
-    private int pduType;
-    /**
-     * ttl, time to live
-     **/
-    private int ttl = 100;
-    /**
-     * src, source address
-     **/
-    private int src;
-    /**
-     * mDst, destination address
-     **/
-    private int dst;
-    /**
-     * sequence number, which is unique 24-bit value for each message
-     **/
-    private byte[] mSequenceNumber;
-    /**
-     * deviceKey, used for encryption in transport layer which could be application deviceKey or device deviceKey
-     **/
-    private byte[] deviceKey;
-
-    private ApplicationKey applicationKey;
-    /**
-     * encryption deviceKey, derived from k2 using network deviceKey
-     **/
-    private byte[] encryptionKey;
-    /**
-     * privacy deviceKey, derived from k2 using network deviceKey
-     **/
-    private byte[] privacyKey;
-    /**
-     * akf if akf = 0 device deviceKey to be used for encryption in the transport layer if not use application deviceKey
-     **/
-    private int akf;
-    /**
-     * aid, if akf = 0 aid is also 0 if not aid is the identifier for the deviceKey used for encrytpion
-     **/
-    private int aid;
-    /**
-     * aszmic, if aszmic = 0 the transmic is 32-bits, if aszmic = 1 transmic 64-bits this is usually for a segmented message
-     **/
-    private int aszmic;
-    /**
-     * opcode, operation code for the message
-     **/
-    private int opCode;
-    /**
-     * parameters, opcode parameters
-     **/
-    private byte[] parameters;
-    private int companyIdentifier;
-    private byte[] ivIndex;
+    protected int ctl;                              // If ctl = 0 access message and ctl = 1 control message
+    protected SparseArray<byte[]> networkLayerPdu;  // Mesh pdu
+    private int pduType;                            // PDU Type
+    private int ttl = 100;                          // Time to live
+    private int src;                                // Source address
+    private int dst;                                // Destination address
+    private byte[] mSequenceNumber;                 // unique 24-bit value for each message
+    private byte[] deviceKey;                       // Used for transport layer encryption of configuration messages
+    private ApplicationKey applicationKey;          // Used for transport layer encryption of application messages
+    private NetworkKey networkKey;                  // Used for transport layer encryption of application messages
+    private byte[] encryptionKey;                   // Derived from network key using k2 function
+    private byte[] privacyKey;                      // Derived from privacy key using k2 function
+    private int akf;                                // Use device key for encryption if akf = 0 or application key otherwise
+    private int aid;                                // Used to identify the application key generated using k4 function
+    private int aszmic;                             // if aszmic = 0 the transmic is 32-bits, if aszmic = 1 transmic 64-bits this is usually for a segmented message
+    private int opCode;                             // Opcode of message
+    private byte[] parameters;                      // Parameters of the message
+    private int companyIdentifier;                  // Company identifier for vendor model messages
+    private byte[] ivIndex;                         // IV Index of the network
     private boolean segmented;
 
-    Message(){}
+    Message() {
+    }
 
     protected Message(final Parcel source) {
         ctl = source.readInt();
-        networkPdu = readSparseArrayToParcelable(source);
+        networkLayerPdu = readSparseArrayToParcelable(source);
         pduType = source.readInt();
         ttl = source.readInt();
         src = source.readInt();
@@ -104,6 +63,7 @@ abstract class Message implements Parcelable {
         mSequenceNumber = source.createByteArray();
         deviceKey = source.createByteArray();
         applicationKey = (ApplicationKey) source.readValue(ApplicationKey.class.getClassLoader());
+        networkKey = (NetworkKey) source.readValue(NetworkKey.class.getClassLoader());
         encryptionKey = source.createByteArray();
         privacyKey = source.createByteArray();
         akf = source.readInt();
@@ -119,7 +79,7 @@ abstract class Message implements Parcelable {
     @Override
     public void writeToParcel(final Parcel dest, final int flags) {
         dest.writeInt(ctl);
-        writeSparseArrayToParcelable(dest, networkPdu);
+        writeSparseArrayToParcelable(dest, networkLayerPdu);
         dest.writeInt(pduType);
         dest.writeInt(ttl);
         dest.writeInt(src);
@@ -127,6 +87,7 @@ abstract class Message implements Parcelable {
         dest.writeByteArray(mSequenceNumber);
         dest.writeByteArray(deviceKey);
         dest.writeValue(applicationKey);
+        dest.writeValue(networkKey);
         dest.writeByteArray(encryptionKey);
         dest.writeByteArray(privacyKey);
         dest.writeInt(akf);
@@ -195,6 +156,14 @@ abstract class Message implements Parcelable {
 
     public final void setApplicationKey(final ApplicationKey key) {
         this.applicationKey = key;
+    }
+
+    public NetworkKey getNetworkKey() {
+        return networkKey;
+    }
+
+    public void setNetworkKey(final NetworkKey networkKey) {
+        this.networkKey = networkKey;
     }
 
     public final byte[] getEncryptionKey() {
@@ -277,26 +246,26 @@ abstract class Message implements Parcelable {
         this.segmented = segmented;
     }
 
-    public final SparseArray<byte[]> getNetworkPdu() {
-        return networkPdu;
+    public final SparseArray<byte[]> getNetworkLayerPdu() {
+        return networkLayerPdu;
     }
 
-    final void setNetworkPdu(final SparseArray<byte[]> pdu) {
-        networkPdu = pdu;
+    final void setNetworkLayerPdu(final SparseArray<byte[]> pdu) {
+        networkLayerPdu = pdu;
     }
 
-    protected final void writeSparseArrayToParcelable(final Parcel dest, final SparseArray<byte[]> array){
+    protected final void writeSparseArrayToParcelable(final Parcel dest, final SparseArray<byte[]> array) {
         final int size = array.size();
         dest.writeInt(size);
-        for(int i = 0; i < size; i++) {
+        for (int i = 0; i < size; i++) {
             dest.writeByteArray(array.valueAt(i));
         }
     }
 
-    protected final SparseArray<byte[]> readSparseArrayToParcelable(final Parcel src){
+    protected final SparseArray<byte[]> readSparseArrayToParcelable(final Parcel src) {
         final SparseArray<byte[]> array = new SparseArray<>();
         final int size = src.readInt();
-        for(int i = 0; i < size; i++) {
+        for (int i = 0; i < size; i++) {
             array.put(i, src.createByteArray());
         }
         return array;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneDelete.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneDelete.java
@@ -24,12 +24,12 @@ public class SceneDelete extends GenericMessage {
     /**
      * Constructs SceneDelete message.
      *
-     * @param appKey      application key for this message
-     * @param sceneNumber scene number of SceneDelete message
+     * @param appKey      {@link ApplicationKey} key for this message
+     * @param sceneNumber Scene number of SceneDelete message
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
     @SuppressWarnings("WeakerAccess")
-    public SceneDelete(@NonNull final byte[] appKey,
+    public SceneDelete(@NonNull final ApplicationKey appKey,
                        final int sceneNumber) {
         super(appKey);
         this.mSceneNumber = sceneNumber;
@@ -43,7 +43,7 @@ public class SceneDelete extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
         final ByteBuffer paramsBuffer;
         Log.v(TAG, "Scene Number: " + mSceneNumber);
         paramsBuffer = ByteBuffer.allocate(SCENE_DELETE_PARAMS_LENGTH).order(ByteOrder.LITTLE_ENDIAN);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneDeleteUnacknowledged.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneDeleteUnacknowledged.java
@@ -24,12 +24,12 @@ public class SceneDeleteUnacknowledged extends GenericMessage {
     /**
      * Constructs SceneDeleteUnacknowledged message.
      *
-     * @param appKey      application key for this message
-     * @param sceneNumber scene number of SceneDeleteUnacknowledged message
+     * @param appKey      {@link ApplicationKey} key for this message
+     * @param sceneNumber Scene number of SceneDeleteUnacknowledged message
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
     @SuppressWarnings("WeakerAccess")
-    public SceneDeleteUnacknowledged(@NonNull final byte[] appKey,
+    public SceneDeleteUnacknowledged(@NonNull final ApplicationKey appKey,
                                      final int sceneNumber) {
         super(appKey);
         this.mSceneNumber = sceneNumber;
@@ -43,7 +43,7 @@ public class SceneDeleteUnacknowledged extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
         final ByteBuffer paramsBuffer;
         Log.v(TAG, "Scene Number: " + mSceneNumber);
         paramsBuffer = ByteBuffer.allocate(SCENE_DELETE_PARAMS_LENGTH).order(ByteOrder.LITTLE_ENDIAN);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneGet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneGet.java
@@ -17,11 +17,11 @@ public class SceneGet extends GenericMessage {
     /**
      * Constructs SceneGet message.
      *
-     * @param appKey application key for this message
+     * @param appKey {@link ApplicationKey} key for this message
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
     @SuppressWarnings("WeakerAccess")
-    public SceneGet(@NonNull final byte[] appKey) {
+    public SceneGet(@NonNull final ApplicationKey appKey) {
         super(appKey);
         assembleMessageParameters();
     }
@@ -33,6 +33,6 @@ public class SceneGet extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRecall.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRecall.java
@@ -30,12 +30,12 @@ public class SceneRecall extends GenericMessage {
     /**
      * Constructs SceneStore message.
      *
-     * @param appKey      application key for this message
-     * @param sceneNumber sceneNumber
-     * @param tId         transaction Id
+     * @param appKey      {@link ApplicationKey} key for this message
+     * @param sceneNumber SceneNumber
+     * @param tId         Transaction Id
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public SceneRecall(@NonNull final byte[] appKey,
+    public SceneRecall(@NonNull final ApplicationKey appKey,
                        final int sceneNumber,
                        final int tId) throws IllegalArgumentException {
         this(appKey, null, null, null, sceneNumber, tId);
@@ -44,16 +44,16 @@ public class SceneRecall extends GenericMessage {
     /**
      * Constructs SceneStore message.
      *
-     * @param appKey               application key for this message
-     * @param transitionSteps      transition steps for the level
-     * @param transitionResolution transition resolution for the level
-     * @param delay                delay for this message to be executed 0 - 1275 milliseconds
+     * @param appKey               {@link ApplicationKey} key for this message
+     * @param transitionSteps      Transition steps for the level
+     * @param transitionResolution Transition resolution for the level
+     * @param delay                Delay for this message to be executed 0 - 1275 milliseconds
      * @param sceneNumber          sceneNumber
-     * @param tId                  transaction Id
+     * @param tId                  Transaction Id
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
     @SuppressWarnings("WeakerAccess")
-    public SceneRecall(@NonNull final byte[] appKey,
+    public SceneRecall(@NonNull final ApplicationKey appKey,
                        @Nullable final Integer transitionSteps,
                        @Nullable final Integer transitionResolution,
                        @Nullable final Integer delay,
@@ -75,7 +75,7 @@ public class SceneRecall extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
         final ByteBuffer paramsBuffer;
         Log.v(TAG, "Scene number: " + mSceneNumber);
         if (mTransitionSteps == null || mTransitionResolution == null || mDelay == null) {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRecallUnacknowledged.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRecallUnacknowledged.java
@@ -30,12 +30,12 @@ public class SceneRecallUnacknowledged extends GenericMessage {
     /**
      * Constructs SceneStore message.
      *
-     * @param appKey      application key for this message
-     * @param sceneNumber sceneNumber
-     * @param tId         transaction id
+     * @param appKey      {@link ApplicationKey} key for this message
+     * @param sceneNumber SceneNumber
+     * @param tId         Transaction id
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public SceneRecallUnacknowledged(@NonNull final byte[] appKey,
+    public SceneRecallUnacknowledged(@NonNull final ApplicationKey appKey,
                                      final int sceneNumber,
                                      final int tId) throws IllegalArgumentException {
         this(appKey, null, null, null, sceneNumber, tId);
@@ -44,16 +44,16 @@ public class SceneRecallUnacknowledged extends GenericMessage {
     /**
      * Constructs SceneStore message.
      *
-     * @param appKey               application key for this message
-     * @param transitionSteps      transition steps for the level
-     * @param transitionResolution transition resolution for the level
-     * @param delay                delay for this message to be executed 0 - 1275 milliseconds
-     * @param sceneNumber          sceneNumber
-     * @param tId                  transaction id
+     * @param appKey               {@link ApplicationKey} key for this message
+     * @param transitionSteps      Transition steps for the level
+     * @param transitionResolution Transition resolution for the level
+     * @param delay                Delay for this message to be executed 0 - 1275 milliseconds
+     * @param sceneNumber          SceneNumber
+     * @param tId                  Transaction id
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
     @SuppressWarnings("WeakerAccess")
-    public SceneRecallUnacknowledged(@NonNull final byte[] appKey,
+    public SceneRecallUnacknowledged(@NonNull final ApplicationKey appKey,
                                      @Nullable final Integer transitionSteps,
                                      @Nullable final Integer transitionResolution,
                                      @Nullable final Integer delay,
@@ -75,7 +75,7 @@ public class SceneRecallUnacknowledged extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
         final ByteBuffer paramsBuffer;
         Log.v(TAG, "Scene number: " + mSceneNumber);
         if (mTransitionSteps == null || mTransitionResolution == null || mDelay == null) {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRegisterGet.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneRegisterGet.java
@@ -21,7 +21,7 @@ public class SceneRegisterGet extends GenericMessage {
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
     @SuppressWarnings("WeakerAccess")
-    public SceneRegisterGet(@NonNull final byte[] appKey) {
+    public SceneRegisterGet(@NonNull final ApplicationKey appKey) {
         super(appKey);
         assembleMessageParameters();
     }
@@ -33,6 +33,6 @@ public class SceneRegisterGet extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneStore.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneStore.java
@@ -29,7 +29,7 @@ public class SceneStore extends GenericMessage {
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
     @SuppressWarnings("WeakerAccess")
-    public SceneStore(@NonNull final byte[] appKey,
+    public SceneStore(@NonNull final ApplicationKey appKey,
                       final int sceneNumber) {
         super(appKey);
         this.mSceneNumber = sceneNumber;
@@ -43,7 +43,7 @@ public class SceneStore extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
         final ByteBuffer paramsBuffer;
         Log.v(TAG, "State Number: " + mSceneNumber);
         paramsBuffer = ByteBuffer.allocate(SCENE_STORE_PARAMS_LENGTH).order(ByteOrder.LITTLE_ENDIAN);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneStoreUnacknowledged.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/SceneStoreUnacknowledged.java
@@ -24,12 +24,12 @@ public class SceneStoreUnacknowledged extends GenericMessage {
     /**
      * Constructs SceneStoreUnacknowledged message.
      *
-     * @param appKey      application key for this message
+     * @param appKey      {@link ApplicationKey} for this message
      * @param sceneNumber scene number of SceneStoreUnacknowledged message
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
     @SuppressWarnings("WeakerAccess")
-    public SceneStoreUnacknowledged(@NonNull final byte[] appKey,
+    public SceneStoreUnacknowledged(@NonNull final ApplicationKey appKey,
                                     final int sceneNumber) {
         super(appKey);
         this.mSceneNumber = sceneNumber;
@@ -43,7 +43,7 @@ public class SceneStoreUnacknowledged extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
         final ByteBuffer paramsBuffer;
         Log.v(TAG, "State Number: " + mSceneNumber);
         paramsBuffer = ByteBuffer.allocate(SCENE_STORE_PARAMS_LENGTH).order(ByteOrder.LITTLE_ENDIAN);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/UpperTransportLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/UpperTransportLayer.java
@@ -216,13 +216,15 @@ abstract class UpperTransportLayer extends AccessLayer {
         final int src = message.getSrc();
         final int dst = message.getDst();
         final byte[] ivIndex = message.getIvIndex();
-        final byte[] key = message.getKey();
+        final byte[] key;
 
         byte[] nonce;
         if (akf == APPLICATION_KEY_IDENTIFIER) {
+             key= message.getDeviceKey();
             nonce = createDeviceNonce(aszmic, sequenceNumber, src, dst, ivIndex);
             Log.v(TAG, "Device nonce: " + MeshParserUtils.bytesToHex(nonce, false));
         } else {
+             key = message.getApplicationKey().getKey();
             nonce = createApplicationNonce(aszmic, sequenceNumber, src, dst, ivIndex);
             Log.v(TAG, "Application nonce: " + MeshParserUtils.bytesToHex(nonce, false));
         }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/UpperTransportLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/UpperTransportLayer.java
@@ -56,7 +56,7 @@ abstract class UpperTransportLayer extends AccessLayer {
     //Nonce paddings
     static final int PAD_NETWORK_NONCE = 0x00;
     static final int PAD_PROXY_NONCE = 0x00;
-    private static final int APPLICATION_KEY_IDENTIFIER = 0; //Identifies that the device key is to be used
+    static final int APPLICATION_KEY_IDENTIFIER = 0; //Identifies that the device key is to be used
     private static final int MAX_UNSEGMENTED_ACCESS_PAYLOAD_LENGTH = 15;
     private static final int NONCE_TYPE_APPLICATION = 0x01;
     private static final int NONCE_TYPE_DEVICE = 0x02;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageAcked.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageAcked.java
@@ -20,12 +20,12 @@ public class VendorModelMessageAcked extends GenericMessage {
     /**
      * Constructs VendorModelMessageAcked message.
      *
-     * @param appKey            Application key for this message
+     * @param appKey            {@link ApplicationKey} for this message
      * @param modelId           32-bit Model identifier
      * @param companyIdentifier 16-bit Company identifier of the vendor model
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public VendorModelMessageAcked(@NonNull final byte[] appKey,
+    public VendorModelMessageAcked(@NonNull final ApplicationKey appKey,
                                    final int modelId,
                                    final int companyIdentifier,
                                    final int opCode,
@@ -45,7 +45,7 @@ public class VendorModelMessageAcked extends GenericMessage {
 
     @Override
     void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
     }
 
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageAckedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageAckedState.java
@@ -40,7 +40,7 @@ class VendorModelMessageAckedState extends GenericMessageState {
     @Override
     protected final void createAccessMessage() {
         final VendorModelMessageAcked vendorModelMessageAcked = (VendorModelMessageAcked) mMeshMessage;
-        final byte[] key = vendorModelMessageAcked.getAppKey();
+        final ApplicationKey key = vendorModelMessageAcked.getAppKey();
         final int akf = vendorModelMessageAcked.getAkf();
         final int aid = vendorModelMessageAcked.getAid();
         final int aszmic = vendorModelMessageAcked.getAszmic();

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageUnacked.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageUnacked.java
@@ -20,12 +20,12 @@ public class VendorModelMessageUnacked extends GenericMessage {
     /**
      * Constructs VendorModelMessageAcked message.
      *
-     * @param appKey            Application key for this message
+     * @param appKey            {@link ApplicationKey} for this message
      * @param modelId           model identifier
      * @param companyIdentifier Company identifier of the vendor model
      * @throws IllegalArgumentException if any illegal arguments are passed
      */
-    public VendorModelMessageUnacked(@NonNull final byte[] appKey,
+    public VendorModelMessageUnacked(@NonNull final ApplicationKey appKey,
                                      final int modelId,
                                      final int companyIdentifier,
                                      final int opCode,
@@ -40,7 +40,7 @@ public class VendorModelMessageUnacked extends GenericMessage {
 
     @Override
     final void assembleMessageParameters() {
-        mAid = SecureUtils.calculateK4(mAppKey);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
     }
 
     @Override

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageUnackedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageUnackedState.java
@@ -37,7 +37,7 @@ class VendorModelMessageUnackedState extends GenericMessageState {
     @Override
     protected final void createAccessMessage() {
         final VendorModelMessageUnacked vendorModelMessageUnacked = (VendorModelMessageUnacked) mMeshMessage;
-        final byte[] key = vendorModelMessageUnacked.getAppKey();
+        final ApplicationKey key = vendorModelMessageUnacked.getAppKey();
         final int akf = vendorModelMessageUnacked.getAkf();
         final int aid = vendorModelMessageUnacked.getAid();
         final int aszmic = vendorModelMessageUnacked.getAszmic();

--- a/android-nrf-mesh-library/meshprovisioner/src/test/java/no/nordicsemi/android/meshprovisioner/transport/LowerTransportLayerTests.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/test/java/no/nordicsemi/android/meshprovisioner/transport/LowerTransportLayerTests.java
@@ -71,7 +71,7 @@ public class LowerTransportLayerTests {
         accessMessage.setDst(dst);
         accessMessage.setSequenceNumber(sequenceNumber);
         accessMessage.setIvIndex(ivIndex);
-        accessMessage.setKey(deviceKey);
+        accessMessage.setDeviceKey(deviceKey);
         accessMessage.setAkf(akf);
         accessMessage.setAszmic(aszmic);
         accessMessage.setUpperTransportPdu(upperTransportPdu);
@@ -105,7 +105,7 @@ public class LowerTransportLayerTests {
         accessMessage.setDst(dst);
         accessMessage.setSequenceNumber(sequenceNumber);
         accessMessage.setIvIndex(ivIndex);
-        accessMessage.setKey(deviceKey);
+        accessMessage.setDeviceKey(deviceKey);
         accessMessage.setAkf(akf);
         accessMessage.setAszmic(aszmic);
         accessMessage.setUpperTransportPdu(upperTransportPdu);

--- a/android-nrf-mesh-library/meshprovisioner/src/test/java/no/nordicsemi/android/meshprovisioner/transport/NetworkLayerTests.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/test/java/no/nordicsemi/android/meshprovisioner/transport/NetworkLayerTests.java
@@ -25,8 +25,8 @@ package no.nordicsemi.android.meshprovisioner.transport;
 import android.content.Context;
 import android.util.SparseArray;
 
-import junit.framework.Assert;
 
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -67,7 +67,6 @@ public class NetworkLayerTests {
 
         final byte[] netkey = MeshParserUtils.toByteArray("7dd7364cd842ad18c17c2b820c84c3d6");
 
-        final int ctl = 0x00;
         final int ttl = 0x0b;
         final byte[] sequenceNumber = MeshParserUtils.toByteArray("000006");
         final int src = 0x1201;
@@ -94,7 +93,7 @@ public class NetworkLayerTests {
 
         final Message message = meshLayerTestBase.createNetworkLayerPDU(accessMessage);
 
-        final SparseArray<byte[]> actualNetworkTransportPdu = message.getNetworkPdu();
+        final SparseArray<byte[]> actualNetworkTransportPdu = message.getNetworkLayerPdu();
 
         Assert.assertFalse("Segment count does not match", expectedNetworkPdu.size() != actualNetworkTransportPdu.size());
 
@@ -117,7 +116,6 @@ public class NetworkLayerTests {
 
         final byte[] netkey = MeshParserUtils.toByteArray("7dd7364cd842ad18c17c2b820c84c3d6");
 
-        final int ctl = 0x00;
         final int ttl = 0x04;
         final byte[] sequenceNumber = MeshParserUtils.toByteArray("3129ab");
         final int src = 0x0003;
@@ -145,7 +143,7 @@ public class NetworkLayerTests {
 
         final Message message = meshLayerTestBase.createNetworkLayerPDU(accessMessage);
 
-        final SparseArray<byte[]> actualNetworkTransportPdu = message.getNetworkPdu();
+        final SparseArray<byte[]> actualNetworkTransportPdu = message.getNetworkLayerPdu();
 
         Assert.assertFalse("Segment count does not match", expectedNetworkPdu.size() != actualNetworkTransportPdu.size());
 
@@ -222,7 +220,6 @@ public class NetworkLayerTests {
 
         final byte[] netkey = MeshParserUtils.toByteArray("d1aafb2a1a3c281cbdb0e960edfad852");
 
-        final int ctl = 0x00;
         final int ttl = 0x04;
         final byte[] sequenceNumber = MeshParserUtils.toByteArray("000001");
         final int src = 0x0001;
@@ -248,7 +245,7 @@ public class NetworkLayerTests {
 
         final Message message = meshLayerTestBase.createNetworkLayerPDU(accessMessage);
 
-        final SparseArray<byte[]> actualNetworkTransportPdu = message.getNetworkPdu();
+        final SparseArray<byte[]> actualNetworkTransportPdu = message.getNetworkLayerPdu();
 
         Assert.assertFalse("Segment count does not match", expectedProxyConfigurationPdu.size() != actualNetworkTransportPdu.size());
 

--- a/android-nrf-mesh-library/meshprovisioner/src/test/java/no/nordicsemi/android/meshprovisioner/transport/UpperTransportLayerTests.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/test/java/no/nordicsemi/android/meshprovisioner/transport/UpperTransportLayerTests.java
@@ -73,7 +73,7 @@ public class UpperTransportLayerTests {
         accessMessage.setDst(dst);
         accessMessage.setSequenceNumber(sequenceNumber);
         accessMessage.setIvIndex(ivIndex);
-        accessMessage.setKey(deviceKey);
+        accessMessage.setDeviceKey(deviceKey);
         accessMessage.setAkf(akf);
         accessMessage.setAszmic(aszmic);
         accessMessage.setAccessPdu(accessPdu);


### PR DESCRIPTION
* Uses the application keys bound net key index when encrypting a message in the network layer.
* Added improvement to network layer decryption by use the NID of a received mesh message. This will also add support to having multiple network keys in the network. P.S. Multiple network keys are experimental and is not completely tested yet.
