### PR TITLE
nRF Mesh Release v2.0.2

### DIFF
--- a/Example/nrf-mesh/app/build.gradle
+++ b/Example/nrf-mesh/app/build.gradle
@@ -30,8 +30,8 @@ android {
         applicationId "no.nordicsemi.android.nrfmeshprovisioner"
         minSdkVersion 18
         targetSdkVersion 29
-        versionCode 49
-        versionName "2.0.1"
+        versionCode 50
+        versionName "2.0.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
         vectorDrawables.useSupportLibrary = true

--- a/Example/nrf-mesh/app/build.gradle
+++ b/Example/nrf-mesh/app/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     implementation 'com.jakewharton:butterknife:10.1.0'
     annotationProcessor 'com.jakewharton:butterknife-compiler:10.1.0'
     // Brings the new BluetoothLeScanner API to older platforms
-    implementation 'no.nordicsemi.android.support.v18:scanner:1.4.0'
+    implementation 'no.nordicsemi.android.support.v18:scanner:1.4.2'
     implementation 'no.nordicsemi.android:ble:1.2.0'
     // Log Bluetooth LE events in nRF Logger
     implementation 'androidx.multidex:multidex:2.0.1'

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/SettingsFragment.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/SettingsFragment.java
@@ -220,6 +220,8 @@ public class SettingsFragment extends Fragment implements Injectable,
         if (requestCode == READ_FILE_REQUEST_CODE) {
             if (resultCode == RESULT_OK) {
                 if (data != null) {
+                    //Disconnect from network before importing
+                    mViewModel.disconnect();
                     final Uri uri = data.getData();
                     mViewModel.getMeshManagerApi().importMeshNetwork(uri);
                 }

--- a/android-nrf-mesh-library/meshprovisioner/build.gradle
+++ b/android-nrf-mesh-library/meshprovisioner/build.gradle
@@ -29,8 +29,8 @@ android {
     defaultConfig {
         minSdkVersion 18
         targetSdkVersion 29
-        versionCode 49
-        versionName "2.0.1"
+        versionCode 50
+        versionName "2.0.2"
 
         javaCompileOptions {
             annotationProcessorOptions {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
@@ -45,7 +45,7 @@ import no.nordicsemi.android.meshprovisioner.R;
 public class MeshParserUtils {
 
     private static final String TAG = MeshParserUtils.class.getSimpleName();
-    private static final SimpleDateFormat SDF = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.US);
+    private static final SimpleDateFormat SDF = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US);
     private static final String PATTERN_KEY = "[0-9a-fA-F]{32}";
     private static final String PATTERN_UUID_HEX = "[0-9a-fA-F]{32}";
     private static final int TAI_YEAR = 2000;


### PR DESCRIPTION
* Fixes an app crash on Android 6 when migrating data caused by an unavailable patter in SimpleDateTimeFormat.
* Upgraded to latest Scanner Compat Library.
* Disconnect from network before importing.