### PR TITLE
nRF Mesh release v2.1.2

### DIFF
--- a/Example/nrf-mesh/app/build.gradle
+++ b/Example/nrf-mesh/app/build.gradle
@@ -30,8 +30,8 @@ android {
         applicationId "no.nordicsemi.android.nrfmeshprovisioner"
         minSdkVersion 18
         targetSdkVersion 29
-        versionCode 57
-        versionName "2.1.1"
+        versionCode 58
+        versionName "2.1.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
         vectorDrawables.useSupportLibrary = true

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ble/BleMeshManager.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ble/BleMeshManager.java
@@ -108,7 +108,7 @@ public class BleMeshManager extends LoggableBleManager<BleMeshManagerCallbacks> 
 
         @Override
         protected void initialize() {
-            //requestMtu(MTU_SIZE_MAX).enqueue();
+            requestMtu(MTU_SIZE_MAX).enqueue();
 
             // This callback will be called each time a notification is received.
             final DataReceivedCallback onDataReceived = (device, data) ->

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ble/BleMeshManager.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ble/BleMeshManager.java
@@ -108,11 +108,11 @@ public class BleMeshManager extends LoggableBleManager<BleMeshManagerCallbacks> 
 
         @Override
         protected void initialize() {
-            requestMtu(MTU_SIZE_MAX).enqueue();
+            //requestMtu(MTU_SIZE_MAX).enqueue();
 
             // This callback will be called each time a notification is received.
             final DataReceivedCallback onDataReceived = (device, data) ->
-                    mCallbacks.onDataReceived(device, getMtu(), data.getValue());
+                    mCallbacks.onDataReceived(device, getMaximumPacketSize(), data.getValue());
 
             // Set the notification callback and enable notification on Data In characteristic.
             final BluetoothGattCharacteristic characteristic = isProvisioningComplete ?
@@ -178,7 +178,7 @@ public class BleMeshManager extends LoggableBleManager<BleMeshManagerCallbacks> 
 
         // This callback will be called each time the data were sent.
         final DataSentCallback callback = (device, data) ->
-                mCallbacks.onDataSent(device, getMtu(), data.getValue());
+                mCallbacks.onDataSent(device, getMaximumPacketSize(), data.getValue());
 
         // Write the right characteristic.
         final BluetoothGattCharacteristic characteristic = isProvisioningComplete ?
@@ -189,9 +189,8 @@ public class BleMeshManager extends LoggableBleManager<BleMeshManagerCallbacks> 
                 .enqueue();
     }
 
-    @Override
-    public int getMtu() {
-        return super.getMtu();
+    public int getMaximumPacketSize() {
+        return super.getMtu() - 3;
     }
 
     public boolean isProvisioningComplete() {

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/NrfMeshRepository.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/viewmodels/NrfMeshRepository.java
@@ -637,7 +637,7 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
 
     @Override
     public int getMtu() {
-        return mBleMeshManager.getMtu();
+        return mBleMeshManager.getMaximumPacketSize();
     }
 
     @Override

--- a/android-nrf-mesh-library/meshprovisioner/build.gradle
+++ b/android-nrf-mesh-library/meshprovisioner/build.gradle
@@ -29,8 +29,8 @@ android {
     defaultConfig {
         minSdkVersion 18
         targetSdkVersion 29
-        versionCode 57
-        versionName "2.1.1"
+        versionCode 58
+        versionName "2.1.2"
 
         javaCompileOptions {
             annotationProcessorOptions {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/provisionerstates/ProvisioningFailedState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/provisionerstates/ProvisioningFailedState.java
@@ -29,14 +29,10 @@ import no.nordicsemi.android.meshprovisioner.R;
 
 public class ProvisioningFailedState extends ProvisioningState {
 
-    private final Context mContext;
-    private final UnprovisionedMeshNode mUnprovisionedMeshNode;
     private int error;
 
-    public ProvisioningFailedState(final Context context, final UnprovisionedMeshNode unprovisionedMeshNode) {
+    public ProvisioningFailedState() {
         super();
-        this.mContext = context;
-        this.mUnprovisionedMeshNode = unprovisionedMeshNode;
     }
 
     @Override
@@ -61,35 +57,6 @@ public class ProvisioningFailedState extends ProvisioningState {
     }
 
     public static String parseProvisioningFailure(final Context context, final int errorCode) {
-        switch (ProvisioningFailureCode.fromErrorCode(errorCode)) {
-            case PROHIBITED:
-                return context.getString(R.string.error_prohibited);
-            case INVALID_PDU:
-                return context.getString(R.string.error_invalid_pdu);
-            case INVALID_FORMAT:
-                return context.getString(R.string.error_invalid_format);
-            case UNEXPECTED_PDU:
-                return context.getString(R.string.error_prohibited);
-            case CONFIRMATION_FAILED:
-                return context.getString(R.string.error_confirmation_failed);
-            case OUT_OF_RESOURCES:
-                return context.getString(R.string.error_prohibited);
-            case DECRYPTION_FAILED:
-                return context.getString(R.string.error_decryption_failed);
-            case UNEXPECTED_ERROR:
-                return context.getString(R.string.error_unexpected_error);
-            case CANNOT_ASSIGN_ADDRESSES:
-                return context.getString(R.string.error_cannot_assign_addresses);
-            case UNKNOWN_ERROR_CODE:
-            default:
-                return context.getString(R.string.error_rfu);
-        }
-    }
-
-    public static String parseProvisioningFailure(final Context context, final byte[] pdu) {
-        if(pdu == null)
-            return "Unknown";
-        final int errorCode = pdu[2];
         switch (ProvisioningFailureCode.fromErrorCode(errorCode)) {
             case PROHIBITED:
                 return context.getString(R.string.error_prohibited);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/provisionerstates/ProvisioningPublicKeyState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/provisionerstates/ProvisioningPublicKeyState.java
@@ -23,7 +23,6 @@
 package no.nordicsemi.android.meshprovisioner.provisionerstates;
 
 
-import androidx.annotation.NonNull;
 import android.util.Log;
 
 import org.spongycastle.jce.ECNamedCurveTable;
@@ -49,6 +48,7 @@ import java.security.spec.InvalidKeySpecException;
 
 import javax.crypto.KeyAgreement;
 
+import androidx.annotation.NonNull;
 import no.nordicsemi.android.meshprovisioner.InternalTransportCallbacks;
 import no.nordicsemi.android.meshprovisioner.MeshManagerApi;
 import no.nordicsemi.android.meshprovisioner.MeshProvisioningStatusCallbacks;
@@ -142,6 +142,10 @@ public class ProvisioningPublicKeyState extends ProvisioningState {
     }
 
     private void generateSharedECDHSecret(final byte[] provisioneePublicKeyXYPDU) {
+        if (provisioneePublicKeyXYPDU.length != 66) {
+            throw new IllegalArgumentException("Invalid Provisionee Public Key PDU," +
+                    " length of the Provisionee public key must be 66 bytes, but was " + provisioneePublicKeyXYPDU.length);
+        }
         final ByteBuffer buffer = ByteBuffer.allocate(provisioneePublicKeyXYPDU.length - 2);
         buffer.put(provisioneePublicKeyXYPDU, 2, buffer.limit());
         final byte[] xy = mTempProvisioneeXY = buffer.array();

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/provisionerstates/ProvisioningState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/provisionerstates/ProvisioningState.java
@@ -90,7 +90,7 @@ public abstract class ProvisioningState {
         SENDING_NETWORK_TRANSMIT_SET(23),
         NETWORK_TRANSMIT_STATUS_RECEIVED(24),
         SENDING_BLOCK_ACKNOWLEDGEMENT(98),
-        BLOCK_ACKNOWLEDGEMENT_RECEIVED(99),;
+        BLOCK_ACKNOWLEDGEMENT_RECEIVED(99);
 
         private int state;
 
@@ -102,9 +102,9 @@ public abstract class ProvisioningState {
             return state;
         }
 
-        public static States fromStatusCode(final int statusCode){
-            for(States state : States.values()){
-                if(state.getState() == statusCode){
+        public static States fromStatusCode(final int statusCode) {
+            for (States state : States.values()) {
+                if (state.getState() == statusCode) {
                     return state;
                 }
             }


### PR DESCRIPTION
This version introduces the following changes
* Fixes a bug causing the maximum packet size to be calculated incorrectly this was introduced while migrating to BLE Library 2.1.1.
* Validate provisionee public key length during provisioning process.