### PR TITLE
Feature/add proxy filter tab

### DIFF
--- a/Example/nrf-mesh/app/build.gradle
+++ b/Example/nrf-mesh/app/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha3'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-alpha5'
 
     // Butter Knife
     implementation 'com.jakewharton:butterknife:10.1.0'

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/MainActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/MainActivity.java
@@ -22,30 +22,29 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner;
 
-import androidx.lifecycle.ViewModelProvider;
-import androidx.lifecycle.ViewModelProviders;
 import android.content.Intent;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import com.google.android.material.bottomnavigation.BottomNavigationView;
-import androidx.fragment.app.Fragment;
-import androidx.fragment.app.FragmentTransaction;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
-
 import android.view.Menu;
 import android.view.MenuItem;
 
+import com.google.android.material.bottomnavigation.BottomNavigationView;
+
 import javax.inject.Inject;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentTransaction;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelProviders;
 import butterknife.ButterKnife;
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
 import dagger.android.support.HasSupportFragmentInjector;
 import no.nordicsemi.android.nrfmeshprovisioner.di.Injectable;
 import no.nordicsemi.android.nrfmeshprovisioner.utils.Utils;
-import no.nordicsemi.android.nrfmeshprovisioner.viewmodels.ModelConfigurationViewModel;
 import no.nordicsemi.android.nrfmeshprovisioner.viewmodels.SharedViewModel;
 
 public class MainActivity extends AppCompatActivity implements Injectable,
@@ -62,10 +61,9 @@ public class MainActivity extends AppCompatActivity implements Injectable,
     @Inject
     ViewModelProvider.Factory mViewModelFactory;
 
-    private BottomNavigationView mBottomNavigationView;
-
     private NetworkFragment mNetworkFragment;
     private GroupsFragment mGroupsFragment;
+    private ProxyFilterFragment mProxyFilterFragment;
     private Fragment mSettingsFragment;
     private SharedViewModel mViewModel;
 
@@ -83,16 +81,17 @@ public class MainActivity extends AppCompatActivity implements Injectable,
 
         mNetworkFragment = (NetworkFragment) getSupportFragmentManager().findFragmentById(R.id.fragment_network);
         mGroupsFragment = (GroupsFragment) getSupportFragmentManager().findFragmentById(R.id.fragment_groups);
+        mProxyFilterFragment = (ProxyFilterFragment) getSupportFragmentManager().findFragmentById(R.id.fragment_proxy);
         mSettingsFragment = getSupportFragmentManager().findFragmentById(R.id.fragment_settings);
-        mBottomNavigationView = findViewById(R.id.bottom_navigation_view);
+        final BottomNavigationView bottomNavigationView = findViewById(R.id.bottom_navigation_view);
 
-        mBottomNavigationView.setOnNavigationItemSelectedListener(this);
-        mBottomNavigationView.setOnNavigationItemReselectedListener(this);
+        bottomNavigationView.setOnNavigationItemSelectedListener(this);
+        bottomNavigationView.setOnNavigationItemReselectedListener(this);
 
         if (savedInstanceState == null) {
-            onNavigationItemSelected(mBottomNavigationView.getMenu().findItem(R.id.action_network));
+            onNavigationItemSelected(bottomNavigationView.getMenu().findItem(R.id.action_network));
         } else {
-            mBottomNavigationView.setSelectedItemId(savedInstanceState.getInt(CURRENT_FRAGMENT));
+            bottomNavigationView.setSelectedItemId(savedInstanceState.getInt(CURRENT_FRAGMENT));
         }
     }
 
@@ -128,11 +127,7 @@ public class MainActivity extends AppCompatActivity implements Injectable,
 
     @Override
     public void onBackPressed() {
-        if(getSupportFragmentManager().getFragments().size() > TAB_COUNT) {
-            getSupportFragmentManager().popBackStack();
-        } else {
-            super.onBackPressed();
-        }
+        super.onBackPressed();
     }
 
     @Override
@@ -146,13 +141,16 @@ public class MainActivity extends AppCompatActivity implements Injectable,
         final FragmentTransaction ft = getSupportFragmentManager().beginTransaction();
         switch (id) {
             case R.id.action_network:
-                ft.show(mNetworkFragment).hide(mGroupsFragment).hide(mSettingsFragment);
+                ft.show(mNetworkFragment).hide(mGroupsFragment).hide(mProxyFilterFragment).hide(mSettingsFragment);
                 break;
-            case R.id.action_scanner:
-                ft.hide(mNetworkFragment).show(mGroupsFragment).hide(mSettingsFragment);
+            case R.id.action_groups:
+                ft.hide(mNetworkFragment).show(mGroupsFragment).hide(mProxyFilterFragment).hide(mSettingsFragment);
+                break;
+            case R.id.action_proxy:
+                ft.hide(mNetworkFragment).hide(mGroupsFragment).show(mProxyFilterFragment).hide(mSettingsFragment);
                 break;
             case R.id.action_settings:
-                ft.hide(mNetworkFragment).hide(mGroupsFragment).show(mSettingsFragment);
+                ft.hide(mNetworkFragment).hide(mGroupsFragment).hide(mProxyFilterFragment).show(mSettingsFragment);
                 break;
         }
         ft.commit();

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/MeshProvisionerActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/MeshProvisionerActivity.java
@@ -23,17 +23,8 @@
 package no.nordicsemi.android.nrfmeshprovisioner;
 
 import android.app.Activity;
-import androidx.lifecycle.ViewModelProvider;
-import androidx.lifecycle.ViewModelProviders;
 import android.content.Intent;
 import android.os.Bundle;
-import androidx.coordinatorlayout.widget.CoordinatorLayout;
-import com.google.android.material.snackbar.Snackbar;
-import androidx.core.content.ContextCompat;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.recyclerview.widget.LinearLayoutManager;
-import androidx.recyclerview.widget.RecyclerView;
-import androidx.appcompat.widget.Toolbar;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
@@ -42,10 +33,20 @@ import android.widget.ProgressBar;
 import android.widget.ScrollView;
 import android.widget.TextView;
 
+import com.google.android.material.snackbar.Snackbar;
+
 import java.util.Locale;
 
 import javax.inject.Inject;
 
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.coordinatorlayout.widget.CoordinatorLayout;
+import androidx.core.content.ContextCompat;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelProviders;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import no.nordicsemi.android.meshprovisioner.provisionerstates.ProvisioningCapabilities;
@@ -61,8 +62,8 @@ import no.nordicsemi.android.meshprovisioner.utils.StaticOOBType;
 import no.nordicsemi.android.nrfmeshprovisioner.adapter.ExtendedBluetoothDevice;
 import no.nordicsemi.android.nrfmeshprovisioner.adapter.ProvisioningProgressAdapter;
 import no.nordicsemi.android.nrfmeshprovisioner.di.Injectable;
-import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentAppKeyAddStatus;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentAuthenticationInput;
+import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentConfigurationComplete;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentFlags;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentIvIndex;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentKeyIndex;
@@ -86,11 +87,11 @@ public class MeshProvisionerActivity extends AppCompatActivity implements Inject
         DialogFragmentIvIndex.DialogFragmentIvIndexListener,
         DialogFragmentUnicastAddress.DialogFragmentUnicastAddressListener,
         DialogFragmentProvisioningFailedError.DialogFragmentProvisioningFailedErrorListener,
-        DialogFragmentAppKeyAddStatus.DialogFragmentAppKeyAddStatusListener {
+        DialogFragmentConfigurationComplete.ConfigurationCompleteListener {
 
     private static final String DIALOG_FRAGMENT_PROVISIONING_FAILED = "DIALOG_FRAGMENT_PROVISIONING_FAILED";
     private static final String DIALOG_FRAGMENT_AUTH_INPUT_TAG = "DIALOG_FRAGMENT_AUTH_INPUT_TAG";
-    private static final String DIALOG_FRAGMENT_APP_KEY_STATUS = "DIALOG_FRAGMENT_APP_KEY_STATUS";
+    private static final String DIALOG_FRAGMENT_CONFIGURATION_STATUS = "DIALOG_FRAGMENT_CONFIGURATION_STATUS";
 
     @BindView(R.id.container)
     CoordinatorLayout mCoordinatorLayout;
@@ -247,10 +248,9 @@ public class MeshProvisionerActivity extends AppCompatActivity implements Inject
 
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                onBackPressed();
-                return true;
+        if (item.getItemId() == android.R.id.home) {
+            onBackPressed();
+            return true;
         }
         return false;
     }
@@ -384,11 +384,11 @@ public class MeshProvisionerActivity extends AppCompatActivity implements Inject
                             if (fragment != null)
                                 fragment.dismiss();
                             break;
-                        case APP_KEY_STATUS_RECEIVED:
-                            if (getSupportFragmentManager().findFragmentByTag(DIALOG_FRAGMENT_APP_KEY_STATUS) == null) {
-                                DialogFragmentAppKeyAddStatus fragmentAppKeyAddStatus = DialogFragmentAppKeyAddStatus.
+                        case NETWORK_TRANSMIT_STATUS_RECEIVED:
+                            if (getSupportFragmentManager().findFragmentByTag(DIALOG_FRAGMENT_CONFIGURATION_STATUS) == null) {
+                                DialogFragmentConfigurationComplete fragmentConfigComplete = DialogFragmentConfigurationComplete.
                                         newInstance(getString(R.string.title_configuration_compete), getString(R.string.configuration_complete_summary));
-                                fragmentAppKeyAddStatus.show(getSupportFragmentManager(), DIALOG_FRAGMENT_APP_KEY_STATUS);
+                                fragmentConfigComplete.show(getSupportFragmentManager(), DIALOG_FRAGMENT_CONFIGURATION_STATUS);
                             }
                             break;
                     }
@@ -401,7 +401,7 @@ public class MeshProvisionerActivity extends AppCompatActivity implements Inject
     }
 
     @Override
-    public void onAppKeyAddStatusReceived() {
+    public void onConfigurationCompleted() {
         setResultIntent();
     }
 

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/NetworkFragment.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/NetworkFragment.java
@@ -110,7 +110,7 @@ public class NetworkFragment extends Fragment implements Injectable,
             }
         });
 
