### PR TITLE
Upgrade BLE library to 2.1.1

### DIFF
--- a/Example/nrf-mesh/app/build.gradle
+++ b/Example/nrf-mesh/app/build.gradle
@@ -75,7 +75,7 @@ dependencies {
     annotationProcessor 'com.jakewharton:butterknife-compiler:10.1.0'
     // Brings the new BluetoothLeScanner API to older platforms
     implementation 'no.nordicsemi.android.support.v18:scanner:1.4.3'
-    implementation 'no.nordicsemi.android:ble:1.2.0'
+    implementation 'no.nordicsemi.android:ble:2.1.1'
     // Log Bluetooth LE events in nRF Logger
     implementation 'androidx.multidex:multidex:2.0.1'
     // Lifecycle extensions


### PR DESCRIPTION
The new BLE (v2.1.1) library has an auto-retry mechanism which useful against Gat 133 error.