### PR TITLE
nRF Mesh release v2.1.3

### DIFF
--- a/Example/nrf-mesh/app/build.gradle
+++ b/Example/nrf-mesh/app/build.gradle
@@ -30,8 +30,8 @@ android {
         applicationId "no.nordicsemi.android.nrfmeshprovisioner"
         minSdkVersion 18
         targetSdkVersion 29
-        versionCode 58
-        versionName "2.1.2"
+        versionCode 59
+        versionName "2.1.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
         vectorDrawables.useSupportLibrary = true

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ble/BleMeshManager.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/ble/BleMeshManager.java
@@ -36,6 +36,7 @@ import no.nordicsemi.android.ble.callback.DataReceivedCallback;
 import no.nordicsemi.android.ble.callback.DataSentCallback;
 
 public class BleMeshManager extends LoggableBleManager<BleMeshManagerCallbacks> {
+    private static final int MTU_SIZE_DEFAULT = 23;
     private static final int MTU_SIZE_MAX = 517;
 
     /**
@@ -123,6 +124,8 @@ public class BleMeshManager extends LoggableBleManager<BleMeshManagerCallbacks> 
 
         @Override
         protected void onDeviceDisconnected() {
+            //We reset the MTU to 23 upon disconnection
+            overrideMtu(MTU_SIZE_DEFAULT);
             mIsDeviceReady = false;
             isProvisioningComplete = false;
             mMeshProvisioningDataInCharacteristic = null;

--- a/android-nrf-mesh-library/meshprovisioner/build.gradle
+++ b/android-nrf-mesh-library/meshprovisioner/build.gradle
@@ -29,7 +29,7 @@ android {
     defaultConfig {
         minSdkVersion 18
         targetSdkVersion 29
-        versionCode 53
+        versionCode 59
         versionName "2.1.3"
 
         javaCompileOptions {

--- a/android-nrf-mesh-library/meshprovisioner/build.gradle
+++ b/android-nrf-mesh-library/meshprovisioner/build.gradle
@@ -29,8 +29,8 @@ android {
     defaultConfig {
         minSdkVersion 18
         targetSdkVersion 29
-        versionCode 58
-        versionName "2.1.2"
+        versionCode 53
+        versionName "2.1.3"
 
         javaCompileOptions {
             annotationProcessorOptions {


### PR DESCRIPTION
This version introduces the following changes
* Set MTU to default value of 23 upon disconnectoin. This is a work around to avoid BLE Library v2.1.1 not resetting the MTU value for the same Ble library instance upon disconnection.