-        mViewModel.getConnectedMeshNodeAddress().observe(this, unicastAddress -> mAdapter.selectConnectedMeshNode(unicastAddress));
+        mViewModel.getConnectedProxyAddress().observe(this, unicastAddress -> mAdapter.selectConnectedMeshNode(unicastAddress));
 
         fab.setOnClickListener(v -> {
             final Intent intent = new Intent(requireActivity(), ScannerActivity.class);

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ProxyFilterFragment.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ProxyFilterFragment.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2018, Nordic Semiconductor
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+ * USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package no.nordicsemi.android.nrfmeshprovisioner;
+
+import android.annotation.SuppressLint;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.cardview.widget.CardView;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelProviders;
+import androidx.recyclerview.widget.DefaultItemAnimator;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import no.nordicsemi.android.meshprovisioner.MeshNetwork;
+import no.nordicsemi.android.meshprovisioner.transport.ProxyConfigAddAddressToFilter;
+import no.nordicsemi.android.meshprovisioner.transport.ProxyConfigRemoveAddressFromFilter;
+import no.nordicsemi.android.meshprovisioner.transport.ProxyConfigSetFilterType;
+import no.nordicsemi.android.meshprovisioner.utils.AddressArray;
+import no.nordicsemi.android.meshprovisioner.utils.MeshAddress;
+import no.nordicsemi.android.meshprovisioner.utils.ProxyFilter;
+import no.nordicsemi.android.meshprovisioner.utils.ProxyFilterType;
+import no.nordicsemi.android.nrfmeshprovisioner.adapter.FilterAddressAdapter;
+import no.nordicsemi.android.nrfmeshprovisioner.di.Injectable;
+import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentFilterAddAddress;
+import no.nordicsemi.android.nrfmeshprovisioner.viewmodels.SharedViewModel;
+import no.nordicsemi.android.nrfmeshprovisioner.widgets.ItemTouchHelperAdapter;
+import no.nordicsemi.android.nrfmeshprovisioner.widgets.RemovableItemTouchHelperCallback;
+import no.nordicsemi.android.nrfmeshprovisioner.widgets.RemovableViewHolder;
+
+public class ProxyFilterFragment extends Fragment implements Injectable,
+        DialogFragmentFilterAddAddress.DialogFragmentFilterAddressListener,
+        ItemTouchHelperAdapter {
+
+    private static final String CLEAR_ADDRESS_PRESSED = "CLEAR_ADDRESS_PRESSED";
+    private static final String PROXY_FILTER_DISABLED = "PROXY_FILTER_DISABLED";
+
+    private SharedViewModel mViewModel;
+
+    @Inject
+    ViewModelProvider.Factory mViewModelFactory;
+    @BindView(R.id.action_white_list)
+    Button actionEnableWhiteList;
+    @BindView(R.id.action_black_list)
+    Button actionEnableBlackList;
+    @BindView(R.id.action_disable)
+    Button actionDisable;
+    @BindView(R.id.action_add_address)
+    Button actionAddFilterAddress;
+    @BindView(R.id.action_clear_addresses)
+    Button actionClearFilterAddress;
+    @BindView(R.id.proxy_filter_address_card)
+    CardView mProxyFilterCard;
+    private ProxyFilter mFilter;
+    private boolean clearAddressPressed;
+    private boolean isProxyFilterDisabled;
+    private FilterAddressAdapter addressAdapter;
+
+    @Override
+    public void onCreate(@Nullable Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+    }
+
+    @Nullable
+    @Override
+    public View onCreateView(@NonNull final LayoutInflater inflater, @Nullable final ViewGroup container, @Nullable final Bundle savedInstanceState) {
+        @SuppressLint("InflateParams") final View rootView = inflater.inflate(R.layout.fragment_proxy_filter, null);
+        mViewModel = ViewModelProviders.of(requireActivity(), mViewModelFactory).get(SharedViewModel.class);
+        ButterKnife.bind(this, rootView);
+
+        if(savedInstanceState != null){
+            clearAddressPressed = savedInstanceState.getBoolean(CLEAR_ADDRESS_PRESSED);
+            isProxyFilterDisabled = savedInstanceState.getBoolean(PROXY_FILTER_DISABLED);
+        }
+
+        final TextView noAddressesAdded = rootView.findViewById(R.id.no_addresses);
+        final RecyclerView recyclerViewAddresses = rootView.findViewById(R.id.recycler_view_addresses);
+        actionEnableWhiteList.setEnabled(false);
+        actionEnableBlackList.setEnabled(false);
+        actionDisable.setEnabled(false);
+
+        recyclerViewAddresses.setLayoutManager(new LinearLayoutManager(requireContext()));
+        recyclerViewAddresses.setItemAnimator(new DefaultItemAnimator());
+        final ItemTouchHelper.Callback itemTouchHelperCallback = new RemovableItemTouchHelperCallback(this);
+        final ItemTouchHelper itemTouchHelper = new ItemTouchHelper(itemTouchHelperCallback);
+        itemTouchHelper.attachToRecyclerView(recyclerViewAddresses);
+        addressAdapter = new FilterAddressAdapter(requireContext());
+        recyclerViewAddresses.setAdapter(addressAdapter);
+        addressAdapter.notifyDataSetChanged();
+
+        mViewModel.isConnectedToProxy().observe(this, isConnected -> {
+            if (!isConnected) {
+                clearAddressPressed = false;
+                final MeshNetwork network = mViewModel.getMeshNetworkLiveData().getMeshNetwork();
+                if (network != null) {
+                    mFilter = network.getProxyFilter();
+                    if (mFilter == null) {
+                        addressAdapter.clearData();
+                        noAddressesAdded.setVisibility(View.VISIBLE);
+                        recyclerViewAddresses.setVisibility(View.GONE);
+                    }
+                }
+
+                actionEnableWhiteList.setSelected(isConnected);
+                actionEnableBlackList.setSelected(isConnected);
+                actionDisable.setSelected(isConnected);
+                actionAddFilterAddress.setEnabled(isConnected);
+                actionClearFilterAddress.setVisibility(View.GONE);
+            }
+            actionEnableWhiteList.setEnabled(isConnected);
+            actionEnableBlackList.setEnabled(isConnected);
+            actionDisable.setEnabled(isConnected);
+        });
+
+        mViewModel.getMeshNetworkLiveData().observe(this, meshNetworkLiveData -> {
+            final MeshNetwork network = meshNetworkLiveData.getMeshNetwork();
+            if (network == null) {
+                return;
+            }
+
+            final ProxyFilter filter = mFilter = network.getProxyFilter();
+            if (filter == null) {
+                addressAdapter.clearData();
+                return;
+            } else if(clearAddressPressed){
+                clearAddressPressed = false;
+                return;
+            } else if(isProxyFilterDisabled){
+                actionDisable.setSelected(true);
+            }
+
+            actionEnableWhiteList.setSelected(mFilter.getFilterType().getType() == ProxyFilterType.WHITE_LIST_FILTER && !actionDisable.isSelected());
+            actionEnableBlackList.setSelected(mFilter.getFilterType().getType() == ProxyFilterType.BLACK_LIST_FILTER);
+
+            if (!mFilter.getAddresses().isEmpty()) {
+                noAddressesAdded.setVisibility(View.GONE);
+                recyclerViewAddresses.setVisibility(View.VISIBLE);
+                actionClearFilterAddress.setVisibility(View.VISIBLE);
+            } else {
+                noAddressesAdded.setVisibility(View.VISIBLE);
+                recyclerViewAddresses.setVisibility(View.GONE);
+                actionClearFilterAddress.setVisibility(View.GONE);
+            }
+
+            actionAddFilterAddress.setEnabled(!actionDisable.isSelected());
+            addressAdapter.updateData(filter);
+        });
+
+
+        actionEnableWhiteList.setOnClickListener(v -> {
+            isProxyFilterDisabled = false;
+            v.setSelected(true);
+            actionEnableBlackList.setSelected(false);
+            actionDisable.setSelected(false);
+            setFilter(new ProxyFilterType(ProxyFilterType.WHITE_LIST_FILTER));
+        });
+
+        actionEnableBlackList.setOnClickListener(v -> {
+            isProxyFilterDisabled = false;
+            v.setSelected(true);
+            actionEnableWhiteList.setSelected(false);
+            actionDisable.setSelected(false);
+            setFilter(new ProxyFilterType(ProxyFilterType.BLACK_LIST_FILTER));
+        });
+
+        actionDisable.setOnClickListener(v -> {
+            v.setSelected(true);
+            isProxyFilterDisabled = true;
+            actionEnableWhiteList.setSelected(false);
+            actionEnableBlackList.setSelected(false);
+            addressAdapter.clearData();
+            setFilter(new ProxyFilterType(ProxyFilterType.WHITE_LIST_FILTER));
+        });
+
+        actionAddFilterAddress.setOnClickListener(v -> {
+            final ProxyFilterType filterType;
+            if (mFilter == null) {
+                filterType = new ProxyFilterType(ProxyFilterType.WHITE_LIST_FILTER);
+            } else {
+                filterType = mFilter.getFilterType();
+            }
+            final DialogFragmentFilterAddAddress filterAddAddress = DialogFragmentFilterAddAddress.newInstance(filterType);
+            filterAddAddress.show(getChildFragmentManager(), null);
+        });
+
+        actionClearFilterAddress.setOnClickListener(v -> removeAddresses());
+
+        return rootView;
+    }
+
+    @Override
+    public void onSaveInstanceState(@NonNull final Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putBoolean(CLEAR_ADDRESS_PRESSED, clearAddressPressed);
+        outState.putBoolean(PROXY_FILTER_DISABLED, isProxyFilterDisabled);
+    }
+
+    @Override
+    public void addAddresses(final List<AddressArray> addresses) {
+        final ProxyConfigAddAddressToFilter addAddressToFilter = new ProxyConfigAddAddressToFilter(addresses);
+        mViewModel.getMeshManagerApi().sendMeshMessage(MeshAddress.UNASSIGNED_ADDRESS, addAddressToFilter);
+    }
+
+    private void removeAddress(final int position) {
+        final MeshNetwork meshNetwork = mViewModel.getMeshNetworkLiveData().getMeshNetwork();
+        if (meshNetwork != null) {
+            final ProxyFilter proxyFilter = meshNetwork.getProxyFilter();
+            if (proxyFilter != null) {
+                clearAddressPressed = true;
+                final AddressArray addressArr = proxyFilter.getAddresses().get(position);
+                final List<AddressArray> addresses = new ArrayList<>();
+                addresses.add(addressArr);
+                addressAdapter.clearRow(position);
+                final ProxyConfigRemoveAddressFromFilter removeAddressFromFilter = new ProxyConfigRemoveAddressFromFilter(addresses);
+                mViewModel.getMeshManagerApi().sendMeshMessage(MeshAddress.UNASSIGNED_ADDRESS, removeAddressFromFilter);
+            }
+        }
+    }
+
+    private void removeAddresses() {
+        final MeshNetwork meshNetwork = mViewModel.getMeshNetworkLiveData().getMeshNetwork();
+        if (meshNetwork != null) {
+            final ProxyFilter proxyFilter = meshNetwork.getProxyFilter();
+            if (proxyFilter != null) {
+                if (!proxyFilter.getAddresses().isEmpty()) {
+                    final ProxyConfigRemoveAddressFromFilter removeAddressFromFilter = new ProxyConfigRemoveAddressFromFilter(proxyFilter.getAddresses());
+                    mViewModel.getMeshManagerApi().sendMeshMessage(MeshAddress.UNASSIGNED_ADDRESS, removeAddressFromFilter);
+                }
+            }
+        }
+    }
+
+    private void setFilter(final ProxyFilterType filterType) {
+        final ProxyConfigSetFilterType setFilterType = new ProxyConfigSetFilterType(filterType);
+        mViewModel.getMeshManagerApi().sendMeshMessage(MeshAddress.UNASSIGNED_ADDRESS, setFilterType);
+    }
+
+    @Override
+    public void onItemDismiss(final RemovableViewHolder viewHolder) {
+        final int position = viewHolder.getAdapterPosition();
+        if (viewHolder instanceof FilterAddressAdapter.ViewHolder) {
+            removeAddress(position);
+        }
+    }
+
+    @Override
+    public void onItemDismissFailed(final RemovableViewHolder viewHolder) {
+
+    }
+}

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ReconnectActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ReconnectActivity.java
@@ -23,24 +23,21 @@
 package no.nordicsemi.android.nrfmeshprovisioner;
 
 import android.app.Activity;
-import androidx.lifecycle.ViewModelProvider;
-import androidx.lifecycle.ViewModelProviders;
 import android.content.Intent;
 import android.os.Bundle;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.TextView;
 
 import javax.inject.Inject;
 
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelProviders;
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import no.nordicsemi.android.meshprovisioner.transport.ProxyConfigSetFilterType;
-import no.nordicsemi.android.meshprovisioner.utils.MeshAddress;
-import no.nordicsemi.android.meshprovisioner.utils.ProxyFilterType;
 import no.nordicsemi.android.nrfmeshprovisioner.adapter.ExtendedBluetoothDevice;
 import no.nordicsemi.android.nrfmeshprovisioner.di.Injectable;
 import no.nordicsemi.android.nrfmeshprovisioner.utils.Utils;

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ReconnectActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ReconnectActivity.java
@@ -69,6 +69,7 @@ public class ReconnectActivity extends AppCompatActivity implements Injectable {
 
         final Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
+        //noinspection ConstantConditions
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         getSupportActionBar().setTitle(deviceName);
         getSupportActionBar().setSubtitle(deviceAddress);
@@ -91,9 +92,6 @@ public class ReconnectActivity extends AppCompatActivity implements Injectable {
                 returnIntent.putExtra(Utils.EXTRA_DATA, true);
                 setResult(Activity.RESULT_OK, returnIntent);
                 finish();
-                //We send a proxy whitelist filter message to identify the node we are connected to when reconnecting to the network
-                final ProxyConfigSetFilterType setFilterType = new ProxyConfigSetFilterType(new ProxyFilterType(ProxyFilterType.WHITE_LIST_FILTER));
-                mReconnectViewModel.getMeshManagerApi().sendMeshMessage(MeshAddress.UNASSIGNED_ADDRESS, setFilterType);
             }
         });
 
@@ -101,10 +99,9 @@ public class ReconnectActivity extends AppCompatActivity implements Injectable {
 
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                onBackPressed();
-                return true;
+        if (item.getItemId() == android.R.id.home) {
+            onBackPressed();
+            return true;
         }
         return false;
     }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/SettingsFragment.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/SettingsFragment.java
@@ -24,16 +24,10 @@ package no.nordicsemi.android.nrfmeshprovisioner;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
-import androidx.lifecycle.ViewModelProvider;
-import androidx.lifecycle.ViewModelProviders;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
-import androidx.core.content.ContextCompat;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -49,11 +43,16 @@ import java.util.Locale;
 
 import javax.inject.Inject;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
+import androidx.lifecycle.ViewModelProviders;
 import no.nordicsemi.android.meshprovisioner.transport.NetworkKey;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 import no.nordicsemi.android.nrfmeshprovisioner.di.Injectable;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentFlags;
-import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentGlobalNetworkName;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentGlobalTtl;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentIvIndex;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentKeyIndex;
@@ -61,6 +60,7 @@ import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentMeshExportM
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentMeshImport;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentMeshImportMsg;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentNetworkKey;
+import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentNetworkName;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentPermissionRationale;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentResetNetwork;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentSourceAddress;
@@ -73,7 +73,7 @@ import static no.nordicsemi.android.nrfmeshprovisioner.ManageAppKeysActivity.RES
 import static no.nordicsemi.android.nrfmeshprovisioner.viewmodels.NrfMeshRepository.EXPORT_PATH;
 
 public class SettingsFragment extends Fragment implements Injectable,
-        DialogFragmentGlobalNetworkName.DialogFragmentNetworkNameListener,
+        DialogFragmentNetworkName.DialogFragmentNetworkNameListener,
         DialogFragmentGlobalTtl.DialogFragmentGlobalTtlListener,
         DialogFragmentNetworkKey.DialogFragmentNetworkKeyListener,
         DialogFragmentKeyIndex.DialogFragmentKeyIndexListener,
@@ -83,7 +83,7 @@ public class SettingsFragment extends Fragment implements Injectable,
         DialogFragmentSourceAddress.DialogFragmentSourceAddressListener,
         DialogFragmentResetNetwork.DialogFragmentResetNetworkListener,
         DialogFragmentMeshImport.DialogFragmentNetworkImportListener,
-DialogFragmentPermissionRationale.StoragePermissionListener {
+        DialogFragmentPermissionRationale.StoragePermissionListener {
 
     private static final int REQUEST_STORAGE_PERMISSION = 2023; // random number
     private static final int READ_FILE_REQUEST_CODE = 42;
@@ -105,8 +105,7 @@ DialogFragmentPermissionRationale.StoragePermissionListener {
     @Nullable
     @Override
     public View onCreateView(@NonNull final LayoutInflater inflater, @Nullable final ViewGroup container, @Nullable final Bundle savedInstanceState) {
-        @SuppressLint("InflateParams")
-        final View rootView = inflater.inflate(R.layout.fragment_settings, null);
+        @SuppressLint("InflateParams") final View rootView = inflater.inflate(R.layout.fragment_settings, null);
         mViewModel = ViewModelProviders.of(getActivity(), mViewModelFactory).get(SharedViewModel.class);
 
         // Set up views
@@ -116,7 +115,7 @@ DialogFragmentPermissionRationale.StoragePermissionListener {
         networkNameTitle.setText(R.string.summary_global_network_name);
         final TextView networkNameView = containerNetworkName.findViewById(R.id.text);
         containerNetworkName.setOnClickListener(v -> {
-            final DialogFragmentGlobalNetworkName dialogFragmentNetworkKey = DialogFragmentGlobalNetworkName.newInstance(networkNameView.getText().toString());
+            final DialogFragmentNetworkName dialogFragmentNetworkKey = DialogFragmentNetworkName.newInstance(networkNameView.getText().toString());
             dialogFragmentNetworkKey.show(getChildFragmentManager(), null);
         });
 
@@ -188,17 +187,6 @@ DialogFragmentPermissionRationale.StoragePermissionListener {
             dialogFragmentFlags.show(getChildFragmentManager(), null);
         });
 
-        final View containerUnicastAddress = rootView.findViewById(R.id.container_supported_algorithm);
-        containerUnicastAddress.findViewById(R.id.image).setBackground(ContextCompat.getDrawable(getContext(), R.drawable.ic_lan_black_alpha_24dp));
-        final TextView unicastAddressTitle = containerUnicastAddress.findViewById(R.id.title);
-        unicastAddressTitle.setText(R.string.summary_unicast_address);
-        final TextView unicastAddressView = containerUnicastAddress.findViewById(R.id.text);
-        containerUnicastAddress.setOnClickListener(v -> {
-            final int unicastAddress = mViewModel.getMeshNetworkLiveData().getValue().getUnicastAddress();
-            final DialogFragmentUnicastAddress dialogFragmentFlags = DialogFragmentUnicastAddress.newInstance(unicastAddress);
-            dialogFragmentFlags.show(getChildFragmentManager(), null);
-        });
-
         final View containerManageAppKeys = rootView.findViewById(R.id.container_app_keys);
         containerManageAppKeys.findViewById(R.id.image).setBackground(ContextCompat.getDrawable(getContext(), R.drawable.ic_folder_key_black_24dp_alpha));
         final TextView manageAppKeys = containerManageAppKeys.findViewById(R.id.title);
@@ -230,7 +218,6 @@ DialogFragmentPermissionRationale.StoragePermissionListener {
                 keyIndexView.setText(getString(R.string.hex_format, String.format(Locale.US, "%03X", key.getKeyIndex())));
                 flagsView.setText(parseFlagsMessage(meshNetworkLiveData.getFlags()));
                 ivIndexView.setText(getString(R.string.hex_format, String.format(Locale.US, "%08X", meshNetworkLiveData.getIvIndex())));
-                unicastAddressView.setText(getString(R.string.hex_format, String.format(Locale.US, "%04X", meshNetworkLiveData.getUnicastAddress())));
                 manageAppKeysView.setText(getString(R.string.app_key_count, meshNetworkLiveData.getAppKeys().size()));
                 sourceAddressView.setText(MeshParserUtils.bytesToHex(meshNetworkLiveData.getProvisionerAddress(), true));
             }
@@ -310,12 +297,10 @@ DialogFragmentPermissionRationale.StoragePermissionListener {
     @Override
     public void onRequestPermissionsResult(final int requestCode, @NonNull final String[] permissions, @NonNull final int[] grantResults) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);
-        switch (requestCode){
-            case REQUEST_STORAGE_PERMISSION:
-                if(PackageManager.PERMISSION_GRANTED != grantResults[0]){
-                    Toast.makeText(getContext(), getString(R.string.ext_storage_permission_denied), Toast.LENGTH_LONG).show();
-                }
-                break;
+        if (requestCode == REQUEST_STORAGE_PERMISSION) {
+            if (PackageManager.PERMISSION_GRANTED != grantResults[0]) {
+                Toast.makeText(getContext(), getString(R.string.ext_storage_permission_denied), Toast.LENGTH_LONG).show();
+            }
         }
     }
 
@@ -419,7 +404,7 @@ DialogFragmentPermissionRationale.StoragePermissionListener {
             fragmentPermissionRationale.show(getChildFragmentManager(), null);
         } else {
             final File f = new File(EXPORT_PATH);
-            if(!f.exists()) {
+            if (!f.exists()) {
                 f.mkdirs();
             }
             mViewModel.getMeshManagerApi().exportMeshNetwork(EXPORT_PATH);

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/FilterAddressAdapter.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/adapter/FilterAddressAdapter.java
@@ -22,11 +22,7 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner.adapter;
 
-import androidx.lifecycle.LifecycleOwner;
-import androidx.lifecycle.LiveData;
 import android.content.Context;
-import androidx.annotation.NonNull;
-import androidx.recyclerview.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -34,9 +30,10 @@ import android.widget.TextView;
 
 import java.util.ArrayList;
 
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
-import no.nordicsemi.android.meshprovisioner.transport.ProvisionedMeshNode;
 import no.nordicsemi.android.meshprovisioner.utils.AddressArray;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 import no.nordicsemi.android.meshprovisioner.utils.ProxyFilter;
@@ -45,23 +42,28 @@ import no.nordicsemi.android.nrfmeshprovisioner.widgets.RemovableViewHolder;
 
 public class FilterAddressAdapter extends RecyclerView.Adapter<FilterAddressAdapter.ViewHolder> {
 
-    private final ArrayList<AddressArray> mAddresses;// = new ArrayList<>();
+    private final ArrayList<AddressArray> mAddresses = new ArrayList<>();
     private final Context mContext;
     private OnItemClickListener mOnItemClickListener;
 
-    public FilterAddressAdapter(@NonNull final Context context, @NonNull final LiveData<ProvisionedMeshNode> meshNodeLiveData) {
+    public FilterAddressAdapter(@NonNull final Context context) {
         this.mContext = context;
-        mAddresses = new ArrayList<>();
-        meshNodeLiveData.observe((LifecycleOwner) context, meshNode -> {
-            if (meshNode != null) {
-                final ProxyFilter proxyFilter = meshNode.getProxyFilter();
-                if (proxyFilter != null) {
-                    mAddresses.clear();
-                    mAddresses.addAll(proxyFilter.getAddresses());
-                    notifyDataSetChanged();
-                }
-            }
-        });
+    }
+
+    public void updateData(@NonNull final ProxyFilter filter){
+        mAddresses.clear();
+        mAddresses.addAll(filter.getAddresses());
+        notifyDataSetChanged();
+    }
+
+    public void clearData(){
+        mAddresses.clear();
+        notifyDataSetChanged();
+    }
+
+    public void clearRow(final int position){
+        mAddresses.remove(position);
+        notifyDataSetChanged();
     }
 
     public void setOnItemClickListener(final FilterAddressAdapter.OnItemClickListener listener) {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/di/FragmentBuildersModule.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/di/FragmentBuildersModule.java
@@ -26,6 +26,7 @@ import dagger.Module;
 import dagger.android.ContributesAndroidInjector;
 import no.nordicsemi.android.nrfmeshprovisioner.GroupsFragment;
 import no.nordicsemi.android.nrfmeshprovisioner.NetworkFragment;
+import no.nordicsemi.android.nrfmeshprovisioner.ProxyFilterFragment;
 import no.nordicsemi.android.nrfmeshprovisioner.SettingsFragment;
 
 @Module
@@ -34,6 +35,8 @@ abstract class FragmentBuildersModule {
 	abstract NetworkFragment contributeNetworkFragment();
 	@ContributesAndroidInjector
 	abstract GroupsFragment contributeGroupFragment();
+	@ContributesAndroidInjector
+	abstract ProxyFilterFragment contributeProxyFilterFragment();
 	@ContributesAndroidInjector
 	abstract SettingsFragment contributeSettingsFragment();
 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentAddAppKey.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentAddAppKey.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
 import android.annotation.SuppressLint;
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -32,6 +32,7 @@ import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.widget.TextView;
 
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
@@ -78,7 +79,7 @@ public class DialogFragmentAddAppKey extends DialogFragment {
         @SuppressLint("InflateParams")
         final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_key_input, null);
         ButterKnife.bind(this, rootView);
-
+        final TextView summary = rootView.findViewById(R.id.summary);
         //Bind ui
         appKeysInputLayout.setHint(getString(R.string.hint_app_key));
         appKeyInput.setText(mAppKey);
@@ -103,13 +104,13 @@ public class DialogFragmentAddAppKey extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).setView(rootView)
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.ok, null).setNegativeButton(R.string.cancel, null)
                 .setNeutralButton(R.string.generate_app_key, null);
 
         alertDialogBuilder.setIcon(R.drawable.ic_vpn_key_black_alpha_24dp);
         alertDialogBuilder.setTitle(R.string.title_manage_app_keys);
-        alertDialogBuilder.setMessage(R.string.summary_app_keys);
+        summary.setText(R.string.summary_app_keys);
 
         final AlertDialog alertDialog = alertDialogBuilder.show();
         alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentConfigurationComplete.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentConfigurationComplete.java
@@ -24,20 +24,20 @@ package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
 import android.app.Dialog;
 import android.os.Bundle;
+
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AlertDialog;
-
 import no.nordicsemi.android.nrfmeshprovisioner.R;
 
-public class DialogFragmentAppKeyAddStatus extends DialogFragmentMessage {
+public class DialogFragmentConfigurationComplete extends DialogFragmentMessage {
 
-    public interface DialogFragmentAppKeyAddStatusListener {
-        void onAppKeyAddStatusReceived();
+    public interface ConfigurationCompleteListener {
+        void onConfigurationCompleted();
     }
 
-    public static DialogFragmentAppKeyAddStatus newInstance(final String title, final String message) {
+    public static DialogFragmentConfigurationComplete newInstance(final String title, final String message) {
         Bundle args = new Bundle();
-        DialogFragmentAppKeyAddStatus fragment = new DialogFragmentAppKeyAddStatus();
+        DialogFragmentConfigurationComplete fragment = new DialogFragmentConfigurationComplete();
         args.putString(TITLE, title);
         args.putString(MESSAGE, message);
         fragment.setArguments(args);
@@ -52,10 +52,10 @@ public class DialogFragmentAppKeyAddStatus extends DialogFragmentMessage {
     @NonNull
     @Override
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
-        alertDialogBuilder = new AlertDialog.Builder(getActivity());
-        alertDialogBuilder.setIcon(R.drawable.ic_vpn_key_black_alpha_24dp);
+        alertDialogBuilder = new AlertDialog.Builder(requireContext());
+        alertDialogBuilder.setIcon(R.drawable.ic_done_all_black_alpha_24dp);
         alertDialogBuilder.setPositiveButton(getString(R.string.ok), (dialog, which) -> (
-                (DialogFragmentAppKeyAddStatusListener)getActivity()).onAppKeyAddStatusReceived());
+                (ConfigurationCompleteListener)requireActivity()).onConfigurationCompleted());
 
         return super.onCreateDialog(savedInstanceState);
     }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentCreateGroup.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentCreateGroup.java
@@ -22,7 +22,9 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
+
+import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -76,7 +78,7 @@ public class DialogFragmentCreateGroup extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
-        final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_create_group, null);
+        @SuppressLint("InflateParams") final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_create_group, null);
 
         //Bind ui
         ButterKnife.bind(this, rootView);
@@ -104,7 +106,7 @@ public class DialogFragmentCreateGroup extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).setView(rootView)
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.ok, null).setNegativeButton(R.string.cancel, null);
 
         alertDialogBuilder.setIcon(R.drawable.ic_outline_group_work_black_alpha_24dp);

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentEditAppKey.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentEditAppKey.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
 import android.annotation.SuppressLint;
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -32,6 +32,7 @@ import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.widget.TextView;
 
 import com.google.android.material.textfield.TextInputEditText;
 import com.google.android.material.textfield.TextInputLayout;
@@ -87,7 +88,7 @@ public class DialogFragmentEditAppKey extends DialogFragment {
         @SuppressLint("InflateParams")
         final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_key_input, null);
         ButterKnife.bind(this, rootView);
-
+        final TextView summary = rootView.findViewById(R.id.summary);
         //Bind ui
         appKeysInputLayout.setHint(getString(R.string.hint_app_key));
         appKeyInput.setText(MeshParserUtils.bytesToHex(mAppKey.getKey(), false));
@@ -112,12 +113,12 @@ public class DialogFragmentEditAppKey extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).setView(rootView)
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.ok, null).setNegativeButton(R.string.cancel, null);
 
         alertDialogBuilder.setIcon(R.drawable.ic_vpn_key_black_alpha_24dp);
         alertDialogBuilder.setTitle(R.string.title_manage_app_keys);
-        alertDialogBuilder.setMessage(R.string.summary_app_keys);
+        summary.setText(R.string.summary_app_keys);
 
         final AlertDialog alertDialog = alertDialogBuilder.show();
         alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentFilterAddAddress.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentFilterAddAddress.java
@@ -22,7 +22,9 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
+
+import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
@@ -91,7 +93,7 @@ public class DialogFragmentFilterAddAddress extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
-        final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_filter_address, null);
+        @SuppressLint("InflateParams") final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_filter_address, null);
 
         //Bind ui
         ButterKnife.bind(this, rootView);
@@ -138,7 +140,7 @@ public class DialogFragmentFilterAddAddress extends DialogFragment {
             }
         });
 
-        return new AlertDialog.Builder(getContext()).setView(rootView)
+        return new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.confirm, (dialog, which) -> {
                     if (!addresses.isEmpty()) {
                         if (getParentFragment() == null) {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentFilterAddAddress.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentFilterAddAddress.java
@@ -41,6 +41,7 @@ import android.text.method.KeyListener;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.Button;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import java.util.ArrayList;
@@ -97,7 +98,7 @@ public class DialogFragmentFilterAddAddress extends DialogFragment {
 
         //Bind ui
         ButterKnife.bind(this, rootView);
-
+        final TextView summary = rootView.findViewById(R.id.summary);
         if (savedInstanceState != null) {
             filterType = savedInstanceState.getParcelable(PROXY_FILTER_KEY);
             addresses = savedInstanceState.getParcelableArrayList("AddressList");
@@ -140,6 +141,8 @@ public class DialogFragmentFilterAddAddress extends DialogFragment {
             }
         });
 
+        summary.setText(getString(R.string.dialog_summary_filter_address, filterType.getFilterTypeName()));
+
         return new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.confirm, (dialog, which) -> {
                     if (!addresses.isEmpty()) {
@@ -154,8 +157,7 @@ public class DialogFragmentFilterAddAddress extends DialogFragment {
                 })
                 .setNegativeButton(R.string.cancel, null)
                 .setIcon(R.drawable.ic_lan_black_alpha_24dp)
-                .setTitle(R.string.title_add_address)
-                .setMessage(getString(R.string.dialog_summary_filter_address, filterType.getFilterTypeName())).create();
+                .setTitle(R.string.title_add_address).create();
     }
 
     @Override

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentFlags.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentFlags.java
@@ -22,7 +22,9 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
+
+import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -81,7 +83,7 @@ public class DialogFragmentFlags extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
-        final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_flags_input, null);
+        @SuppressLint("InflateParams") final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_flags_input, null);
 
         //Bind ui
         ButterKnife.bind(this, rootView);
@@ -100,12 +102,11 @@ public class DialogFragmentFlags extends DialogFragment {
         radioGroupKeyRefreshFlag.setEnabled(false);
         radioGroupIVUpdateFlag.setEnabled(false);
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).setView(rootView)
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.ok, null).setNegativeButton(R.string.cancel, null);
 
         alertDialogBuilder.setIcon(R.drawable.ic_flag);
         alertDialogBuilder.setTitle(R.string.title_flags);
-        alertDialogBuilder.setMessage(R.string.dialog_summary_flags);
 
         final AlertDialog alertDialog = alertDialogBuilder.show();
         alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {
@@ -113,7 +114,7 @@ public class DialogFragmentFlags extends DialogFragment {
                 final int keyRefreshFlag = parseKeyRefreshFlag();
                 final int ivUpdateFlag = parseIvUpdateFlag();
                 if (getParentFragment() == null) {
-                    ((DialogFragmentFlagsListener) getActivity()).onFlagsSelected(keyRefreshFlag, ivUpdateFlag);
+                    ((DialogFragmentFlagsListener) requireActivity()).onFlagsSelected(keyRefreshFlag, ivUpdateFlag);
                 } else {
                     ((DialogFragmentFlagsListener) getParentFragment()).onFlagsSelected(keyRefreshFlag, ivUpdateFlag);
                 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentGlobalTtl.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentGlobalTtl.java
@@ -22,7 +22,9 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
+
+import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -74,7 +76,7 @@ public class DialogFragmentGlobalTtl extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
-        final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_ttl_input, null);
+        @SuppressLint("InflateParams") final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_ttl_input, null);
 
         //Bind ui
         ButterKnife.bind(this, rootView);
@@ -103,19 +105,18 @@ public class DialogFragmentGlobalTtl extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).setView(rootView)
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.ok, null).setNegativeButton(R.string.cancel, null);
 
         alertDialogBuilder.setIcon(R.drawable.ic_timer);
         alertDialogBuilder.setTitle(R.string.title_global_ttl);
-        alertDialogBuilder.setMessage(R.string.summary_ttl);
 
         final AlertDialog alertDialog = alertDialogBuilder.show();
         alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {
-            final String globalTTL = ttlInput.getText().toString();
+            final String globalTTL = ttlInput.getEditableText().toString();
             if (validateInput(globalTTL)) {
                 if(getParentFragment() == null) {
-                    ((DialogFragmentGlobalTtlListener) getActivity()).onGlobalTtlEntered(Integer.parseInt(globalTTL));
+                    ((DialogFragmentGlobalTtlListener) requireActivity()).onGlobalTtlEntered(Integer.parseInt(globalTTL));
                 } else {
                     ((DialogFragmentGlobalTtlListener) getParentFragment()).onGlobalTtlEntered(Integer.parseInt(globalTTL));
                 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentGroupSubscription.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentGroupSubscription.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
 import android.annotation.SuppressLint;
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -203,7 +203,7 @@ public class DialogFragmentGroupSubscription extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).
                 setIcon(R.drawable.ic_subscribe_black_alpha_24dp).
                 setTitle(R.string.title_subscribe_group).
                 setView(rootView).

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentGroupSubscription.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentGroupSubscription.java
@@ -241,10 +241,6 @@ public class DialogFragmentGroupSubscription extends DialogFragment {
         return alertDialog;
     }
 
-    private void setSubscriptionAddressType() {
-        int address = 0;
-    }
-
     private void updateAddress(final AddressType addressType) {
         if (addressType == VIRTUAL_ADDRESS) {
             labelSummary.setVisibility(VISIBLE);

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentIvIndex.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentIvIndex.java
@@ -22,7 +22,9 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
+
+import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -78,7 +80,7 @@ public class DialogFragmentIvIndex extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
-        final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_ivindex_input, null);
+        @SuppressLint("InflateParams") final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_ivindex_input, null);
 
         //Bind ui
         ButterKnife.bind(this, rootView);
@@ -110,19 +112,18 @@ public class DialogFragmentIvIndex extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).setView(rootView)
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.ok, null).setNegativeButton(R.string.cancel, null);
 
         alertDialogBuilder.setIcon(R.drawable.ic_list);
         alertDialogBuilder.setTitle(R.string.title_iv_index);
-        alertDialogBuilder.setMessage(R.string.dialog_summary_iv_index);
 
         final AlertDialog alertDialog = alertDialogBuilder.show();
         alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {
-            final String ivIndexInput = this.ivIndexInput.getText().toString();
+            final String ivIndexInput = this.ivIndexInput.getEditableText().toString();
             if (validateInput(ivIndexInput)) {
                 if (getParentFragment() == null) {
-                    ((DialogFragmentIvIndexListener) getActivity()).setIvIndex(Integer.parseInt(ivIndexInput, 16));
+                    ((DialogFragmentIvIndexListener) requireActivity()).setIvIndex(Integer.parseInt(ivIndexInput, 16));
                 } else {
                     ((DialogFragmentIvIndexListener) getParentFragment()).setIvIndex(Integer.parseInt(ivIndexInput, 16));
                 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentKeyIndex.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentKeyIndex.java
@@ -22,7 +22,9 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
+
+import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -78,7 +80,7 @@ public class DialogFragmentKeyIndex extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
-        final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_key_index_input, null);
+        @SuppressLint("InflateParams") final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_key_index_input, null);
 
         //Bind ui
         ButterKnife.bind(this, rootView);
@@ -110,19 +112,18 @@ public class DialogFragmentKeyIndex extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).setView(rootView)
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.ok, null).setNegativeButton(R.string.cancel, null);
 
         alertDialogBuilder.setIcon(R.drawable.ic_numeric);
         alertDialogBuilder.setTitle(R.string.title_key_index);
-        alertDialogBuilder.setMessage(R.string.dialog_summary_key_index);
 
         final AlertDialog alertDialog = alertDialogBuilder.show();
         alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {
-            final String keyIndex = keyIndexInput.getText().toString();
+            final String keyIndex = keyIndexInput.getEditableText().toString();
             if (validateInput(keyIndex)) {
                 if ((getParentFragment()) == null) {
-                    ((DialogFragmentKeyIndexListener) getActivity()).onKeyIndexGenerated(Integer.valueOf(keyIndex));
+                    ((DialogFragmentKeyIndexListener) requireActivity()).onKeyIndexGenerated(Integer.valueOf(keyIndex));
                 } else {
                     ((DialogFragmentKeyIndexListener) getParentFragment()).onKeyIndexGenerated(Integer.valueOf(keyIndex));
                 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentModelConfiguration.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentModelConfiguration.java
@@ -22,7 +22,9 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
+
+import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -74,7 +76,7 @@ public class DialogFragmentModelConfiguration extends DialogFragment{
     @NonNull
     @Override
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
-        final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_provision_data_input, null);
+        @SuppressLint("InflateParams") final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_provision_data_input, null);
         ButterKnife.bind(this, rootView);
 
         //Bind ui
@@ -102,7 +104,7 @@ public class DialogFragmentModelConfiguration extends DialogFragment{
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).setView(rootView)
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.ok, null).setNegativeButton(R.string.cancel, null)
                 .setNeutralButton(R.string.generate_app_key, null);
 
@@ -112,31 +114,25 @@ public class DialogFragmentModelConfiguration extends DialogFragment{
 
         final AlertDialog alertDialog = alertDialogBuilder.show();
         alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {
-            final String appKey = appKeyInput.getText().toString();
+            final String appKey = appKeyInput.getEditableText().toString();
             if (validateInput(appKey)) {
-                ((DialogFragmentAddAppKey.DialogFragmentAddAppKeysListener) getContext()).onAppKeyAdded(appKey);
+                ((DialogFragmentAddAppKey.DialogFragmentAddAppKeysListener) requireContext()).onAppKeyAdded(appKey);
                 dismiss();
             }
         });
-        alertDialog.getButton(DialogInterface.BUTTON_NEUTRAL).setOnClickListener(v -> {
-            appKeyInput.setText(SecureUtils.generateRandomNetworkKey());
-        });
+        alertDialog.getButton(DialogInterface.BUTTON_NEUTRAL).setOnClickListener(v -> appKeyInput.setText(SecureUtils.generateRandomNetworkKey()));
 
         return alertDialog;
     }
 
     private boolean validateInput(final String appKey) {
         try {
-            if(MeshParserUtils.validateAppKeyInput(getContext(), appKey)) {
+            if(MeshParserUtils.validateAppKeyInput(requireContext(), appKey)) {
                 return true;
             }
         } catch (IllegalArgumentException ex) {
             appKeysInputLayout.setError(ex.getMessage());
         }
         return false;
-    }
-
-    public interface DialogFragmentAddAppKeysListener {
-        void onAppKeyAdded(final String appKey);
     }
 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentNetworkKey.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentNetworkKey.java
@@ -22,7 +22,9 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
+
+import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -38,6 +40,7 @@ import android.text.method.KeyListener;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.widget.TextView;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -81,11 +84,12 @@ public class DialogFragmentNetworkKey extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
-        final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_key_input, null);
+        @SuppressLint("InflateParams") final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_key_input, null);
 
         final KeyListener hexKeyListener = new HexKeyListener();
         //Bind ui
         ButterKnife.bind(this, rootView);
+        final TextView summary = rootView.findViewById(R.id.summary);
         final String key = MeshParserUtils.bytesToHex(mNetworkKey.getKey(), false);
         networkKeyInputLayout.setHint(getString(R.string.hint_network_key));
         networkKeyInput.setKeyListener(hexKeyListener);
@@ -112,21 +116,21 @@ public class DialogFragmentNetworkKey extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).setView(rootView)
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.ok, null).setNegativeButton(R.string.cancel, null)
                 .setNeutralButton(R.string.generate_network_key, null);
 
         alertDialogBuilder.setIcon(R.drawable.ic_vpn_key_black_alpha_24dp);
         alertDialogBuilder.setTitle(R.string.title_generate_network_key);
-        alertDialogBuilder.setMessage(R.string.summary_generate_network_key);
+        summary.setText(R.string.summary_generate_network_key);
 
         final AlertDialog alertDialog = alertDialogBuilder.show();
         alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {
-            final String networkKey = networkKeyInput.getText().toString();
+            final String networkKey = networkKeyInput.getEditableText().toString();
             if (validateInput(networkKey)) {
                 try {
                     if (getParentFragment() == null) {
-                        ((DialogFragmentNetworkKeyListener) getActivity()).onNetworkKeyGenerated(networkKey);
+                        ((DialogFragmentNetworkKeyListener) requireActivity()).onNetworkKeyGenerated(networkKey);
                     } else {
                         ((DialogFragmentNetworkKeyListener) getParentFragment()).onNetworkKeyGenerated(networkKey);
                     }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentNetworkName.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentNetworkName.java
@@ -22,7 +22,9 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
+
+import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -36,12 +38,13 @@ import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.widget.TextView;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import no.nordicsemi.android.nrfmeshprovisioner.R;
 
-public class DialogFragmentGlobalNetworkName extends DialogFragment {
+public class DialogFragmentNetworkName extends DialogFragment {
 
     private static final String NETWORK_NAME = "NETWORK_NAME";
 
@@ -53,8 +56,8 @@ public class DialogFragmentGlobalNetworkName extends DialogFragment {
 
     private String mNetworkName;
 
-    public static DialogFragmentGlobalNetworkName newInstance(final String networkName) {
-        DialogFragmentGlobalNetworkName fragmentNetworkKey = new DialogFragmentGlobalNetworkName();
+    public static DialogFragmentNetworkName newInstance(final String networkName) {
+        DialogFragmentNetworkName fragmentNetworkKey = new DialogFragmentNetworkName();
         final Bundle args = new Bundle();
         args.putString(NETWORK_NAME, networkName);
         fragmentNetworkKey.setArguments(args);
@@ -72,10 +75,11 @@ public class DialogFragmentGlobalNetworkName extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
-        final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_name, null);
+        @SuppressLint("InflateParams") final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_name, null);
 
         //Bind ui
         ButterKnife.bind(this, rootView);
+        final TextView summary = rootView.findViewById(R.id.summary);
         networkNameInputLayout.setHint(getString(R.string.hint_global_network_name));
         networkNameInput.setText(mNetworkName);
         networkNameInput.addTextChangedListener(new TextWatcher() {
@@ -99,19 +103,19 @@ public class DialogFragmentGlobalNetworkName extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).setView(rootView)
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.ok, null).setNegativeButton(R.string.cancel, null);
 
         alertDialogBuilder.setIcon(R.drawable.ic_lan_black_alpha_24dp);
         alertDialogBuilder.setTitle(R.string.title_network_name);
-        alertDialogBuilder.setMessage(R.string.summary_network_name);
+        summary.setText(R.string.summary_network_name);
 
         final AlertDialog alertDialog = alertDialogBuilder.show();
         alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {
-            final String networkKey = networkNameInput.getText().toString();
+            final String networkKey = networkNameInput.getEditableText().toString();
             if (validateInput(networkKey)) {
                 if(getParentFragment() == null) {
-                    ((DialogFragmentNetworkNameListener) getActivity()).onNetworkNameEntered(networkKey);
+                    ((DialogFragmentNetworkNameListener) requireActivity()).onNetworkNameEntered(networkKey);
                 } else {
                     ((DialogFragmentNetworkNameListener) getParentFragment()).onNetworkNameEntered(networkKey);
                 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentNetworkTransmitSettings.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentNetworkTransmitSettings.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
 import android.annotation.SuppressLint;
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -22,8 +22,8 @@ public class DialogFragmentNetworkTransmitSettings extends DialogFragment {
 
     private static final String TAG = DialogFragmentNetworkTransmitSettings.class.getSimpleName();
 
-    public static final String TRANSMIT_COUNT = "TRANSMIT_COUNT";
-    public static final String TRANSMIT_INTERVAL_STEPS = "TRANSMIT_INTERVAL_STEPS";
+    private static final String TRANSMIT_COUNT = "TRANSMIT_COUNT";
+    private static final String TRANSMIT_INTERVAL_STEPS = "TRANSMIT_INTERVAL_STEPS";
 
     private static final int MIN_TRANSMIT_COUNT = 0;
     private static final int MAX_TRANSMIT_COUNT = 0b111;
@@ -110,7 +110,7 @@ public class DialogFragmentNetworkTransmitSettings extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).setView(rootView)
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.ok, null).setNegativeButton(R.string.cancel, null);
 
         alertDialogBuilder.setIcon(R.drawable.ic_repeat_black_24dp);

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentNodeName.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentNodeName.java
@@ -22,7 +22,9 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
+
+import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -36,6 +38,7 @@ import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.widget.TextView;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -72,10 +75,11 @@ public class DialogFragmentNodeName extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
-        final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_name, null);
+        @SuppressLint("InflateParams") final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_name, null);
 
         //Bind ui
         ButterKnife.bind(this, rootView);
+        final TextView summary = rootView.findViewById(R.id.summary);
         nodeNameInputLayout.setHint(getString(R.string.hint_node_name));
         nodeNameInput.setText(mNodeName);
         nodeNameInput.addTextChangedListener(new TextWatcher() {
@@ -99,18 +103,18 @@ public class DialogFragmentNodeName extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).setView(rootView)
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.ok, null).setNegativeButton(R.string.cancel, null);
 
         alertDialogBuilder.setIcon(R.drawable.ic_vpn_key_black_alpha_24dp);
         alertDialogBuilder.setTitle(R.string.title_node_name);
-        alertDialogBuilder.setMessage(R.string.name_rationale);
+        summary.setText(R.string.name_rationale);
 
         final AlertDialog alertDialog = alertDialogBuilder.show();
         alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {
-            final String nodeName = nodeNameInput.getText().toString();
+            final String nodeName = nodeNameInput.getEditableText().toString();
             if (!TextUtils.isEmpty(nodeName)) {
-                ((DialogFragmentNodeNameListener) getContext()).onNodeNameUpdated(nodeName);
+                ((DialogFragmentNodeNameListener) requireContext()).onNodeNameUpdated(nodeName);
                 dismiss();
             }
         });

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentPubRetransmitIntervalSteps.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentPubRetransmitIntervalSteps.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
 import android.annotation.SuppressLint;
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -109,7 +109,7 @@ public class DialogFragmentPubRetransmitIntervalSteps extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).setView(rootView)
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.ok, null).setNegativeButton(R.string.cancel, null);
 
         alertDialogBuilder.setIcon(R.drawable.ic_index);

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentPublicationResolution.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentPublicationResolution.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
 
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
 import android.app.Dialog;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
@@ -36,7 +36,7 @@ public class DialogFragmentPublicationResolution extends DialogFragment {
     @Override
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext())
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext())
                 .setIcon(R.drawable.ic_linear_scale_black_alpha_24dp)
                 .setTitle(R.string.title_publication_resolution)
                 .setSingleChoiceItems(R.array.arr_publication_resolution, mPublicationResolution, null)

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentPublicationSteps.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentPublicationSteps.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
 import android.annotation.SuppressLint;
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -110,7 +110,7 @@ public class DialogFragmentPublicationSteps extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).setView(rootView)
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.ok, null).setNegativeButton(R.string.cancel, null);
 
         alertDialogBuilder.setIcon(R.drawable.ic_index);

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentPublishAddress.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentPublishAddress.java
@@ -77,6 +77,8 @@ public class DialogFragmentPublishAddress extends DialogFragment {
     //UI Bindings
     @BindView(R.id.address_types)
     Spinner addressTypesSpinnerView;
+    @BindView(R.id.prefix)
+    TextView prefix;
     @BindView(R.id.text_input_layout)
     TextInputLayout unicastAddressInputLayout;
     @BindView(R.id.text_input)
@@ -347,6 +349,7 @@ public class DialogFragmentPublishAddress extends DialogFragment {
             case UNASSIGNED_ADDRESS:
                 publishAddress = MeshAddress.formatAddress(MeshAddress.UNASSIGNED_ADDRESS, false);
                 unicastAddressInput.setText(publishAddress);
+                prefix.setVisibility(View.VISIBLE);
                 unicastAddressInputLayout.setVisibility(View.VISIBLE);
                 groupContainer.setVisibility(View.GONE);
                 labelUuidView.setVisibility(View.GONE);
@@ -355,6 +358,7 @@ public class DialogFragmentPublishAddress extends DialogFragment {
             case UNICAST_ADDRESS:
                 publishAddress = MeshAddress.formatAddress(address, false);
                 unicastAddressInput.setText(publishAddress);
+                prefix.setVisibility(View.VISIBLE);
                 unicastAddressInputLayout.setVisibility(View.VISIBLE);
                 groupContainer.setVisibility(View.GONE);
                 labelUuidView.setVisibility(View.GONE);
@@ -364,6 +368,7 @@ public class DialogFragmentPublishAddress extends DialogFragment {
                 final int index = getGroupIndex(address);
                 groups.setSelection(index);
                 groupContainer.setVisibility(View.VISIBLE);
+                prefix.setVisibility(View.GONE);
                 unicastAddressInputLayout.setVisibility(View.GONE);
                 labelUuidView.setVisibility(View.GONE);
                 mGenerateLabelUUID.setVisibility(View.GONE);
@@ -374,6 +379,7 @@ public class DialogFragmentPublishAddress extends DialogFragment {
                 }
                 labelUuidView.setVisibility(View.VISIBLE);
                 mGenerateLabelUUID.setVisibility(View.VISIBLE);
+                prefix.setVisibility(View.GONE);
                 unicastAddressInputLayout.setVisibility(View.GONE);
                 groupContainer.setVisibility(View.GONE);
                 break;

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentPublishAddress.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentPublishAddress.java
@@ -23,7 +23,7 @@
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
 import android.annotation.SuppressLint;
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -238,7 +238,7 @@ public class DialogFragmentPublishAddress extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).
                 setIcon(R.drawable.ic_lan_black_alpha_24dp).
                 setTitle(R.string.title_publish_address).
                 setView(rootView).

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentPublishTtl.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentPublishTtl.java
@@ -22,7 +22,9 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
+
+import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -76,7 +78,7 @@ public class DialogFragmentPublishTtl extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
-        final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_publish_ttl_input, null);
+        @SuppressLint("InflateParams") final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_publish_ttl_input, null);
         ButterKnife.bind(this, rootView);
 
         chkPublishTtl.setOnCheckedChangeListener((buttonView, isChecked) -> {
@@ -107,7 +109,7 @@ public class DialogFragmentPublishTtl extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).setView(rootView)
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.ok, null).setNegativeButton(R.string.cancel, null);
 
         alertDialogBuilder.setIcon(R.drawable.ic_timer);
@@ -117,12 +119,12 @@ public class DialogFragmentPublishTtl extends DialogFragment {
         final AlertDialog alertDialog = alertDialogBuilder.show();
         alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {
             if(chkPublishTtl.isChecked()) {
-                ((DialogFragmentPublishTtlListener) getActivity()).setPublishTtl(MeshParserUtils.USE_DEFAULT_TTL);
+                ((DialogFragmentPublishTtlListener) requireActivity()).setPublishTtl(MeshParserUtils.USE_DEFAULT_TTL);
                 dismiss();
             } else {
-                final String publishTtl = ttlInput.getText().toString();
+                final String publishTtl = ttlInput.getEditableText().toString();
                 if (validateInput(publishTtl)) {
-                    ((DialogFragmentPublishTtlListener) getActivity()).setPublishTtl(Integer.parseInt(publishTtl));
+                    ((DialogFragmentPublishTtlListener) requireActivity()).setPublishTtl(Integer.parseInt(publishTtl));
                     dismiss();
                 }
             }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentPublishTtl.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentPublishTtl.java
@@ -114,7 +114,6 @@ public class DialogFragmentPublishTtl extends DialogFragment {
 
         alertDialogBuilder.setIcon(R.drawable.ic_timer);
         alertDialogBuilder.setTitle(R.string.title_publish_ttl);
-        alertDialogBuilder.setMessage(R.string.dialog_summary_publish_ttl);
 
         final AlertDialog alertDialog = alertDialogBuilder.show();
         alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentRetransmitCount.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentRetransmitCount.java
@@ -22,7 +22,9 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
+
+import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -75,7 +77,7 @@ public class DialogFragmentRetransmitCount extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
-        final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_publication_parameters, null);
+        @SuppressLint("InflateParams") final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_publication_parameters, null);
 
         //Bind ui
         ButterKnife.bind(this, rootView);
@@ -107,7 +109,7 @@ public class DialogFragmentRetransmitCount extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).setView(rootView)
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.ok, null).setNegativeButton(R.string.cancel, null);
 
         alertDialogBuilder.setIcon(R.drawable.ic_numeric);
@@ -115,10 +117,10 @@ public class DialogFragmentRetransmitCount extends DialogFragment {
 
         final AlertDialog alertDialog = alertDialogBuilder.show();
         alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {
-            final String ivIndexInput = this.retransmitInput.getText().toString();
+            final String ivIndexInput = this.retransmitInput.getEditableText().toString();
             if (validateInput(ivIndexInput)) {
                 if (getParentFragment() == null) {
-                    ((DialogFragmentRetransmitCountListener) getActivity()).setRetransmitCount(Integer.parseInt(ivIndexInput, 16));
+                    ((DialogFragmentRetransmitCountListener) requireActivity()).setRetransmitCount(Integer.parseInt(ivIndexInput, 16));
                 } else {
                     ((DialogFragmentRetransmitCountListener) getParentFragment()).setRetransmitCount(Integer.parseInt(ivIndexInput, 16));
                 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentSelectOOBType.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentSelectOOBType.java
@@ -22,7 +22,9 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
+
+import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
@@ -114,7 +116,7 @@ public class DialogFragmentSelectOOBType extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
-        final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_select_oob_type, null);
+        @SuppressLint("InflateParams") final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_select_oob_type, null);
 
         //Bind ui
         ButterKnife.bind(this, rootView);
@@ -162,7 +164,7 @@ public class DialogFragmentSelectOOBType extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).
                 setView(rootView).
                 setIcon(R.drawable.ic_oob_lock_outline).
                 setTitle(R.string.title_select_oob).

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentSourceAddress.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentSourceAddress.java
@@ -22,7 +22,9 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
+
+import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -37,6 +39,7 @@ import android.text.TextWatcher;
 import android.text.method.KeyListener;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.widget.TextView;
 
 import java.util.Locale;
 
@@ -78,10 +81,11 @@ public class DialogFragmentSourceAddress extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
-        final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_address_input, null);
+        @SuppressLint("InflateParams") final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_address_input, null);
 
         //Bind ui
         ButterKnife.bind(this, rootView);
+        final TextView summary = rootView.findViewById(R.id.summary);
 
         final KeyListener hexKeyListener = new HexKeyListener();
         final String unicastAddress = String.format(Locale.US, "%04X", mUnicastAddress);
@@ -110,20 +114,20 @@ public class DialogFragmentSourceAddress extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).setView(rootView)
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.ok, null).setNegativeButton(R.string.cancel, null);
 
         alertDialogBuilder.setIcon(R.drawable.ic_lan_black_alpha_24dp);
         alertDialogBuilder.setTitle(R.string.title_src_address);
-        alertDialogBuilder.setMessage(R.string.dialog_summary_src);
+        summary.setText(R.string.dialog_summary_src);
 
         final AlertDialog alertDialog = alertDialogBuilder.show();
         alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {
-            final String unicast = unicastAddressInput.getText().toString();
+            final String unicast = unicastAddressInput.getEditableText().toString();
             if (validateInput(unicast)) {
                 try {
                     if (getParentFragment() == null) {
-                        if(((DialogFragmentSourceAddressListener) getActivity()).setSourceAddress(Integer.parseInt(unicast, 16))){
+                        if(((DialogFragmentSourceAddressListener) requireActivity()).setSourceAddress(Integer.parseInt(unicast, 16))){
                             dismiss();
                         }
                     } else {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentUnicastAddress.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogFragmentUnicastAddress.java
@@ -22,7 +22,9 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
+
+import android.annotation.SuppressLint;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
@@ -37,6 +39,7 @@ import android.text.TextWatcher;
 import android.text.method.KeyListener;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.widget.TextView;
 
 import java.util.Locale;
 
@@ -78,11 +81,11 @@ public class DialogFragmentUnicastAddress extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(final Bundle savedInstanceState) {
-        final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_address_input, null);
+        @SuppressLint("InflateParams") final View rootView = LayoutInflater.from(getContext()).inflate(R.layout.dialog_fragment_address_input, null);
 
         //Bind ui
         ButterKnife.bind(this, rootView);
-
+        final TextView summary = rootView.findViewById(R.id.summary);
         final KeyListener hexKeyListener = new HexKeyListener();
         final String unicastAddress = String.format(Locale.US, "%04X", mUnicastAddress);
         unicastAddressInputLayout.setHint(getString((R.string.hint_unicast_address)));
@@ -110,19 +113,19 @@ public class DialogFragmentUnicastAddress extends DialogFragment {
             }
         });
 
-        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(getContext()).setView(rootView)
+        final AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(requireContext()).setView(rootView)
                 .setPositiveButton(R.string.ok, null).setNegativeButton(R.string.cancel, null);
 
         alertDialogBuilder.setIcon(R.drawable.ic_lan_black_alpha_24dp);
         alertDialogBuilder.setTitle(R.string.title_unicast_address);
-        alertDialogBuilder.setMessage(R.string.dialog_summary_unicast_address);
+        summary.setText(R.string.dialog_summary_unicast_address);
 
         final AlertDialog alertDialog = alertDialogBuilder.show();
         alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {
             final String unicast = unicastAddressInput.getEditableText().toString();
             if (validateInput(unicast)) {
                 if (getParentFragment() == null) {
-                    ((DialogFragmentUnicastAddressListener) getActivity()).setUnicastAddress(Integer.parseInt(unicast, 16));
+                    ((DialogFragmentUnicastAddressListener) requireActivity()).setUnicastAddress(Integer.parseInt(unicast, 16));
                 } else {
                     ((DialogFragmentUnicastAddressListener) getParentFragment()).setUnicastAddress(Integer.parseInt(unicast, 16));
                 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogRelayRetransmitSettings.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/dialog/DialogRelayRetransmitSettings.java
@@ -1,7 +1,7 @@
 package no.nordicsemi.android.nrfmeshprovisioner.dialog;
 
 import android.annotation.SuppressLint;
-import android.app.AlertDialog;
+import androidx.appcompat.app.AlertDialog;
 import android.app.Dialog;
 import android.os.Bundle;
 import androidx.annotation.NonNull;
@@ -23,9 +23,9 @@ public class DialogRelayRetransmitSettings extends DialogFragment {
 
     private static final String TAG = DialogRelayRetransmitSettings.class.getSimpleName();
 
-    public static final String RELAY = "RELAY";
-    public static final String TRANSMIT_COUNT = "TRANSMIT_COUNT";
-    public static final String TRANSMIT_INTERVAL_STEPS = "TRANSMIT_INTERVAL_STEPS";
+    private static final String RELAY = "RELAY";
+    private static final String TRANSMIT_COUNT = "TRANSMIT_COUNT";
+    private static final String TRANSMIT_INTERVAL_STEPS = "TRANSMIT_INTERVAL_STEPS";
 
     private static final int MIN_RETRANSMIT_COUNT = 0;
     private static final int MAX_RETRANSMIT_COUNT = 0b111;
@@ -120,7 +120,7 @@ public class DialogRelayRetransmitSettings extends DialogFragment {
             }
         });
 
-        return new AlertDialog.Builder(getContext())
+        return new AlertDialog.Builder(requireContext())
                 .setView(rootView)
                 .setPositiveButton(R.string.ok, (dialog, which) -> {
                     if (getParentFragment() == null) {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/NodeConfigurationViewModel.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/NodeConfigurationViewModel.java
@@ -101,7 +101,7 @@ public class NodeConfigurationViewModel extends ViewModel {
     }
 
     public LiveData<Integer> getConnectedMeshNodeAddress(){
-        return mNrfMeshRepository.getConnectedMeshNodeAddress();
+        return mNrfMeshRepository.getConnectedProxyAddress();
     }
 
 }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/NrfMeshRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/NrfMeshRepository.java
@@ -468,9 +468,7 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
             mIsConnectedToProxy.postValue(false);
             if (mConnectedProxyAddress.getValue() != null) {
                 final MeshNetwork network = mMeshManagerApi.getMeshNetwork();
-                final ProvisionedMeshNode node = network.getProvisionedNode(mConnectedProxyAddress.getValue());
-                if (node != null)
-                    node.setProxyFilter(null);
+                network.setProxyFilter(null);
 
             }
             clearExtendedMeshNode();

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/NrfMeshRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/NrfMeshRepository.java
@@ -1,14 +1,11 @@
 package no.nordicsemi.android.nrfmeshprovisioner.viewmodels;
 
-import androidx.lifecycle.LiveData;
-import androidx.lifecycle.MutableLiveData;
 import android.bluetooth.BluetoothDevice;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Environment;
 import android.os.Handler;
 import android.os.ParcelUuid;
-import androidx.annotation.NonNull;
 import android.util.Log;
 
 import java.io.File;
@@ -17,6 +14,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import androidx.annotation.NonNull;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
 import no.nordicsemi.android.log.LogSession;
 import no.nordicsemi.android.log.Logger;
 import no.nordicsemi.android.meshprovisioner.Group;
@@ -52,9 +52,7 @@ import no.nordicsemi.android.meshprovisioner.transport.MeshModel;
 import no.nordicsemi.android.meshprovisioner.transport.ProvisionedMeshNode;
 import no.nordicsemi.android.meshprovisioner.transport.ProxyConfigFilterStatus;
 import no.nordicsemi.android.meshprovisioner.transport.VendorModelMessageStatus;
-import no.nordicsemi.android.meshprovisioner.utils.AddressUtils;
 import no.nordicsemi.android.meshprovisioner.utils.MeshAddress;
-import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 import no.nordicsemi.android.nrfmeshprovisioner.adapter.ExtendedBluetoothDevice;
 import no.nordicsemi.android.nrfmeshprovisioner.ble.BleMeshManager;
 import no.nordicsemi.android.nrfmeshprovisioner.ble.BleMeshManagerCallbacks;
@@ -93,7 +91,7 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
     private final SingleLiveEvent<Boolean> mIsReconnecting = new SingleLiveEvent<>();
     private final MutableLiveData<UnprovisionedMeshNode> mUnprovisionedMeshNodeLiveData = new MutableLiveData<>();
     private final MutableLiveData<ProvisionedMeshNode> mProvisionedMeshNodeLiveData = new MutableLiveData<>();
-    private final SingleLiveEvent<Integer> mConnectedMeshNodeAddress = new SingleLiveEvent<>();
+    private final SingleLiveEvent<Integer> mConnectedProxyAddress = new SingleLiveEvent<>();
 
     // Contains the initial provisioning live data
     private NetworkInformationLiveData mNetworkInformationLiveData;
@@ -371,8 +369,8 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
         return mProvisionedMeshNodeLiveData;
     }
 
-    LiveData<Integer> getConnectedMeshNodeAddress() {
-        return mConnectedMeshNodeAddress;
+    LiveData<Integer> getConnectedProxyAddress() {
+        return mConnectedProxyAddress;
     }
 
     /**
@@ -468,9 +466,9 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
         } else {
             mIsConnected.postValue(false);
             mIsConnectedToProxy.postValue(false);
-            if (mConnectedMeshNodeAddress.getValue() != null) {
-                final ProvisionedMeshNode node = mMeshManagerApi.getMeshNetwork().
-                        getProvisionedNode(AddressUtils.getUnicastAddressBytes(mConnectedMeshNodeAddress.getValue()));
+            if (mConnectedProxyAddress.getValue() != null) {
+                final MeshNetwork network = mMeshManagerApi.getMeshNetwork();
+                final ProvisionedMeshNode node = network.getProvisionedNode(mConnectedProxyAddress.getValue());
                 if (node != null)
                     node.setProxyFilter(null);
 
@@ -478,7 +476,7 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
             clearExtendedMeshNode();
         }
         mSetupProvisionedNode = false;
-        mConnectedMeshNodeAddress.postValue(null);
+        mConnectedProxyAddress.postValue(null);
     }
 
     @Override
@@ -635,10 +633,8 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
     public void onProvisioningFailed(final UnprovisionedMeshNode meshNode, final ProvisioningState.States state, final byte[] data) {
         mUnprovisionedMeshNode = meshNode;
         mUnprovisionedMeshNodeLiveData.postValue(meshNode);
-        switch (state) {
-            case PROVISIONING_FAILED:
-                mIsProvisioningComplete = false;
-                break;
+        if (state == ProvisioningState.States.PROVISIONING_FAILED) {
+            mIsProvisioningComplete = false;
         }
         mProvisioningStateLiveData.onMeshNodeStateUpdated(state);
 
@@ -649,10 +645,8 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
         mProvisionedMeshNode = meshNode;
         mUnprovisionedMeshNodeLiveData.postValue(null);
         mProvisionedMeshNodeLiveData.postValue(meshNode);
-        switch (state) {
-            case PROVISIONING_COMPLETE:
-                onProvisioningCompleted(meshNode);
-                break;
+        if (state == ProvisioningState.States.PROVISIONING_COMPLETE) {
+            onProvisioningCompleted(meshNode);
         }
         mProvisioningStateLiveData.onMeshNodeStateUpdated(state);
 
@@ -774,14 +768,14 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
                 final ProxyConfigFilterStatus status = (ProxyConfigFilterStatus) meshMessage;
                 final int unicastAddress = status.getSrc();
                 Log.v(TAG, "Proxy configuration source: " + MeshAddress.formatAddress(status.getSrc(), false));
-                mConnectedMeshNodeAddress.postValue(unicastAddress);
+                mConnectedProxyAddress.postValue(unicastAddress);
                 mMeshMessageLiveData.postValue(status);
             } else if (meshMessage instanceof ConfigCompositionDataStatus) {
                 final ConfigCompositionDataStatus status = (ConfigCompositionDataStatus) meshMessage;
                 if (mSetupProvisionedNode) {
                     mIsCompositionDataReceived = true;
                     mProvisionedMeshNodeLiveData.postValue(node);
-                    mConnectedMeshNodeAddress.postValue(node.getUnicastAddress());
+                    mConnectedProxyAddress.postValue(node.getUnicastAddress());
                     mProvisioningStateLiveData.onMeshNodeStateUpdated(ProvisioningState.States.COMPOSITION_DATA_STATUS_RECEIVED);
                     //We send app key add after composition is complete. Adding a delay so that we don't send anything before the acknowledgement is sent out.
                     if (!mMeshNetwork.getAppKeys().isEmpty()) {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/SharedViewModel.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/SharedViewModel.java
@@ -22,16 +22,17 @@
 
 package no.nordicsemi.android.nrfmeshprovisioner.viewmodels;
 
-import androidx.lifecycle.LiveData;
-import androidx.lifecycle.ViewModel;
 import android.net.Uri;
 
 import java.util.List;
 
 import javax.inject.Inject;
 
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.ViewModel;
 import no.nordicsemi.android.meshprovisioner.Group;
 import no.nordicsemi.android.meshprovisioner.MeshManagerApi;
+import no.nordicsemi.android.meshprovisioner.transport.MeshMessage;
 import no.nordicsemi.android.meshprovisioner.transport.ProvisionedMeshNode;
 
 public class SharedViewModel extends ViewModel {
@@ -63,6 +64,10 @@ public class SharedViewModel extends ViewModel {
 
     public MeshNetworkLiveData getMeshNetworkLiveData() {
         return nRFMeshRepository.getMeshNetworkLiveData();
+    }
+
+    public LiveData<MeshMessage> getMeshMessageLiveData() {
+        return nRFMeshRepository.getMeshMessageLiveData();
     }
 
     public LiveData<List<Group>> getGroups(){

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/SharedViewModel.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/SharedViewModel.java
@@ -135,8 +135,8 @@ public class SharedViewModel extends ViewModel {
         return nRFMeshRepository.getNetworkExportState();
     }
 
-    public LiveData<Integer> getConnectedMeshNodeAddress(){
-        return nRFMeshRepository.getConnectedMeshNodeAddress();
+    public LiveData<Integer> getConnectedProxyAddress(){
+        return nRFMeshRepository.getConnectedProxyAddress();
     }
 
     public void setSelectedGroup(final int address){

--- a/Example/nrf-mesh/app/src/main/res/color/blue_button_states.xml
+++ b/Example/nrf-mesh/app/src/main/res/color/blue_button_states.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="?colorAccent" android:state_selected="true"/>
-    <item android:color="@color/textColorSecondary" android:state_selected="false"/>
-    <item android:color="@color/textColorSecondary" android:state_enabled="true"/>
-    <item android:color="@android:color/darker_gray" android:state_enabled="false"/>
-</selector>

--- a/Example/nrf-mesh/app/src/main/res/color/blue_button_states.xml
+++ b/Example/nrf-mesh/app/src/main/res/color/blue_button_states.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="?colorAccent" android:state_selected="true"/>
+    <item android:color="@color/textColorSecondary" android:state_selected="false"/>
+    <item android:color="@color/textColorSecondary" android:state_enabled="true"/>
+    <item android:color="@android:color/darker_gray" android:state_enabled="false"/>
+</selector>

--- a/Example/nrf-mesh/app/src/main/res/color/filter_add_button_states.xml
+++ b/Example/nrf-mesh/app/src/main/res/color/filter_add_button_states.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@android:color/darker_gray" android:state_enabled="false"/>
+    <item android:color="?colorAccent" android:state_enabled="true"/>
+</selector>

--- a/Example/nrf-mesh/app/src/main/res/color/proxy_filter_button_states.xml
+++ b/Example/nrf-mesh/app/src/main/res/color/proxy_filter_button_states.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/colorAccent" android:state_selected="true"/>
+    <item android:color="@android:color/darker_gray" android:state_enabled="false"/>
+    <item android:color="@color/textColorSecondary" android:state_enabled="true"/>
+</selector>

--- a/Example/nrf-mesh/app/src/main/res/drawable/ic_done_all_black_alpha_24dp.xml
+++ b/Example/nrf-mesh/app/src/main/res/drawable/ic_done_all_black_alpha_24dp.xml
@@ -1,0 +1,5 @@
+<vector android:alpha="0.6" android:height="24dp"
+    android:viewportHeight="24.0" android:viewportWidth="24.0"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="#FF000000" android:pathData="M18,7l-1.41,-1.41 -6.34,6.34 1.41,1.41L18,7zM22.24,5.59L11.66,16.17 7.48,12l-1.41,1.41L11.66,19l12,-12 -1.42,-1.41zM0.41,13.41L6,19l1.41,-1.41L1.83,12 0.41,13.41z"/>
+</vector>

--- a/Example/nrf-mesh/app/src/main/res/drawable/ic_filter_list_black_24dp.xml
+++ b/Example/nrf-mesh/app/src/main/res/drawable/ic_filter_list_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M10,18h4v-2h-4v2zM3,6v2h18L21,6L3,6zM6,13h12v-2L6,11v2z"/>
+</vector>

--- a/Example/nrf-mesh/app/src/main/res/layout/activity_main.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/activity_main.xml
@@ -68,6 +68,16 @@
         app:layout_constraintBottom_toTopOf="@+id/bottom_navigation_view"/>
 
     <fragment
+        android:id="@+id/fragment_proxy"
+        android:name="no.nordicsemi.android.nrfmeshprovisioner.ProxyFilterFragment"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintTop_toBottomOf="@+id/app_bar_layout"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/bottom_navigation_view"/>
+
+    <fragment
         android:id="@+id/fragment_settings"
         android:name="no.nordicsemi.android.nrfmeshprovisioner.SettingsFragment"
         android:layout_width="0dp"
@@ -98,6 +108,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
+        app:labelVisibilityMode="labeled"
         app:elevation="8dp"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/activity_mesh_provisioner.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/activity_mesh_provisioner.xml
@@ -138,9 +138,8 @@
                             app:layout_constraintRight_toRightOf="parent"
                             app:layout_constraintTop_toBottomOf="@+id/container_public_key_type"/>
 
-                        <Button
+                        <com.google.android.material.button.MaterialButton
                             android:id="@+id/action_provision_device"
-                            style="@style/BlueTextButton"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_gravity="center_horizontal"

--- a/Example/nrf-mesh/app/src/main/res/layout/activity_model_configuration.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/activity_model_configuration.xml
@@ -164,9 +164,8 @@
                         app:layout_constraintTop_toBottomOf="@id/div1"
                         tools:visibility="visible"/>
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
                         android:id="@+id/action_bind_app_key"
-                        style="@style/BlueTextButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_horizontal"
@@ -178,9 +177,8 @@
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/div1"/>
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
                         android:id="@+id/action_unbind_app_key"
-                        style="@style/BlueTextButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_horizontal"
@@ -279,12 +277,11 @@
                         android:layout_width="0dp"
                         android:layout_height="1dp"
                         app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toEndOf="@id/icon"
+                        app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/container_publish_address"/>
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
                         android:id="@+id/action_set_publication"
-                        style="@style/BlueTextButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_horizontal"
@@ -296,9 +293,8 @@
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/div2"/>
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
                         android:id="@+id/action_clear_publication_set"
-                        style="@style/BlueTextButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_horizontal"
@@ -403,9 +399,8 @@
                         app:layout_constraintTop_toBottomOf="@id/div3"
                         tools:visibility="visible"/>
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
                         android:id="@+id/action_subscribe_address"
-                        style="@style/BlueTextButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_horizontal"

--- a/Example/nrf-mesh/app/src/main/res/layout/activity_node_configuration.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/activity_node_configuration.xml
@@ -145,9 +145,8 @@
                             app:layout_constraintStart_toStartOf="parent"
                             app:layout_constraintTop_toTopOf="parent"/>
 
-                        <Button
+                        <com.google.android.material.button.MaterialButton
                             android:id="@+id/action_get_compostion_data"
-                            style="@style/BlueTextButton"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_gravity="center_horizontal"
@@ -238,9 +237,8 @@
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/container_app_key_bind"/>
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
                         android:id="@+id/action_add_app_keys"
-                        style="@style/BlueTextButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_horizontal"
@@ -302,9 +300,8 @@
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/proxy_state_summary"/>
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
                         android:id="@+id/action_get_proxy_state"
-                        style="@style/BlueTextButton"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_horizontal"
@@ -316,7 +313,7 @@
                         app:layout_constraintEnd_toStartOf="@id/action_set_proxy_state"
                         app:layout_constraintTop_toBottomOf="@id/div2"/>
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
                         android:id="@+id/action_set_proxy_state"
                         style="@style/RedButton"
                         android:layout_width="wrap_content"
@@ -382,7 +379,7 @@
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/textview"/>
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
                         android:id="@+id/action_reset_node"
                         style="@style/RedButton"
                         android:layout_width="wrap_content"

--- a/Example/nrf-mesh/app/src/main/res/layout/activity_node_configuration.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/activity_node_configuration.xml
@@ -336,141 +336,6 @@
             </androidx.cardview.widget.CardView>
 
             <androidx.cardview.widget.CardView
-                android:id="@+id/proxy_filter_card"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/activity_vertical_margin"
-                android:layout_marginBottom="@dimen/activity_vertical_margin"
-                android:background="@color/white"
-                android:visibility="gone"
-                app:cardElevation="1dp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/node_proxy_state_card"
-                tools:visibility="visible">
-
-                <androidx.constraintlayout.widget.ConstraintLayout
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
-
-                    <androidx.appcompat.widget.Toolbar
-                        android:id="@+id/proxy_filter_tool_bar"
-                        android:layout_width="0dp"
-                        android:layout_height="?actionBarSize"
-                        android:layout_marginEnd="8dp"
-                        app:layout_constraintEnd_toStartOf="@+id/filter_switch"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:logo="@drawable/ic_filter_list_black_alpha_24dp"
-                        app:title="@string/title_proxy_filter"
-                        app:titleMarginStart="@dimen/toolbar_title_margin"/>
-
-                    <Switch
-                        android:id="@+id/filter_switch"
-                        android:layout_width="150dp"
-                        android:layout_height="wrap_content"
-                        android:layout_marginEnd="@dimen/activity_horizontal_margin"
-                        android:checked="true"
-                        android:text="@string/white_list_filter"
-                        android:textColor="@color/textColorSecondary"
-                        app:layout_constraintBottom_toBottomOf="@+id/proxy_filter_tool_bar"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/proxy_filter_tool_bar"
-                        app:layout_constraintTop_toTopOf="@id/proxy_filter_tool_bar"/>
-
-                    <androidx.constraintlayout.widget.ConstraintLayout
-                        android:id="@+id/container_proxy_filter"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:background="?selectableItemBackground"
-                        android:paddingTop="@dimen/item_padding_top"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/proxy_filter_tool_bar">
-
-                        <TextView
-                            android:id="@+id/no_addresses"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:paddingStart="@dimen/activity_horizontal_margin"
-                            android:paddingEnd="@dimen/activity_horizontal_margin"
-                            android:paddingBottom="@dimen/activity_vertical_margin"
-                            android:text="@string/no_addresses_added"
-                            android:textSize="16sp"
-                            app:layout_constraintLeft_toLeftOf="parent"
-                            app:layout_constraintRight_toRightOf="parent"
-                            app:layout_constraintTop_toTopOf="parent"/>
-
-                        <androidx.recyclerview.widget.RecyclerView
-                            android:id="@+id/recycler_view_addresses"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:clipToPadding="false"
-                            android:paddingBottom="@dimen/activity_vertical_margin"
-                            android:scrollbars="none"
-                            android:visibility="gone"
-                            app:layout_constraintLeft_toLeftOf="parent"
-                            app:layout_constraintRight_toRightOf="parent"
-                            app:layout_constraintTop_toTopOf="parent"
-                            tools:visibility="invisible"/>
-
-                    </androidx.constraintlayout.widget.ConstraintLayout>
-
-                    <include
-                        android:id="@+id/div2"
-                        layout="@layout/layout_divider"
-                        android:layout_width="0dp"
-                        android:layout_height="1dp"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/container_proxy_filter"/>
-
-                    <Button
-                        android:id="@+id/action_add_address"
-                        style="@style/BlueTextButton"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_horizontal"
-                        android:layout_marginStart="@dimen/item_padding_end"
-                        android:layout_marginEnd="@dimen/item_padding_start"
-                        android:padding="@dimen/activity_horizontal_margin"
-                        android:text="@string/action_add"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintTop_toBottomOf="@id/div2"/>
-
-
-                    <Button
-                        android:id="@+id/action_clear_addresses"
-                        style="@style/RedButton"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_horizontal"
-                        android:layout_marginStart="@dimen/item_padding_end"
-                        android:layout_marginEnd="@dimen/item_padding_start"
-                        android:padding="@dimen/activity_horizontal_margin"
-                        android:text="@string/action_clear"
-                        android:visibility="gone"
-                        app:layout_constraintBottom_toBottomOf="@id/action_add_address"
-                        app:layout_constraintEnd_toStartOf="@id/action_add_address"
-                        app:layout_constraintTop_toTopOf="@id/action_add_address"
-                        tools:visibility="visible"/>
-
-                    <TextView
-                        android:id="@+id/remove_hint"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginEnd="@dimen/item_padding_end"
-                        android:padding="@dimen/activity_horizontal_margin"
-                        android:text="@string/hint_remove"
-                        app:layout_constraintBottom_toBottomOf="@id/action_add_address"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="@id/action_add_address"/>
-
-                </androidx.constraintlayout.widget.ConstraintLayout>
-            </androidx.cardview.widget.CardView>
-
-            <androidx.cardview.widget.CardView
                 android:id="@+id/node_reset_card"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
@@ -480,7 +345,7 @@
                 app:cardElevation="1dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/proxy_filter_card">
+                app:layout_constraintTop_toBottomOf="@id/node_proxy_state_card">
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
@@ -514,7 +379,7 @@
                         android:layout_width="0dp"
                         android:layout_height="1dp"
                         app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintStart_toEndOf="@id/icon"
+                        app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/textview"/>
 
                     <Button

--- a/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_address_input.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_address_input.xml
@@ -25,40 +25,49 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:paddingBottom="@dimen/alert_dialog_padding_bottom"
+    android:paddingEnd="@dimen/alert_dialog_padding_right"
+    android:paddingStart="@dimen/alert_dialog_padding_left"
+    android:paddingTop="@dimen/alert_dialog_padding">
+
+    <TextView
+        android:id="@+id/summary"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <TextView
+        android:id="@+id/prefix"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/hex_prefix"
+        android:textSize="16sp"
+        app:layout_constraintTop_toTopOf="@id/text_input_layout"
+        app:layout_constraintBaseline_toBaselineOf="@id/text_input_layout"
+        app:layout_constraintEnd_toStartOf="@id/text_input_layout"
+        app:layout_constraintStart_toStartOf="parent"/>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/text_input_layout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:paddingTop="@dimen/item_padding_top"
-        android:layout_marginStart="@dimen/activity_horizontal_margin"
-        android:layout_marginEnd="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
+        android:layout_marginStart="@dimen/item_padding_start"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintStart_toEndOf="@id/prefix"
+        app:layout_constraintTop_toBottomOf="@id/summary">
 
-        <LinearLayout
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/text_input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
+            android:inputType="text|textCapCharacters"
+            android:maxLength="4"
+            android:singleLine="true"
+            android:textSize="16sp"/>
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="8dp"
-                android:text="@string/hex_prefix"
-                android:textSize="16sp"/>
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/text_input"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:textSize="16sp"
-                android:inputType="text|textCapCharacters"
-                android:maxLength="4"
-                android:singleLine="true"/>
-
-        </LinearLayout>
     </com.google.android.material.textfield.TextInputLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_create_group.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_create_group.xml
@@ -26,102 +26,73 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:clipToPadding="false">
+    android:clipToPadding="false"
+    android:paddingStart="@dimen/alert_dialog_padding_left"
+    android:paddingTop="@dimen/alert_dialog_padding"
+    android:paddingEnd="@dimen/alert_dialog_padding_right"
+    android:paddingBottom="@dimen/alert_dialog_padding_bottom">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:padding="@dimen/activity_horizontal_margin">
+        android:layout_height="wrap_content">
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/group_name_layout"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:hint="@string/name"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            android:paddingStart="@dimen/activity_horizontal_margin"
             tools:ignore="RtlSymmetry">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/name_input"
                 android:layout_width="match_parent"
-                android:layout_height="match_parent">
-
-                <TextView
-                    android:id="@+id/address_name_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/group_name"
-                    app:layout_constraintBottom_toBottomOf="@id/name_input"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="@id/name_input"/>
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/name_input"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/activity_horizontal_margin"
-                    android:hint="Living Room"
-                    android:inputType="textCapWords"
-                    android:maxLength="20"
-                    android:singleLine="true"
-                    android:textSize="16sp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/address_name_text"
-                    app:layout_constraintTop_toTopOf="parent"
-                    tools:ignore="HardcodedText"/>
-            </androidx.constraintlayout.widget.ConstraintLayout>
+                android:layout_height="wrap_content"
+                android:inputType="textCapWords"
+                android:maxLength="20"
+                android:singleLine="true"
+                android:text="Living Room"
+                android:textSize="16sp"
+                tools:ignore="HardcodedText"/>
         </com.google.android.material.textfield.TextInputLayout>
+
+
+        <TextView
+            android:id="@+id/prefix"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/hex_prefix"
+            android:textSize="16sp"
+            app:layout_constraintBaseline_toBaselineOf="@id/group_address_layout"
+            app:layout_constraintEnd_toStartOf="@id/group_address_layout"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@id/group_address_layout"/>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/group_address_layout"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/item_padding_start"
+            android:layout_marginTop="@dimen/activity_vertical_margin"
+            android:hint="@string/address"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@id/group_name_layout"
+            app:layout_constraintStart_toEndOf="@id/prefix"
             app:layout_constraintTop_toBottomOf="@id/group_name_layout"
-            android:paddingStart="@dimen/activity_horizontal_margin"
             tools:ignore="RtlSymmetry">
 
-            <androidx.constraintlayout.widget.ConstraintLayout
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/address_input"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content">
+                android:layout_height="wrap_content"
+                android:inputType="text|textCapCharacters"
+                android:maxLength="4"
+                android:singleLine="true"
+                android:text="C000 - 0xFEFF"
+                android:textSize="16sp"
+                tools:ignore="HardcodedText"/>
 
-                <TextView
-                    android:id="@+id/address_text"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="@string/group_address"
-                    app:layout_constraintBottom_toBottomOf="@id/address_input"
-                    app:layout_constraintStart_toStartOf="parent"
-                    app:layout_constraintTop_toTopOf="@id/address_input"/>
-
-                <TextView
-                    android:id="@+id/prefix"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginStart="@dimen/activity_vertical_margin"
-                    android:text="@string/hex_prefix"
-                    android:textSize="16sp"
-                    app:layout_constraintBottom_toBottomOf="@id/address_input"
-                    app:layout_constraintStart_toEndOf="@id/address_text"
-                    app:layout_constraintTop_toTopOf="@id/address_input"/>
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/address_input"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:hint="C000 - 0xFEFF"
-                    android:inputType="text|textCapCharacters"
-                    android:maxLength="4"
-                    android:singleLine="true"
-                    android:textSize="16sp"
-                    app:layout_constraintEnd_toEndOf="parent"
-                    app:layout_constraintStart_toEndOf="@id/prefix"
-                    app:layout_constraintTop_toTopOf="parent"
-                    tools:ignore="HardcodedText"/>
-
-            </androidx.constraintlayout.widget.ConstraintLayout>
         </com.google.android.material.textfield.TextInputLayout>
 
     </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_filter_address.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_filter_address.xml
@@ -62,9 +62,8 @@
                 android:singleLine="true"
                 android:textSize="16sp"/>
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/action_add"
-                style="@style/BlueTextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/action_add"/>

--- a/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_filter_address.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_filter_address.xml
@@ -24,37 +24,49 @@
 <androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:paddingBottom="@dimen/alert_dialog_padding_bottom"
+    android:paddingEnd="@dimen/alert_dialog_padding_right"
+    android:paddingStart="@dimen/alert_dialog_padding_left"
+    android:paddingTop="@dimen/alert_dialog_padding">
 
-    <com.google.android.material.textfield.TextInputLayout
-        android:id="@+id/text_input_layout"
+    <TextView
+        android:id="@+id/summary"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        android:paddingTop="@dimen/item_padding_top"
-        android:paddingBottom="@dimen/item_padding_bottom"
-        android:clipToPadding="false">
+        android:text=""/>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingStart="@dimen/activity_horizontal_margin"
-            android:paddingEnd="@dimen/activity_horizontal_margin"
-            android:orientation="horizontal">
+    <TextView
+        android:id="@+id/prefix"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/hex_prefix"
+        android:textSize="16sp"
+        app:layout_constraintBaseline_toBaselineOf="@id/text_input_layout"
+        app:layout_constraintEnd_toStartOf="@id/text_input_layout"
+        app:layout_constraintStart_toStartOf="parent"/>
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="8dp"
-                android:text="@string/hex_prefix"
-                android:textSize="16sp"/>
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/text_input_layout"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingEnd="@dimen/item_padding_end"
+        android:layout_marginTop="@dimen/item_padding_top"
+        android:layout_marginStart="@dimen/item_padding_start"
+        app:layout_constraintEnd_toStartOf="@id/action_add"
+        app:layout_constraintStart_toEndOf="@id/prefix"
+        app:layout_constraintTop_toBottomOf="@id/summary"
+        android:hint="@string/hint_filter_address"
+        tools:ignore="RtlSymmetry">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/text_input"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
                 android:inputType="text|textCapCharacters"
@@ -62,14 +74,17 @@
                 android:singleLine="true"
                 android:textSize="16sp"/>
 
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/action_add"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/action_add"/>
-
-        </LinearLayout>
     </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/action_add"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/action_add"
+        app:layout_constraintTop_toTopOf="@id/text_input_layout"
+        app:layout_constraintBottom_toBottomOf="@id/text_input_layout"
+        app:layout_constraintStart_toEndOf="@id/text_input_layout"
+        app:layout_constraintEnd_toEndOf="parent"/>
 
     <androidx.recyclerview.widget.RecyclerView
         android:layout_marginTop="@dimen/activity_vertical_margin"
@@ -77,11 +92,9 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:clipToPadding="false"
-        android:paddingStart="@dimen/activity_horizontal_margin"
-        android:paddingEnd="@dimen/activity_horizontal_margin"
         android:scrollbars="none"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@id/prefix"
         app:layout_constraintTop_toBottomOf="@id/text_input_layout"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_flags_input.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_flags_input.xml
@@ -25,19 +25,31 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content"
+    android:paddingStart="@dimen/alert_dialog_padding_left"
+    android:paddingTop="@dimen/alert_dialog_padding"
+    android:paddingEnd="@dimen/alert_dialog_padding_right"
+    android:paddingBottom="@dimen/alert_dialog_padding_bottom">
+
+    <TextView
+        android:id="@+id/summary"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:text="@string/dialog_summary_flags"/>
 
     <TextView
         android:id="@+id/title_key_refresh_flag"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
         android:paddingBottom="@dimen/activity_horizontal_margin"
-        android:paddingEnd="@dimen/activity_horizontal_margin"
-        android:paddingStart="@dimen/activity_horizontal_margin"
         android:text="@string/title_key_refresh_flag"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        app:layout_constraintTop_toBottomOf="@id/summary"/>
 
     <RadioGroup
         android:id="@+id/radio_group_refresh_flag"
@@ -69,7 +81,8 @@
         android:id="@+id/title_iv_update_flag"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:padding="@dimen/activity_horizontal_margin"
+        android:paddingTop="@dimen/activity_vertical_margin"
+        android:paddingBottom="@dimen/activity_vertical_margin"
         android:text="@string/title_iv_update_flag"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"

--- a/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_ivindex_input.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_ivindex_input.xml
@@ -25,41 +25,50 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content"
+    android:paddingStart="@dimen/alert_dialog_padding_left"
+    android:paddingTop="@dimen/alert_dialog_padding"
+    android:paddingEnd="@dimen/alert_dialog_padding_right"
+    android:paddingBottom="@dimen/alert_dialog_padding_bottom">
+
+    <TextView
+        android:id="@+id/summary"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/dialog_summary_iv_index"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <TextView
+        android:id="@+id/prefix"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:text="@string/hex_prefix"
+        android:textSize="16sp"
+        app:layout_constraintBaseline_toBaselineOf="@id/text_input_layout"
+        app:layout_constraintEnd_toStartOf="@id/text_input_layout"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/text_input_layout"/>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/text_input_layout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:paddingTop="@dimen/item_padding_top"
-        android:layout_marginStart="@dimen/activity_horizontal_margin"
-        android:layout_marginEnd="@dimen/activity_horizontal_margin"
+        android:layout_marginStart="@dimen/item_padding_start"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintStart_toEndOf="@id/prefix"
+        app:layout_constraintTop_toBottomOf="@id/summary">
 
-        <LinearLayout
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/text_input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="8dp"
-                android:text="0x"
-                android:textSize="16sp"/>
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/text_input"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:textSize="16sp"
-                android:inputType="text|textCapCharacters"
-                android:maxLength="8"
-                android:singleLine="true"/>
-
-        </LinearLayout>
-
+            android:inputType="text|textCapCharacters"
+            android:maxLength="8"
+            android:singleLine="true"
+            android:textSize="16sp"/>
     </com.google.android.material.textfield.TextInputLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_key_index_input.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_key_index_input.xml
@@ -25,41 +25,50 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content"
+    android:paddingStart="@dimen/alert_dialog_padding_left"
+    android:paddingTop="@dimen/alert_dialog_padding"
+    android:paddingEnd="@dimen/alert_dialog_padding_right"
+    android:paddingBottom="@dimen/alert_dialog_padding_bottom">
+
+    <TextView
+        android:id="@+id/summary"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        android:text="@string/dialog_summary_key_index"/>
+
+    <TextView
+        android:id="@+id/prefix"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:text="@string/hex_prefix"
+        android:textSize="16sp"
+        app:layout_constraintBaseline_toBaselineOf="@id/text_input_layout"
+        app:layout_constraintEnd_toStartOf="@id/text_input_layout"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/text_input_layout"/>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/text_input_layout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:paddingTop="@dimen/item_padding_top"
-        android:layout_marginStart="@dimen/activity_horizontal_margin"
-        android:layout_marginEnd="@dimen/activity_horizontal_margin"
+        android:layout_marginStart="@dimen/item_padding_start"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintStart_toEndOf="@id/prefix"
+        app:layout_constraintTop_toBottomOf="@id/summary">
 
-        <LinearLayout
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/text_input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="8dp"
-                android:text="0x"
-                android:textSize="16sp"/>
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/text_input"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:textSize="16sp"
-                android:inputType="text|textCapCharacters"
-                android:maxLength="3"
-                android:singleLine="true"/>
-
-        </LinearLayout>
-
+            android:inputType="text|textCapCharacters"
+            android:maxLength="3"
+            android:singleLine="true"
+            android:textSize="16sp"/>
     </com.google.android.material.textfield.TextInputLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_key_input.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_key_input.xml
@@ -25,41 +25,50 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content"
+    android:paddingStart="@dimen/alert_dialog_padding_left"
+    android:paddingTop="@dimen/alert_dialog_padding"
+    android:paddingEnd="@dimen/alert_dialog_padding_right"
+    android:paddingBottom="@dimen/alert_dialog_padding_bottom">
+
+    <TextView
+        android:id="@+id/summary"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
+
+    <TextView
+        android:id="@+id/prefix"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:text="@string/hex_prefix"
+        android:textSize="16sp"
+        app:layout_constraintBaseline_toBaselineOf="@id/text_input_layout"
+        app:layout_constraintEnd_toStartOf="@id/text_input_layout"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/text_input_layout"/>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/text_input_layout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:paddingTop="@dimen/item_padding_top"
-        android:layout_marginStart="@dimen/activity_horizontal_margin"
-        android:layout_marginEnd="@dimen/activity_horizontal_margin"
+        android:layout_marginStart="@dimen/item_padding_start"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintStart_toEndOf="@id/prefix"
+        app:layout_constraintTop_toBottomOf="@id/summary">
 
-        <LinearLayout
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/text_input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="8dp"
-                android:text="0x"
-                android:textSize="16sp"/>
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/text_input"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:textSize="16sp"
-                android:inputType="text|textCapCharacters"
-                android:maxLength="32"
-                android:singleLine="true"/>
-
-        </LinearLayout>
+            android:inputType="text|textCapCharacters"
+            android:maxLength="32"
+            android:singleLine="true"
+            android:textSize="16sp"/>
 
     </com.google.android.material.textfield.TextInputLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_name.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_name.xml
@@ -25,18 +25,28 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content"
+    android:paddingBottom="@dimen/alert_dialog_padding_bottom"
+    android:paddingEnd="@dimen/alert_dialog_padding_right"
+    android:paddingStart="@dimen/alert_dialog_padding_left"
+    android:paddingTop="@dimen/alert_dialog_padding">
+
+    <TextView
+        android:id="@+id/summary"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/text_input_layout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:paddingTop="@dimen/item_padding_top"
-        android:layout_marginStart="@dimen/activity_horizontal_margin"
-        android:layout_marginEnd="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toBottomOf="@id/summary">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/text_input"

--- a/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_publication_parameters.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_publication_parameters.xml
@@ -25,38 +25,39 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:paddingStart="@dimen/activity_horizontal_margin"
-    android:paddingEnd="@dimen/activity_horizontal_margin">
+    android:layout_height="wrap_content"
+    android:paddingStart="@dimen/alert_dialog_padding_left"
+    android:paddingTop="@dimen/alert_dialog_padding"
+    android:paddingEnd="@dimen/alert_dialog_padding_right"
+    android:paddingBottom="@dimen/alert_dialog_padding_bottom">
 
     <TextView
         android:id="@+id/summary"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:textSize="16sp"
-        android:textColor="@color/black"
-        android:padding="@dimen/item_padding_top"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
         android:gravity="center_vertical"
         android:text="@string/dialog_summary_retransmit_count"
-        app:layout_constraintEnd_toEndOf="parent"/>
+        android:textColor="@color/black"
+        android:textSize="16sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/text_input_layout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:padding="@dimen/item_padding_top"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginTop="@dimen/item_padding_top"
+        app:layout_constraintEnd_toEndOf="@id/summary"
+        app:layout_constraintStart_toStartOf="@id/summary"
         app:layout_constraintTop_toBottomOf="@id/summary">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/text_input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="16sp"
             android:inputType="text|textCapCharacters"
-            android:singleLine="true"/>
+            android:singleLine="true"
+            android:textSize="16sp"/>
     </com.google.android.material.textfield.TextInputLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_publish_address_input.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_publish_address_input.xml
@@ -27,21 +27,20 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:paddingStart="@dimen/alert_dialog_padding_left"
+    android:paddingTop="@dimen/alert_dialog_padding"
+    android:paddingEnd="@dimen/alert_dialog_padding_right"
     android:clipToPadding="false">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingStart="@dimen/activity_horizontal_margin"
-        android:paddingEnd="@dimen/activity_horizontal_margin">
+        android:layout_height="wrap_content">
 
         <TextView
             android:id="@+id/summary"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/item_padding_top"
-            android:layout_marginStart="@dimen/activity_horizontal_margin"
-            android:layout_marginEnd="@dimen/activity_horizontal_margin"
             android:text="@string/publish_address_dialog_summary"
             android:textSize="16sp"
             android:textColor="@color/black"
@@ -54,6 +53,7 @@
             android:id="@+id/address_types"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/item_padding_top"
             app:layout_constraintEnd_toEndOf="@id/summary"
             app:layout_constraintStart_toStartOf="@id/summary"
             app:layout_constraintTop_toBottomOf="@id/summary"/>
@@ -75,6 +75,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/item_padding_top"
             android:layout_marginStart="@dimen/item_padding_start"
+            android:paddingBottom="@dimen/alert_dialog_padding_bottom"
             app:layout_constraintEnd_toEndOf="@id/summary"
             app:layout_constraintStart_toEndOf="@id/prefix"
             app:layout_constraintTop_toBottomOf="@id/address_types">
@@ -100,6 +101,7 @@
             app:layout_constraintEnd_toEndOf="@id/summary"
             app:layout_constraintStart_toStartOf="@id/summary"
             app:layout_constraintTop_toBottomOf="@id/text_input_layout"
+            android:paddingBottom="@dimen/alert_dialog_padding_bottom"
             tools:ignore="HardcodedText"/>
 
         <include

--- a/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_publish_address_input.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_publish_address_input.xml
@@ -40,8 +40,8 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/item_padding_top"
-            android:paddingStart="@dimen/activity_horizontal_margin"
-            android:paddingEnd="@dimen/activity_horizontal_margin"
+            android:layout_marginStart="@dimen/activity_horizontal_margin"
+            android:layout_marginEnd="@dimen/activity_horizontal_margin"
             android:text="@string/publish_address_dialog_summary"
             android:textSize="16sp"
             android:textColor="@color/black"
@@ -54,32 +54,30 @@
             android:id="@+id/address_types"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/summary"
+            app:layout_constraintStart_toStartOf="@id/summary"
             app:layout_constraintTop_toBottomOf="@id/summary"/>
+
+        <TextView
+            android:id="@+id/prefix"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/hex_prefix"
+            android:textSize="16sp"
+            app:layout_constraintBaseline_toBaselineOf="@id/text_input_layout"
+            app:layout_constraintEnd_toStartOf="@id/text_input_layout"
+            app:layout_constraintStart_toStartOf="@id/summary"
+            app:layout_constraintTop_toTopOf="@id/text_input_layout"/>
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/text_input_layout"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/item_padding_top"
-            android:paddingStart="@dimen/activity_horizontal_margin"
-            android:paddingEnd="@dimen/activity_horizontal_margin"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginStart="@dimen/item_padding_start"
+            app:layout_constraintEnd_toEndOf="@id/summary"
+            app:layout_constraintStart_toEndOf="@id/prefix"
             app:layout_constraintTop_toBottomOf="@id/address_types">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-
-                <TextView
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginBottom="8dp"
-                    android:text="@string/hex_prefix"
-                    android:textSize="16sp"/>
 
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/text_input"
@@ -90,7 +88,6 @@
                     android:singleLine="true"
                     android:textSize="16sp"/>
 
-            </LinearLayout>
         </com.google.android.material.textfield.TextInputLayout>
 
         <TextView
@@ -98,12 +95,10 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/item_padding_top"
-            android:paddingStart="@dimen/activity_horizontal_margin"
-            android:paddingEnd="@dimen/activity_horizontal_margin"
             android:text="EA57D9F1-975D-4EBD-A78A-37D189AC58F4"
             android:textSize="14sp"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="@id/summary"
+            app:layout_constraintStart_toStartOf="@id/summary"
             app:layout_constraintTop_toBottomOf="@id/text_input_layout"
             tools:ignore="HardcodedText"/>
 

--- a/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_publish_ttl_input.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_publish_ttl_input.xml
@@ -25,26 +25,38 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content"
+    android:paddingStart="@dimen/alert_dialog_padding_left"
+    android:paddingTop="@dimen/alert_dialog_padding"
+    android:paddingEnd="@dimen/alert_dialog_padding_right"
+    android:paddingBottom="@dimen/alert_dialog_padding_bottom">
+
+    <TextView
+        android:id="@+id/summary"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/dialog_summary_publish_ttl"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
 
     <CheckBox
         android:id="@+id/chk_default_ttl"
-        android:layout_width="wrap_content"
-        android:layout_height="0dp"
-        android:layout_marginStart="@dimen/activity_horizontal_margin"
-        android:layout_marginEnd="@dimen/activity_horizontal_margin"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
         android:text="@string/use_default_ttl"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"/>
+        android:layout_marginTop="@dimen/item_padding_top"
+        app:layout_constraintEnd_toEndOf="@id/summary"
+        app:layout_constraintStart_toStartOf="@id/summary"
+        app:layout_constraintTop_toBottomOf="@id/summary"/>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/text_input_layout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/item_padding_top"
-        android:layout_marginEnd="@dimen/activity_horizontal_margin"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@id/chk_default_ttl"
+        app:layout_constraintEnd_toEndOf="@id/summary"
+        app:layout_constraintStart_toStartOf="@id/summary"
         app:layout_constraintTop_toBottomOf="@id/chk_default_ttl">
 
         <com.google.android.material.textfield.TextInputEditText

--- a/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_ttl_input.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/dialog_fragment_ttl_input.xml
@@ -25,26 +25,37 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="wrap_content"
+    android:paddingStart="@dimen/alert_dialog_padding_left"
+    android:paddingTop="@dimen/alert_dialog_padding"
+    android:paddingEnd="@dimen/alert_dialog_padding_right"
+    android:paddingBottom="@dimen/alert_dialog_padding_bottom">
+
+    <TextView
+        android:id="@+id/summary"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="@string/summary_ttl"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/text_input_layout"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:paddingTop="@dimen/item_padding_top"
-        android:layout_marginStart="@dimen/activity_horizontal_margin"
-        android:layout_marginEnd="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="@dimen/activity_vertical_margin"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
+        app:layout_constraintTop_toBottomOf="@id/summary">
 
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/text_input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="16sp"
             android:inputType="number"
-            android:maxLines="1"/>
+            android:maxLines="1"
+            android:textSize="16sp"/>
 
     </com.google.android.material.textfield.TextInputLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/fragment_bottom_sheet_dialog.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/fragment_bottom_sheet_dialog.xml
@@ -39,9 +39,8 @@
                 android:singleLine="true"
                 android:textSize="16sp"/>
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/action_apply"
-                style="@style/BlueTextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/action_apply"/>

--- a/Example/nrf-mesh/app/src/main/res/layout/fragment_bottom_sheet_dialog.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/fragment_bottom_sheet_dialog.xml
@@ -1,57 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:paddingBottom="@dimen/activity_vertical_margin">
+    android:paddingBottom="@dimen/alert_dialog_padding_bottom">
 
     <androidx.appcompat.widget.Toolbar
         android:id="@+id/capabilities_bar"
         android:layout_width="match_parent"
         android:layout_height="?actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         app:logo="@drawable/ic_edit_black_alpha_24dp"
         app:title="@string/title_edit_group_info"
         app:titleMarginStart="@dimen/toolbar_title_margin"/>
 
-
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/text_input_layout"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:hint="@string/name"
+        app:layout_constraintEnd_toStartOf="@id/action_apply"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/summary">
+        app:layout_constraintTop_toBottomOf="@id/capabilities_bar"
+        android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:layout_marginEnd="@dimen/item_padding_start"
+        android:layout_marginTop="@dimen/activity_vertical_margin">
 
-        <LinearLayout
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/text_input"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_margin="@dimen/activity_horizontal_margin"
-            android:orientation="horizontal">
+            android:layout_weight="1"
+            android:singleLine="true"
+            android:text="Living Room"
+            android:textSize="16sp"
+            tools:ignore="HardcodedText"/>
 
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/text_input"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:hint="@string/group_friendly_name"
-                android:singleLine="true"
-                android:textSize="16sp"/>
-
-            <com.google.android.material.button.MaterialButton
-                android:id="@+id/action_apply"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/action_apply"/>
-
-        </LinearLayout>
     </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/action_apply"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/action_apply"
+        app:layout_constraintBottom_toBottomOf="@id/text_input_layout"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/text_input_layout"
+        app:layout_constraintTop_toTopOf="@id/text_input_layout"
+        android:layout_marginEnd="@dimen/activity_horizontal_margin"/>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/group_items"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:paddingBottom="@dimen/item_padding_bottom"/>
+        android:layout_marginTop="@dimen/item_padding_bottom"
+        app:layout_constraintEnd_toEndOf="@id/action_apply"
+        app:layout_constraintStart_toStartOf="@id/text_input_layout"
+        app:layout_constraintTop_toBottomOf="@id/text_input_layout"/>
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/fragment_groups.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/fragment_groups.xml
@@ -29,8 +29,6 @@
     android:layout_height="match_parent">
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:app="http://schemas.android.com/apk/res-auto"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
@@ -57,7 +55,6 @@
             app:layout_constraintTop_toTopOf="parent"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-
 
     <com.google.android.material.floatingactionbutton.FloatingActionButton
         android:id="@+id/fab_add_group"

--- a/Example/nrf-mesh/app/src/main/res/layout/fragment_proxy_filter.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/fragment_proxy_filter.xml
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (c) 2018, Nordic Semiconductor
+  ~ All rights reserved.
+  ~
+  ~ Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+  ~
+  ~ 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+  ~
+  ~ 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the
+  ~ documentation and/or other materials provided with the distribution.
+  ~
+  ~ 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this
+  ~ software without specific prior written permission.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  ~ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+  ~ HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+  ~ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+  ~ ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+  ~ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.core.widget.NestedScrollView
+        android:id="@+id/main_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:clipChildren="false">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <androidx.cardview.widget.CardView
+                android:id="@+id/proxy_filter_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/white"
+                app:cardElevation="1dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <androidx.appcompat.widget.Toolbar
+                        android:id="@+id/proxy_filter_tool_bar"
+                        android:layout_width="0dp"
+                        android:layout_height="?actionBarSize"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:logo="@drawable/ic_filter_list_black_alpha_24dp"
+                        app:title="@string/title_proxy_filter"
+                        app:titleMarginStart="@dimen/toolbar_title_margin"/>
+
+                    <TextView
+                        android:id="@+id/proxy_filter_summary"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:padding="@dimen/activity_horizontal_margin"
+                        android:text="@string/proxy_filter_summary"
+                        android:textSize="16sp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/proxy_filter_tool_bar"/>
+
+                    <include
+                        android:id="@+id/div2"
+                        layout="@layout/layout_divider"
+                        android:layout_width="0dp"
+                        android:layout_height="1dp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/proxy_filter_summary"/>
+
+                    <Button
+                        android:id="@+id/action_disable"
+                        style="@style/BlueTextButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal"
+                        android:layout_marginStart="@dimen/item_padding_end"
+                        android:layout_marginEnd="@dimen/item_padding_start"
+                        android:padding="@dimen/activity_horizontal_margin"
+                        android:text="@string/action_disable"
+                        android:textColor="@color/blue_button_states"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/div2"/>
+
+                    <Button
+                        android:id="@+id/action_black_list"
+                        style="@style/BlueTextButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal"
+                        android:layout_marginStart="@dimen/item_padding_end"
+                        android:layout_marginEnd="@dimen/item_padding_start"
+                        android:padding="@dimen/activity_horizontal_margin"
+                        android:text="@string/black_list_filter"
+                        android:textColor="@color/blue_button_states"
+                        app:layout_constraintBottom_toBottomOf="@id/action_disable"
+                        app:layout_constraintEnd_toStartOf="@id/action_disable"
+                        app:layout_constraintTop_toTopOf="@id/action_disable"/>
+
+                    <Button
+                        android:id="@+id/action_white_list"
+                        style="@style/BlueTextButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal"
+                        android:layout_marginStart="@dimen/item_padding_end"
+                        android:layout_marginEnd="@dimen/item_padding_start"
+                        android:padding="@dimen/activity_horizontal_margin"
+                        android:text="@string/white_list_filter"
+                        android:textColor="@color/blue_button_states"
+                        app:layout_constraintBottom_toBottomOf="@id/action_black_list"
+                        app:layout_constraintEnd_toStartOf="@id/action_black_list"
+                        app:layout_constraintTop_toTopOf="@id/action_black_list"/>
+
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+
+            </androidx.cardview.widget.CardView>
+
+            <androidx.cardview.widget.CardView
+                android:id="@+id/proxy_filter_address_card"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/activity_vertical_margin"
+                android:layout_marginBottom="@dimen/activity_vertical_margin"
+                android:background="@color/white"
+                app:cardElevation="1dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/proxy_filter_card">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content">
+
+                    <androidx.appcompat.widget.Toolbar
+                        android:id="@+id/proxy_filter__address_tool_bar"
+                        android:layout_width="0dp"
+                        android:layout_height="?actionBarSize"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:logo="@drawable/ic_lan_black_alpha_24dp"
+                        app:title="@string/title_filter_addresses"
+                        app:titleMarginStart="@dimen/toolbar_title_margin"/>
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:id="@+id/container_proxy_filter"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:background="?selectableItemBackground"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/proxy_filter__address_tool_bar">
+
+                        <TextView
+                            android:id="@+id/no_addresses"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:padding="@dimen/activity_horizontal_margin"
+                            android:text="@string/no_addresses_added"
+                            android:textSize="16sp"
+                            app:layout_constraintLeft_toLeftOf="parent"
+                            app:layout_constraintRight_toRightOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"/>
+
+                        <androidx.recyclerview.widget.RecyclerView
+                            android:id="@+id/recycler_view_addresses"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:clipToPadding="false"
+                            android:scrollbars="none"
+                            android:visibility="gone"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"/>
+
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+
+                    <include
+                        android:id="@+id/div2"
+                        layout="@layout/layout_divider"
+                        android:layout_width="0dp"
+                        android:layout_height="1dp"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/container_proxy_filter"/>
+
+                    <Button
+                        android:id="@+id/action_add_address"
+                        style="@style/BlueTextButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal"
+                        android:layout_marginStart="@dimen/item_padding_end"
+                        android:layout_marginEnd="@dimen/item_padding_start"
+                        android:padding="@dimen/activity_horizontal_margin"
+                        android:text="@string/action_add"
+                        android:enabled="false"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toBottomOf="@id/div2"/>
+
+
+                    <Button
+                        android:id="@+id/action_clear_addresses"
+                        style="@style/RedButton"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal"
+                        android:layout_marginStart="@dimen/item_padding_end"
+                        android:layout_marginEnd="@dimen/item_padding_start"
+                        android:padding="@dimen/activity_horizontal_margin"
+                        android:text="@string/action_clear"
+                        android:visibility="gone"
+                        app:layout_constraintBottom_toBottomOf="@id/action_add_address"
+                        app:layout_constraintEnd_toStartOf="@id/action_add_address"
+                        app:layout_constraintTop_toTopOf="@id/action_add_address"
+                        tools:visibility= "visible"/>
+
+                    <TextView
+                        android:id="@+id/remove_hint"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginEnd="@dimen/item_padding_end"
+                        android:padding="@dimen/activity_horizontal_margin"
+                        android:text="@string/hint_remove"
+                        app:layout_constraintBottom_toBottomOf="@id/action_add_address"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="@id/action_add_address"
+                        android:visibility="gone"
+                        tools:visibility="visible"/>
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </androidx.cardview.widget.CardView>
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/fragment_proxy_filter.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/fragment_proxy_filter.xml
@@ -52,7 +52,8 @@
 
                 <androidx.constraintlayout.widget.ConstraintLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content">
+                    android:layout_height="wrap_content"
+                    style="?buttonBarStyle">
 
                     <androidx.appcompat.widget.Toolbar
                         android:id="@+id/proxy_filter_tool_bar"
@@ -85,9 +86,9 @@
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/proxy_filter_summary"/>
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
                         android:id="@+id/action_disable"
-                        style="@style/BlueTextButton"
+                        style="?materialButtonStyle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_horizontal"
@@ -95,14 +96,13 @@
                         android:layout_marginEnd="@dimen/item_padding_start"
                         android:padding="@dimen/activity_horizontal_margin"
                         android:text="@string/action_disable"
-                        android:textColor="@color/blue_button_states"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/div2"/>
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
                         android:id="@+id/action_black_list"
-                        style="@style/BlueTextButton"
+                        style="?materialButtonStyle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_horizontal"
@@ -110,14 +110,13 @@
                         android:layout_marginEnd="@dimen/item_padding_start"
                         android:padding="@dimen/activity_horizontal_margin"
                         android:text="@string/black_list_filter"
-                        android:textColor="@color/blue_button_states"
                         app:layout_constraintBottom_toBottomOf="@id/action_disable"
                         app:layout_constraintEnd_toStartOf="@id/action_disable"
                         app:layout_constraintTop_toTopOf="@id/action_disable"/>
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
                         android:id="@+id/action_white_list"
-                        style="@style/BlueTextButton"
+                        style="?materialButtonStyle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_horizontal"
@@ -125,7 +124,6 @@
                         android:layout_marginEnd="@dimen/item_padding_start"
                         android:padding="@dimen/activity_horizontal_margin"
                         android:text="@string/white_list_filter"
-                        android:textColor="@color/blue_button_states"
                         app:layout_constraintBottom_toBottomOf="@id/action_black_list"
                         app:layout_constraintEnd_toStartOf="@id/action_black_list"
                         app:layout_constraintTop_toTopOf="@id/action_black_list"/>
@@ -205,9 +203,9 @@
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/container_proxy_filter"/>
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
                         android:id="@+id/action_add_address"
-                        style="@style/BlueTextButton"
+                        style="?materialButtonStyle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_horizontal"
@@ -221,7 +219,7 @@
                         app:layout_constraintTop_toBottomOf="@id/div2"/>
 
 
-                    <Button
+                    <com.google.android.material.button.MaterialButton
                         android:id="@+id/action_clear_addresses"
                         style="@style/RedButton"
                         android:layout_width="wrap_content"

--- a/Example/nrf-mesh/app/src/main/res/layout/fragment_proxy_filter.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/fragment_proxy_filter.xml
@@ -88,7 +88,6 @@
 
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/action_disable"
-                        style="?materialButtonStyle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_horizontal"
@@ -96,13 +95,14 @@
                         android:layout_marginEnd="@dimen/item_padding_start"
                         android:padding="@dimen/activity_horizontal_margin"
                         android:text="@string/action_disable"
+                        android:enabled="false"
+                        android:textColor="@color/proxy_filter_button_states"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/div2"/>
 
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/action_black_list"
-                        style="?materialButtonStyle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_horizontal"
@@ -110,13 +110,14 @@
                         android:layout_marginEnd="@dimen/item_padding_start"
                         android:padding="@dimen/activity_horizontal_margin"
                         android:text="@string/black_list_filter"
+                        android:enabled="false"
+                        android:textColor="@color/proxy_filter_button_states"
                         app:layout_constraintBottom_toBottomOf="@id/action_disable"
                         app:layout_constraintEnd_toStartOf="@id/action_disable"
                         app:layout_constraintTop_toTopOf="@id/action_disable"/>
 
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/action_white_list"
-                        style="?materialButtonStyle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_horizontal"
@@ -124,6 +125,8 @@
                         android:layout_marginEnd="@dimen/item_padding_start"
                         android:padding="@dimen/activity_horizontal_margin"
                         android:text="@string/white_list_filter"
+                        android:enabled="false"
+                        android:textColor="@color/proxy_filter_button_states"
                         app:layout_constraintBottom_toBottomOf="@id/action_black_list"
                         app:layout_constraintEnd_toStartOf="@id/action_black_list"
                         app:layout_constraintTop_toTopOf="@id/action_black_list"/>
@@ -205,7 +208,6 @@
 
                     <com.google.android.material.button.MaterialButton
                         android:id="@+id/action_add_address"
-                        style="?materialButtonStyle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_gravity="center_horizontal"
@@ -214,6 +216,7 @@
                         android:padding="@dimen/activity_horizontal_margin"
                         android:text="@string/action_add"
                         android:enabled="false"
+                        android:textColor="@color/filter_add_button_states"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintEnd_toEndOf="parent"
                         app:layout_constraintTop_toBottomOf="@id/div2"/>

--- a/Example/nrf-mesh/app/src/main/res/layout/fragment_settings.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/fragment_settings.xml
@@ -149,15 +149,6 @@
                         app:layout_constraintLeft_toLeftOf="parent"
                         app:layout_constraintRight_toRightOf="parent"
                         app:layout_constraintTop_toBottomOf="@+id/container_flags"/>
-
-                    <include
-                        android:id="@+id/container_supported_algorithm"
-                        layout="@layout/layout_container"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        app:layout_constraintLeft_toLeftOf="parent"
-                        app:layout_constraintRight_toRightOf="parent"
-                        app:layout_constraintTop_toBottomOf="@+id/container_iv_index"/>
                 </androidx.constraintlayout.widget.ConstraintLayout>
             </androidx.cardview.widget.CardView>
 

--- a/Example/nrf-mesh/app/src/main/res/layout/grouped_item.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/grouped_item.xml
@@ -78,26 +78,24 @@
                 app:layout_constraintTop_toBottomOf="@id/group_summary"
                 app:layout_constraintStart_toStartOf="@id/icon"
                 app:layout_constraintEnd_toEndOf="@id/icon">
-                <Button
+                <com.google.android.material.button.MaterialButton
                     android:id="@+id/action_on"
                     android:gravity="center"
                     android:layout_width="50dp"
                     android:layout_height="wrap_content"
                     android:padding="@dimen/group_on_off_button_padding"
                     android:text="@string/action_generic_on"
-                    android:background="?selectableItemBackgroundBorderless"
-                    style="@style/BlueTextButton"/>
+                    android:background="?selectableItemBackgroundBorderless"/>
 
 
-                <Button
+                <com.google.android.material.button.MaterialButton
                     android:id="@+id/action_off"
                     android:gravity="center"
                     android:layout_width="50dp"
                     android:layout_height="wrap_content"
                     android:padding="@dimen/group_on_off_button_padding"
                     android:text="@string/action_generic_off"
-                    android:background="?selectableItemBackgroundBorderless"
-                    style="@style/BlueTextButton"/>
+                    android:background="?selectableItemBackgroundBorderless"/>
 
             </LinearLayout>
 

--- a/Example/nrf-mesh/app/src/main/res/layout/info_no_bluetooth.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/info_no_bluetooth.xml
@@ -53,9 +53,8 @@
         android:gravity="center_horizontal"
         android:text="@string/bluetooth_disabled_info"/>
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/action_enable_bluetooth"
-        style="@style/BlueTextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"

--- a/Example/nrf-mesh/app/src/main/res/layout/info_no_devices.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/info_no_devices.xml
@@ -64,9 +64,8 @@
             android:layout_marginTop="@dimen/activity_vertical_margin"
             android:text="@string/unprovisioned_node_guide_location_info"/>
 
-        <Button
+        <com.google.android.material.button.MaterialButton
             android:id="@+id/action_enable_location"
-            style="@style/BlueTextButton"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"

--- a/Example/nrf-mesh/app/src/main/res/layout/info_no_permission.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/info_no_permission.xml
@@ -52,17 +52,15 @@
         android:layout_marginTop="@dimen/activity_vertical_margin"
         android:text="@string/location_permission_info"/>
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/action_grant_location_permission"
-        style="@style/BlueTextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"
         android:text="@string/location_permission_action"/>
 
-    <Button
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/action_permission_settings"
-        style="@style/BlueTextButton"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center_horizontal"

--- a/Example/nrf-mesh/app/src/main/res/layout/layout_config_server_model.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/layout_config_server_model.xml
@@ -149,9 +149,8 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/container_relay_retransmit_interval_steps"/>
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/action_relay_retransmit_get"
-                style="@style/BlueTextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -162,9 +161,8 @@
                 app:layout_constraintEnd_toStartOf="@id/action_relay_retransmit_configure"
                 app:layout_constraintTop_toBottomOf="@id/relay_retransmit_divider"/>
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/action_relay_retransmit_configure"
-                style="@style/BlueTextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -316,9 +314,8 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/container_network_transmit_interval_steps"/>
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/action_network_transmit_get"
-                style="@style/BlueTextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -329,9 +326,8 @@
                 app:layout_constraintEnd_toStartOf="@id/action_network_transmit_configure"
                 app:layout_constraintTop_toBottomOf="@id/network_transmit_divider"/>
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/action_network_transmit_configure"
-                style="@style/BlueTextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"

--- a/Example/nrf-mesh/app/src/main/res/layout/layout_generic_level.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/layout_generic_level.xml
@@ -199,12 +199,11 @@
                 android:layout_width="0dp"
                 android:layout_height="1dp"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/icon"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/container_controls"/>
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/action_read"
-                style="@style/BlueTextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"

--- a/Example/nrf-mesh/app/src/main/res/layout/layout_generic_on_off.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/layout_generic_on_off.xml
@@ -189,12 +189,11 @@
                 android:layout_width="0dp"
                 android:layout_height="1dp"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/icon"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/state"/>
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/action_read"
-                style="@style/BlueTextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -205,9 +204,8 @@
                 app:layout_constraintEnd_toStartOf="@id/action_on"
                 app:layout_constraintTop_toTopOf="@+id/action_on"/>
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/action_on"
-                style="@style/BlueTextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"

--- a/Example/nrf-mesh/app/src/main/res/layout/layout_generic_on_off_bottom_sheet.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/layout_generic_on_off_bottom_sheet.xml
@@ -156,12 +156,11 @@
                 android:layout_width="0dp"
                 android:layout_height="1dp"
                 app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/icon"
+                app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/container_controls"/>
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/action_off"
-                style="@style/BlueTextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
@@ -172,9 +171,8 @@
                 app:layout_constraintEnd_toStartOf="@id/action_on"
                 app:layout_constraintTop_toTopOf="@+id/action_on"/>
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/action_on"
-                style="@style/BlueTextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"

--- a/Example/nrf-mesh/app/src/main/res/layout/layout_group_subscription.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/layout_group_subscription.xml
@@ -1,131 +1,111 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<androidx.constraintlayout.widget.ConstraintLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical"
-    android:padding="@dimen/activity_horizontal_margin">
+    android:paddingStart="@dimen/alert_dialog_padding_left"
+    android:paddingEnd="@dimen/alert_dialog_padding_right"
+    android:paddingBottom="@dimen/alert_dialog_padding_bottom">
 
     <RadioButton
         android:id="@+id/radio_select_group"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:gravity="start|center_vertical"
-        android:text="@string/select_a_group_rationale"/>
+        android:text="@string/select_a_group_rationale"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"/>
 
     <TextView
         android:id="@+id/no_groups_configured"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/activity_vertical_margin"
         android:layout_marginStart="@dimen/activity_horizontal_margin"
+        android:layout_marginTop="@dimen/item_padding_top"
         android:layout_marginEnd="@dimen/activity_horizontal_margin"
         android:text="@string/no_available_groups"
         android:visibility="gone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/radio_select_group"
         tools:visibility="visible"/>
 
     <Spinner
         android:id="@+id/groups"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/activity_vertical_margin"/>
+        android:layout_marginTop="@dimen/item_padding_top"
+        app:layout_constraintStart_toStartOf="@id/radio_select_group"
+        app:layout_constraintTop_toBottomOf="@id/radio_select_group"/>
 
     <RadioButton
         android:id="@+id/radio_create_group"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginTop="@dimen/activity_vertical_margin"
+        android:layout_marginTop="@dimen/item_padding_top"
         android:gravity="start|center_vertical"
-        android:text="@string/create_a_group_rationale"/>
+        android:text="@string/create_a_group_rationale"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/groups"/>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/group_name_layout"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginStart="@dimen/item_padding_start"
+        android:layout_marginTop="@dimen/item_padding_top"
+        app:layout_constraintEnd_toEndOf="@id/radio_create_group"
         app:layout_constraintStart_toStartOf="@id/radio_create_group"
-        app:layout_constraintTop_toBottomOf="@id/radio_create_group">
+        app:layout_constraintTop_toBottomOf="@id/radio_create_group"
+        android:hint="@string/name">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/name_input"
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
-
-            <TextView
-                android:id="@+id/address_name_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/activity_horizontal_margin"
-                android:text="@string/group_name"
-                app:layout_constraintBottom_toBottomOf="@id/name_input"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/name_input"/>
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/name_input"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/activity_horizontal_margin"
-                android:hint="Living Room"
-                android:inputType="textCapWords"
-                android:maxLength="20"
-                android:singleLine="true"
-                android:textSize="16sp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/address_name_text"
-                app:layout_constraintTop_toTopOf="parent"
-                tools:ignore="HardcodedText"/>
-        </androidx.constraintlayout.widget.ConstraintLayout>
+            android:layout_height="wrap_content"
+            android:text="Living Room"
+            android:inputType="textCapWords"
+            android:maxLength="20"
+            android:singleLine="true"
+            android:textSize="16sp"
+            tools:ignore="HardcodedText"/>
     </com.google.android.material.textfield.TextInputLayout>
+
+    <TextView
+        android:id="@+id/prefix"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/hex_prefix"
+        android:textSize="16sp"
+        app:layout_constraintBaseline_toBaselineOf="@id/group_address_layout"
+        app:layout_constraintEnd_toStartOf="@id/group_address_layout"
+        app:layout_constraintStart_toStartOf="@id/group_name_layout"
+        app:layout_constraintTop_toTopOf="@id/group_address_layout"/>
 
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/group_address_layout"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="@id/radio_create_group"
-        app:layout_constraintTop_toBottomOf="@id/group_name_layout">
-
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-
-            <TextView
-                android:id="@+id/address_text"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/activity_horizontal_margin"
-                android:text="@string/group_address"
-                app:layout_constraintBottom_toBottomOf="@id/address_input"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="@id/address_input"/>
-
-            <TextView
-                android:id="@+id/prefix"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/activity_vertical_margin"
-                android:text="@string/hex_prefix"
-                android:textSize="16sp"
-                app:layout_constraintBottom_toBottomOf="@id/address_input"
-                app:layout_constraintStart_toEndOf="@id/address_text"
-                app:layout_constraintTop_toTopOf="@id/address_input"/>
+        android:layout_marginTop="@dimen/item_padding_top"
+        android:layout_marginStart="@dimen/item_padding_start"
+        app:layout_constraintEnd_toEndOf="@id/group_name_layout"
+        app:layout_constraintStart_toEndOf="@id/prefix"
+        app:layout_constraintTop_toBottomOf="@id/group_name_layout"
+        android:hint="@string/address">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:id="@+id/address_input"
-                android:layout_width="0dp"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="C000 - 0xFEFF"
                 android:inputType="text|textCapCharacters"
                 android:maxLength="4"
                 android:singleLine="true"
                 android:textSize="16sp"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@id/prefix"
-                app:layout_constraintTop_toTopOf="parent"
+                android:text="C000"
                 tools:ignore="HardcodedText"/>
 
-        </androidx.constraintlayout.widget.ConstraintLayout>
     </com.google.android.material.textfield.TextInputLayout>
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/layout/layout_vendor_model_bottom_sheet.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/layout_vendor_model_bottom_sheet.xml
@@ -158,9 +158,8 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/received_message_container"/>
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/action_send"
-                style="@style/BlueTextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"

--- a/Example/nrf-mesh/app/src/main/res/layout/layout_vendor_model_controls.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/layout_vendor_model_controls.xml
@@ -161,9 +161,8 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/received_message_container"/>
 
-            <Button
+            <com.google.android.material.button.MaterialButton
                 android:id="@+id/action_send"
-                style="@style/BlueTextButton"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"

--- a/Example/nrf-mesh/app/src/main/res/menu/menu_bottom_navigation.xml
+++ b/Example/nrf-mesh/app/src/main/res/menu/menu_bottom_navigation.xml
@@ -21,9 +21,9 @@
   ~ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   -->
 
-<menu xmlns:tools="http://schemas.android.com/tools"
-      xmlns:android="http://schemas.android.com/apk/res/android"
-      xmlns:app="http://schemas.android.com/apk/res-auto">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto"
+      xmlns:tools="http://schemas.android.com/tools">
     <item
         android:id="@+id/action_network"
         android:enabled="true"
@@ -33,10 +33,18 @@
         tools:ignore="AlwaysShowAction"/>
 
     <item
-        android:id="@+id/action_scanner"
+        android:id="@+id/action_groups"
         android:enabled="true"
         android:icon="@drawable/ic_outline_group_work_black_24dp"
         android:title="@string/action_groups"
+        app:showAsAction="always"
+        tools:ignore="AlwaysShowAction"/>
+
+    <item
+        android:id="@+id/action_proxy"
+        android:enabled="true"
+        android:icon="@drawable/ic_filter_list_black_24dp"
+        android:title="@string/action_proxy"
         app:showAsAction="always"
         tools:ignore="AlwaysShowAction"/>
 

--- a/Example/nrf-mesh/app/src/main/res/values/dimens.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/dimens.xml
@@ -35,4 +35,10 @@
     <dimen name="network_recycler_view_bottom_padding">72dp</dimen>
     <dimen name="mesh_list_icon_padding">3dp</dimen>
     <dimen name="group_on_off_button_padding">8dp</dimen>
+
+    <dimen name="alert_dialog_padding">16dp</dimen>
+    <dimen name="alert_dialog_padding_left">24dp</dimen>
+    <dimen name="alert_dialog_padding_right">24dp</dimen>
+    <dimen name="alert_dialog_padding_top">20dp</dimen>
+    <dimen name="alert_dialog_padding_bottom">32dp</dimen>
 </resources>

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -176,8 +176,9 @@
     <string name="hint_unicast_address">Unicast address</string>
     <string name="error_empty_unicast_address">Unicast Address cannot be empty!</string>
     <string name="network">Network</string>
-    <string name="action_settings">Settings</string>
     <string name="action_groups">Groups</string>
+    <string name="action_proxy">Proxy Filter</string>
+    <string name="action_settings">Settings</string>
     <string name="no_nodes_provisioned_title">NO NODES PROVISIONED</string>
     <string name="no_nodes_provisioned_rationale">Add a mesh node by scanning and provisioning the device.</string>
 
@@ -309,9 +310,15 @@
         However, you will still be able to continue sending messages via the other proxy nodes in the network. Do you wish to continue?</string>
 
     <string name="proxy_filter_settings">Proxy Filter Settings</string>
-    <string name="title_proxy_filter">Proxy Filter</string>
-    <string name="white_list_filter">Whitelist Filter</string>
-    <string name="black_list_filter">Blacklist Filter</string>
+    <string name="title_proxy_filter">Proxy Filter Type</string>
+    <string name="title_filter_addresses">Filter Addresses</string>
+    <string name="white_list_filter">Whitelist</string>
+    <string name="black_list_filter">Blacklist</string>
+    <string name="proxy_filter_summary">Proxy filter can be used to monitor mesh messages sent across a mesh network.
+        \n\nWhite list filter blocks all destination addresses except those that have been added to the white list.
+    \n\nThe black list filter accepts all destination addresses except those that have been added to the black list.</string>
+
+    <string name="action_disable">Disable</string>
     <string name="hint_remove">Hint: Swipe address to remove.</string>
     <string name="hint_filter_address">Unicast/Group Address</string>
     <string name="no_addresses_added">No addresses are added to this filter!</string>

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -146,7 +146,7 @@
     <string name="title_generate_network_key">Network Key</string>
     <string name="summary_generate_network_key">Enter your own network key or click generate to create a new random network key.</string>
     <string name="hint_network_key">Network key</string>
-    <string name="generate_network_key">Generate network key</string>
+    <string name="generate_network_key">Generate Key</string>
     <string name="error_empty_network_key">Network key cannot be empty!</string>
     <string name="error_invalid_network_key">Network key must be 16 bytes long!</string>
 

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -465,4 +465,5 @@
     <string name="subscription_address_dialog_summary">Subscription address for this model.</string>
     <string name="label_uuid_summary">Label UUID:</string>
     <string name="label_uuid">Label UUID</string>
+    <string name="name">Name</string>
 </resources>

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -184,7 +184,6 @@
 
     <string name="no_groups_configured_title">NO GROUPS CONFIGURED</string>
     <string name="no_groups_configured_rationale">Create a group to control your devices. All groups listed here can be subscribed to from a model.</string>
-    <string name="group_friendly_name">Friendly Name</string>
     <string name="group_name">Name</string>
     <string name="group_address">Address</string>
     <string name="group_address_summary">Address %s</string>
@@ -397,7 +396,7 @@
     <string name="error_invalid_publish_ttl">Publish TTL value must be in range of 0 to 127!</string>
 
     <string name="dialog_summary_retransmit_count">Enter the desired number of retransmissions.</string>
-    <string name="dialog_summary_interval_steps">Enter the desired number of interval steps for retransmission. \n1 step = 50ms</string>
+    <string name="dialog_summary_interval_steps">Enter the desired number of interval steps for retransmission. \n\n1 step = 50ms</string>
     <string name="dialog_summary_publication_steps">Enter the desired number of steps for publication period.</string>
     <string name="dialog_summary_publish_ttl">Enter the desired publish ttl.</string>
     <string name="resolution_summary_100_ms">100 milliseconds</string>

--- a/Example/nrf-mesh/app/src/main/res/values/styles.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/styles.xml
@@ -27,23 +27,52 @@
         <!-- Customize your theme here. -->
     </style>
 
-    <style name="AppTheme.Base" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="AppTheme.Base" parent="Theme.MaterialComponents.Light.NoActionBar">
         <item name="android:windowBackground">@color/background</item>
-        <!-- Toolbar -->
+
+        <!-- Primary colors map to components and elements, like app bars and buttons -->
+        <!-- Secondary colors are most often used as accents on components, such as FABS and selection controls -->
+        <!-- Color variants can be used to complement and provide accessible options for your primary and secondary colors. -->
+        <!-- Surface colors map to components such as cards, sheets, and menus -->
+        <!-- Background color is found behind scrollable content -->
+        <!-- Error color indicates errors in components, such as text fields -->
+        <!-- “On” colors are primarily applied to text, iconography, and strokes. Sometimes, they are also applied to surfaces. -->
+
+        <!-- Primary colors -->
         <item name="colorPrimary">@color/colorPrimary</item>
-        <!-- Status bar -->
+        <item name="colorOnPrimary">@color/white</item>
+
+        <!-- Primary  variant colors -->
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <!-- Checked checkboxes, radio buttons and switches -->
-        <item name="colorAccent">@color/colorAccent</item>
+        <item name="colorPrimaryVariant">@color/colorPrimaryDark</item>
+
+        <item name="colorSecondary">@color/colorAccent</item>
+        <item name="colorOnSecondary">@color/white</item>
+
+        <item name="colorSurface">@color/white</item>
+        <item name="colorOnSurface">@color/black</item>
+        <!-- Error views -->
+        <item name="colorError">@color/nordicRed</item>
+        <item name="colorOnError">@color/white</item>
+
         <!-- Primary text color i.e. titles of lists etc -->
         <item name="android:textColorPrimary">@color/black</item>
         <!-- Secondary text color i.e. descriptions and subtitles of lists etc -->
         <item name="android:textColorSecondary">@color/textColorSecondary</item>
+
+        <!-- All buttons should not have border, except specified otherwise -->
+        <item name="materialButtonStyle">@style/BlueTextButton</item>
+        <!-- All TextInputLayout should use OutlinedBox style  -->
+        <item name="textInputStyle">@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox</item>
+
+        <item name="alertDialogTheme">@style/CustomDialogTheme</item>
+
+        <!--<item name="alertDialogTheme">@style/CustomDialogTheme</item>-->
     </style>
 
-    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar"/>
+    <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.MaterialComponents.Dark.ActionBar"/>
 
-    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light"/>
+    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.MaterialComponents.Light"/>
 
     <style name="AppTheme.SplashScreen">
         <item name="colorPrimaryDark">@android:color/transparent</item>
@@ -62,10 +91,11 @@
         <item name="android:textSize">20sp</item>
     </style>
 
-    <style name="BlueTextButton" parent="Widget.AppCompat.Button.Borderless.Colored">
+    <style name="BlueTextButton" parent="Widget.MaterialComponents.Button.TextButton">
+        <item name="android:textColor">@color/nordicLake</item>
     </style>
 
-    <style name="RedButton" parent="Widget.AppCompat.Button.Borderless.Colored">
+    <style name="RedButton" parent="Widget.MaterialComponents.Button.TextButton">
         <item name="android:textColor">@drawable/red_button_states</item>
     </style>
 
@@ -73,5 +103,11 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+    </style>
+
+    <style name="CustomDialogTheme" parent="Theme.MaterialComponents.Light.Dialog.Alert">
+        <item name="colorPrimary">@color/colorAccent</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <item name="colorSecondary">@color/colorAccent</item>
     </style>
 </resources>

--- a/android-nrf-mesh-library/meshprovisioner/build.gradle
+++ b/android-nrf-mesh-library/meshprovisioner/build.gradle
@@ -67,8 +67,8 @@ dependencies {
     implementation 'com.madgag.spongycastle:prov:1.56.0.0'
     implementation 'com.google.code.gson:gson:2.8.5'
 
-    implementation 'androidx.room:room-runtime:2.1.0-alpha06'
-    annotationProcessor 'androidx.room:room-compiler:2.1.0-alpha06'
-    androidTestImplementation 'androidx.room:room-testing:2.1.0-alpha06'
+    implementation 'androidx.room:room-runtime:2.1.0-alpha07'
+    annotationProcessor 'androidx.room:room-compiler:2.1.0-alpha07'
+    androidTestImplementation 'androidx.room:room-testing:2.1.0-alpha07'
 
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNetwork.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNetwork.java
@@ -1,12 +1,5 @@
 package no.nordicsemi.android.meshprovisioner;
 
-import androidx.room.ColumnInfo;
-import androidx.room.Ignore;
-import androidx.room.PrimaryKey;
-import androidx.annotation.IntDef;
-import androidx.annotation.NonNull;
-import androidx.annotation.RestrictTo;
-
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -17,10 +10,18 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
+import androidx.room.ColumnInfo;
+import androidx.room.Ignore;
+import androidx.room.PrimaryKey;
 import no.nordicsemi.android.meshprovisioner.transport.ApplicationKey;
 import no.nordicsemi.android.meshprovisioner.transport.NetworkKey;
 import no.nordicsemi.android.meshprovisioner.transport.ProvisionedMeshNode;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
+import no.nordicsemi.android.meshprovisioner.utils.ProxyFilter;
 
 @SuppressWarnings({"unused", "WeakerAccess"})
 abstract class BaseMeshNetwork {
@@ -117,6 +118,10 @@ abstract class BaseMeshNetwork {
 
     @Ignore
     private final Comparator<ApplicationKey> appKeyComparator = (key1, key2) -> Integer.compare(key1.getKeyIndex(), key2.getKeyIndex());
+
+    @Ignore
+    @Expose(serialize = false, deserialize = false)
+    private ProxyFilter proxyFilter;
 
     BaseMeshNetwork(@NonNull final String meshUUID) {
         this.meshUUID = meshUUID;
@@ -487,6 +492,25 @@ abstract class BaseMeshNetwork {
         final Provisioner provisioner = provisioners.get(0);
         provisioner.setGlobalTtl(globalTtl);
         notifyProvisionerUpdated(provisioner);
+    }
+
+    /**
+     * Returns the {@link ProxyFilter} set on the proxy
+     */
+    @Nullable
+    public ProxyFilter getProxyFilter() {
+        return proxyFilter;
+    }
+
+    /**
+     * Sets the {@link ProxyFilter} settings on the proxy
+     * <p>
+     * Please note that this is not persisted within the node since the filter is reinitialized to a whitelist filter upon connecting to a proxy node.
+     * Therefore after setting a proxy filter and disconnecting users will have to manually
+     * <p/>
+     */
+    public void setProxyFilter(@Nullable final ProxyFilter proxyFilter) {
+        this.proxyFilter = proxyFilter;
     }
 
     final void notifyNetworkUpdated() {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/InternalTransportCallbacks.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/InternalTransportCallbacks.java
@@ -22,11 +22,12 @@
 
 package no.nordicsemi.android.meshprovisioner;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
-
 import no.nordicsemi.android.meshprovisioner.provisionerstates.UnprovisionedMeshNode;
 import no.nordicsemi.android.meshprovisioner.transport.MeshMessage;
 import no.nordicsemi.android.meshprovisioner.transport.ProvisionedMeshNode;
+import no.nordicsemi.android.meshprovisioner.utils.ProxyFilter;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public interface InternalTransportCallbacks {
@@ -54,6 +55,11 @@ public interface InternalTransportCallbacks {
      */
     @RestrictTo(RestrictTo.Scope.LIBRARY)
     void onMeshPduCreated(final int dst, final byte[] pdu);
+
+
+    ProxyFilter getProxyFilter();
+
+    void setProxyFilter(@NonNull final ProxyFilter filter);
 
     /**
      * Update mesh network

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
@@ -25,8 +25,6 @@ package no.nordicsemi.android.meshprovisioner;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Handler;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.util.Log;
 
 import com.google.gson.Gson;
@@ -41,6 +39,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import no.nordicsemi.android.meshprovisioner.data.ApplicationKeyDao;
 import no.nordicsemi.android.meshprovisioner.data.GroupDao;
 import no.nordicsemi.android.meshprovisioner.data.GroupsDao;
@@ -64,6 +64,7 @@ import no.nordicsemi.android.meshprovisioner.utils.InputOOBAction;
 import no.nordicsemi.android.meshprovisioner.utils.MeshAddress;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 import no.nordicsemi.android.meshprovisioner.utils.OutputOOBAction;
+import no.nordicsemi.android.meshprovisioner.utils.ProxyFilter;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
 
 
@@ -403,7 +404,7 @@ public class MeshManagerApi implements MeshMngrApi {
             mIncomingBufferOffset += length;
             mIncomingBuffer = buffer;
             if (length < mtuSize) {
-                final byte packet[] = mIncomingBuffer;
+                final byte[] packet = mIncomingBuffer;
                 mIncomingBuffer = null;
                 return packet;
             }
@@ -432,7 +433,7 @@ public class MeshManagerApi implements MeshMngrApi {
             mOutgoingBufferOffset += length;
             mOutgoingBuffer = buffer;
             if (length < mtuSize) {
-                final byte packet[] = mOutgoingBuffer;
+                final byte[] packet = mOutgoingBuffer;
                 mOutgoingBuffer = null;
                 return packet;
             }
@@ -841,6 +842,16 @@ public class MeshManagerApi implements MeshMngrApi {
             updateNetwork(meshNode);
             final int mtu = mTransportCallbacks.getMtu();
             mTransportCallbacks.onMeshPduCreated(applySegmentation(mtu, pdu));
+        }
+
+        @Override
+        public ProxyFilter getProxyFilter() {
+            return mMeshNetwork.getProxyFilter();
+        }
+
+        @Override
+        public void setProxyFilter(@NonNull final ProxyFilter filter) {
+            mMeshNetwork.setProxyFilter(filter);
         }
 
         @Override

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshProvisioningHandler.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshProvisioningHandler.java
@@ -23,12 +23,12 @@
 package no.nordicsemi.android.meshprovisioner;
 
 import android.content.Context;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 
 import java.nio.ByteBuffer;
 import java.util.UUID;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import no.nordicsemi.android.meshprovisioner.provisionerstates.ProvisioningCapabilities;
 import no.nordicsemi.android.meshprovisioner.provisionerstates.ProvisioningCapabilitiesState;
 import no.nordicsemi.android.meshprovisioner.provisionerstates.ProvisioningCompleteState;
@@ -310,7 +310,7 @@ class MeshProvisioningHandler implements InternalProvisioningCallbacks {
     }
 
     /**
-     * Starts provisioning an unprovisioned mesh node usign Static OOB
+     * Starts provisioning an unprovisioned mesh node using Static OOB
      * <p>
      * This method will continue the provisioning process that was started by invoking {@link #identify(UUID, String, NetworkKey, int, int, int, int, int, int)}.
      * </p>

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProvisionedBaseMeshNode.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProvisionedBaseMeshNode.java
@@ -22,17 +22,7 @@
 
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import androidx.room.ColumnInfo;
-import androidx.room.Embedded;
-import androidx.room.Ignore;
-import androidx.room.PrimaryKey;
-import androidx.room.TypeConverters;
 import android.os.Parcelable;
-import androidx.annotation.IntDef;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.RestrictTo;
-import androidx.annotation.VisibleForTesting;
 import android.text.TextUtils;
 
 import com.google.gson.annotations.Expose;
@@ -45,12 +35,21 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
+import androidx.annotation.VisibleForTesting;
+import androidx.room.ColumnInfo;
+import androidx.room.Embedded;
+import androidx.room.Ignore;
+import androidx.room.PrimaryKey;
+import androidx.room.TypeConverters;
 import no.nordicsemi.android.meshprovisioner.Features;
 import no.nordicsemi.android.meshprovisioner.MeshNetwork;
 import no.nordicsemi.android.meshprovisioner.SecureNetworkBeacon;
 import no.nordicsemi.android.meshprovisioner.utils.MeshTypeConverters;
 import no.nordicsemi.android.meshprovisioner.utils.NetworkTransmitSettings;
-import no.nordicsemi.android.meshprovisioner.utils.ProxyFilter;
 import no.nordicsemi.android.meshprovisioner.utils.RelaySettings;
 import no.nordicsemi.android.meshprovisioner.utils.SparseIntArrayParcelable;
 
@@ -215,10 +214,6 @@ abstract class ProvisionedBaseMeshNode implements Parcelable {
     @Ignore
     @Expose(deserialize = false)
     protected String bluetoothDeviceAddress;
-
-    @Ignore
-    @Expose(serialize = false)
-    private ProxyFilter proxyFilter;
 
     public ProvisionedBaseMeshNode() {
 
@@ -409,24 +404,5 @@ abstract class ProvisionedBaseMeshNode implements Parcelable {
     @Retention(RetentionPolicy.SOURCE)
     @IntDef({LOW, HIGH})
     public @interface SecurityState {
-    }
-
-    /**
-     * Returns the {@link ProxyFilter} set on the node
-     */
-    @Nullable
-    public ProxyFilter getProxyFilter() {
-        return proxyFilter;
-    }
-
-    /**
-     * Sets the {@link ProxyFilter} settings on the node
-     * <p>
-     * Please note that this is not persisted within the node since the filter is reinitialized to a whitelist filter upon connecting to a proxy node.
-     * Therefore after setting a proxy filter and disconnecting users will have to manually
-     * <p/>
-     */
-    public void setProxyFilter(@Nullable final ProxyFilter proxyFilter) {
-        this.proxyFilter = proxyFilter;
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/OutputOOBAction.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/OutputOOBAction.java
@@ -7,6 +7,8 @@ import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Locale;
 
+import androidx.annotation.NonNull;
+
 /**
  * Output OOB Actions
  */
@@ -152,7 +154,7 @@ public enum OutputOOBAction {
      * @param outputActionType selected {@link OutputOOBAction}
      * @param input            input
      */
-    public static byte[] generateOutputOOBAuthenticationValue(final OutputOOBAction outputActionType, final String input) {
+    public static byte[] generateOutputOOBAuthenticationValue(@NonNull final OutputOOBAction outputActionType, @NonNull final String input) {
         final int authLength = 16;
         final ByteBuffer buffer = ByteBuffer.allocate(authLength).order(ByteOrder.BIG_ENDIAN);
         switch (outputActionType) {


### PR DESCRIPTION
* The proxy filter has been moved out of the node view to a new tab view. This allows to remove the workaround used to send a proxy filter message to identify in which node the proxy filter settings must be displayed.

*  Migrated to material components