### PR TITLE
Handle IV Index update procedure

### DIFF
--- a/Example/nrf-mesh/app/build.gradle
+++ b/Example/nrf-mesh/app/build.gradle
@@ -60,17 +60,17 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     // Required -- JUnit 4 framework
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
     implementation 'androidx.test:runner:1.2.0'
 
     implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.google.android.material:material:1.2.0-alpha01'
-    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation 'com.google.android.material:material:1.2.0-alpha05'
+    implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta3'
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0-rc02'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta4'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
 
     // Butter Knife
     implementation 'com.jakewharton:butterknife:10.2.0'
@@ -80,10 +80,10 @@ dependencies {
     // Android BLE Library
     implementation 'no.nordicsemi.android:ble:2.1.1'
 
-    implementation 'com.google.dagger:dagger:2.25.2'
-    implementation 'com.google.dagger:dagger-android:2.25.2'
-    implementation 'com.google.dagger:dagger-android-support:2.25.2'
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.25.2'
-    annotationProcessor 'com.google.dagger:dagger-android-processor:2.25.2'
+    implementation 'com.google.dagger:dagger:2.26'
+    implementation 'com.google.dagger:dagger-android:2.26'
+    implementation 'com.google.dagger:dagger-android-support:2.26'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.26'
+    annotationProcessor 'com.google.dagger:dagger-android-processor:2.26'
     implementation project(':meshprovisioner')
 }

--- a/Example/nrf-mesh/build.gradle
+++ b/Example/nrf-mesh/build.gradle
@@ -29,7 +29,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.6.2'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/Example/nrf-mesh/gradle/wrapper/gradle-wrapper.properties
+++ b/Example/nrf-mesh/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Sep 04 08:34:58 CEST 2019
+#Fri Apr 03 10:48:50 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/android-nrf-mesh-library/meshprovisioner/build.gradle
+++ b/android-nrf-mesh-library/meshprovisioner/build.gradle
@@ -58,8 +58,8 @@ android {
 
 dependencies {
     // Required -- JUnit 4 framework
-    testImplementation 'junit:junit:4.12'
-    testImplementation 'org.mockito:mockito-core:2.18.0'
+    testImplementation 'junit:junit:4.13'
+    testImplementation 'org.mockito:mockito-core:2.19.0'
     androidTestImplementation 'org.mockito:mockito-android:2.6.3'
     implementation 'androidx.annotation:annotation:1.1.0'
     api 'no.nordicsemi.android:log:2.2.0'
@@ -68,8 +68,8 @@ dependencies {
     implementation 'com.madgag.spongycastle:prov:1.58.0.0'
     implementation 'com.google.code.gson:gson:2.8.6'
 
-    implementation 'androidx.room:room-runtime:2.2.1'
-    annotationProcessor 'androidx.room:room-compiler:2.2.1'
-    androidTestImplementation 'androidx.room:room-testing:2.2.1'
+    implementation 'androidx.room:room-runtime:2.2.5'
+    annotationProcessor 'androidx.room:room-compiler:2.2.5'
+    androidTestImplementation 'androidx.room:room-testing:2.2.5'
 
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNetwork.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNetwork.java
@@ -4,6 +4,15 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.util.SparseIntArray;
 
+import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
+import androidx.room.ColumnInfo;
+import androidx.room.Ignore;
+import androidx.room.PrimaryKey;
+import androidx.room.TypeConverters;
+
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
@@ -16,14 +25,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
-import androidx.annotation.IntDef;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.RestrictTo;
-import androidx.room.ColumnInfo;
-import androidx.room.Ignore;
-import androidx.room.PrimaryKey;
-import androidx.room.TypeConverters;
 import no.nordicsemi.android.meshprovisioner.transport.Element;
 import no.nordicsemi.android.meshprovisioner.transport.ProvisionedMeshNode;
 import no.nordicsemi.android.meshprovisioner.utils.MeshAddress;
@@ -35,8 +36,8 @@ import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
 abstract class BaseMeshNetwork {
     private static final String TAG = "BaseMeshNetwork";
     // Key refresh phases
-    public static final int NORMAL_OPERATION = 0; //Distribution of new keys
-    public static final int IV_UPDATE_ACTIVE = 1; //Switching to the new keys
+    public static final int NORMAL_OPERATION = 0; //Normal operation
+    public static final int IV_UPDATE_ACTIVE = 1; //IV Update active
     @PrimaryKey
     @NonNull
     @ColumnInfo(name = "mesh_uuid")

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshNetwork.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshNetwork.java
@@ -3,16 +3,17 @@ package no.nordicsemi.android.meshprovisioner;
 
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RestrictTo;
+import androidx.room.Entity;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.RestrictTo;
-import androidx.room.Entity;
 import no.nordicsemi.android.meshprovisioner.transport.Element;
 import no.nordicsemi.android.meshprovisioner.transport.MeshModel;
 import no.nordicsemi.android.meshprovisioner.transport.ProvisionedMeshNode;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/SecureNetworkBeacon.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/SecureNetworkBeacon.java
@@ -3,9 +3,9 @@ package no.nordicsemi.android.meshprovisioner;
 import android.os.Parcel;
 import android.os.Parcelable;
 
-import java.nio.ByteBuffer;
-
 import androidx.annotation.NonNull;
+
+import java.nio.ByteBuffer;
 
 /**
  * Contains the information related to a secure network beacon.
@@ -14,9 +14,12 @@ import androidx.annotation.NonNull;
 public class SecureNetworkBeacon extends MeshBeacon {
     public static final int BEACON_DATA_LENGTH = 22;
     private final int flags;
+    private boolean isKeyRefreshActive;
+    private boolean isIvUpdateActive;
     private final byte[] networkId = new byte[8];
     private final int ivIndex;
     private final byte[] authenticationValue = new byte[8];
+
 
     /**
      * Constructs a {@link SecureNetworkBeacon} object
@@ -33,6 +36,8 @@ public class SecureNetworkBeacon extends MeshBeacon {
         final ByteBuffer byteBuffer = ByteBuffer.wrap(beaconData);
         byteBuffer.position(1);
         flags = byteBuffer.get();
+        isKeyRefreshActive = (flags & 0x01) == 1;
+        isIvUpdateActive = ((flags >> 1) & 0x02) == BaseMeshNetwork.NORMAL_OPERATION;
         byteBuffer.get(networkId, 0, 8);
         ivIndex = byteBuffer.getInt();
         byteBuffer.get(authenticationValue, 0, 8);
@@ -48,6 +53,20 @@ public class SecureNetworkBeacon extends MeshBeacon {
      */
     public int getFlags() {
         return flags;
+    }
+
+    /**
+     * Returns true if Key Refresh Procedure is active.
+     */
+    public boolean isKeyRefreshActive() {
+        return isKeyRefreshActive;
+    }
+
+    /**
+     * Returns true is IV Update is active.
+     */
+    public boolean isIvUpdateActive() {
+        return isIvUpdateActive;
     }
 
     /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/SecureNetworkBeacon.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/SecureNetworkBeacon.java
@@ -7,6 +7,8 @@ import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
 
+import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
+
 /**
  * Contains the information related to a secure network beacon.
  */
@@ -37,10 +39,20 @@ public class SecureNetworkBeacon extends MeshBeacon {
         byteBuffer.position(1);
         flags = byteBuffer.get();
         isKeyRefreshActive = (flags & 0x01) == 1;
-        isIvUpdateActive = ((flags >> 1) & 0x02) == BaseMeshNetwork.NORMAL_OPERATION;
+        isIvUpdateActive = ((flags & 0x02) >> 1) == BaseMeshNetwork.IV_UPDATE_ACTIVE;
         byteBuffer.get(networkId, 0, 8);
         ivIndex = byteBuffer.getInt();
         byteBuffer.get(authenticationValue, 0, 8);
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "SecureNetworkBeacon" +
+                " KeyRefreshActive: " + isKeyRefreshActive +
+                " IvUpdateActive: " + isIvUpdateActive +
+                " IV Index: " + ivIndex +
+                " Authentication Value: " + MeshParserUtils.bytesToHex(authenticationValue, true);
     }
 
     @Override

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/BaseMeshMessageHandler.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/BaseMeshMessageHandler.java
@@ -26,6 +26,9 @@ import android.content.Context;
 import android.util.Log;
 import android.util.SparseArray;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import org.spongycastle.crypto.InvalidCipherTextException;
 
 import java.nio.ByteBuffer;
@@ -33,8 +36,6 @@ import java.nio.ByteOrder;
 import java.util.List;
 import java.util.UUID;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import no.nordicsemi.android.meshprovisioner.InternalTransportCallbacks;
 import no.nordicsemi.android.meshprovisioner.MeshManagerApi;
 import no.nordicsemi.android.meshprovisioner.MeshNetwork;
@@ -102,13 +103,14 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
         final List<NetworkKey> networkKeys = network.getNetKeys();
         final int ivi = ((pdu[1] & 0xFF) >>> 7) & 0x01;
         final int nid = pdu[1] & 0x7F;
-        //Here we go through all the network keys and filter out network keys based on the nid.
-        for (int i = 0; i < networkKeys.size(); i++) {
-            NetworkKey networkKey = networkKeys.get(i);
-            final SecureUtils.K2Output k2Output = SecureUtils.calculateK2(networkKey.getKey(), SecureUtils.K2_MASTER_INPUT);
-            if (nid == k2Output.getNid()) {
-                final byte[] networkHeader = deObfuscateNetworkHeader(pdu, MeshParserUtils.intToBytes(network.getIvIndex()), k2Output.getPrivacyKey());
-                if (networkHeader != null) {
+        int ivIndex = network.getIvIndex() - 1;
+        while (ivIndex <= ivIndex + 1) {
+            //Here we go through all the network keys and filter out network keys based on the nid.
+            for (int i = 0; i < networkKeys.size(); i++) {
+                NetworkKey networkKey = networkKeys.get(i);
+                final SecureUtils.K2Output k2Output = SecureUtils.calculateK2(networkKey.getKey(), SecureUtils.K2_MASTER_INPUT);
+                if (nid == k2Output.getNid()) {
+                    final byte[] networkHeader = deObfuscateNetworkHeader(pdu, MeshParserUtils.intToBytes(ivIndex), k2Output.getPrivacyKey());
                     final int ctlTtl = networkHeader[0];
                     final int ctl = (ctlTtl >> 7) & 0x01;
                     final int ttl = ctlTtl & 0x7F;
@@ -136,20 +138,18 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
                     }
                     //TODO validate ivi
                     byte[] nonce;
-                    final byte[] ivIndex = MeshParserUtils.intToBytes(network.getIvIndex());
                     try {
-
                         final int networkPayloadLength = pdu.length - (2 + networkHeader.length);
                         final byte[] transportPdu = new byte[networkPayloadLength];
                         System.arraycopy(pdu, 8, transportPdu, 0, networkPayloadLength);
                         final byte[] decryptedNetworkPayload;
                         final MeshMessageState state;
                         if (pdu[0] == MeshManagerApi.PDU_TYPE_NETWORK) {
-                            nonce = createNetworkNonce((byte) ctlTtl, sequenceNumber, src, ivIndex);
+                            nonce = createNetworkNonce((byte) ctlTtl, sequenceNumber, src, MeshParserUtils.intToBytes(ivIndex));
                             decryptedNetworkPayload = SecureUtils.decryptCCM(transportPdu, k2Output.getEncryptionKey(), nonce, SecureUtils.getNetMicLength(ctl));
                             state = getState(src);
                         } else {
-                            nonce = createProxyNonce(sequenceNumber, src, ivIndex);
+                            nonce = createProxyNonce(sequenceNumber, src, MeshParserUtils.intToBytes(ivIndex));
                             decryptedNetworkPayload = SecureUtils.decryptCCM(transportPdu, k2Output.getEncryptionKey(), nonce, SecureUtils.getNetMicLength(ctl));
                             state = getState(MeshAddress.UNASSIGNED_ADDRESS);
                         }
@@ -165,6 +165,7 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
                     }
                 }
             }
+            ivIndex++;
         }
     }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/DefaultNoOperationMessageState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/DefaultNoOperationMessageState.java
@@ -2,12 +2,13 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.util.Log;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import no.nordicsemi.android.meshprovisioner.Group;
 import no.nordicsemi.android.meshprovisioner.MeshManagerApi;
 import no.nordicsemi.android.meshprovisioner.MeshNetwork;
@@ -46,7 +47,10 @@ class DefaultNoOperationMessageState extends MeshMessageState {
         return null;
     }
 
-    void parseMeshPdu(@NonNull final ProvisionedMeshNode node, @NonNull final byte[] pdu, @NonNull final byte[] networkHeader, @NonNull final byte[] decryptedNetworkPayload) {
+    void parseMeshPdu(@NonNull final ProvisionedMeshNode node,
+                      @NonNull final byte[] pdu,
+                      @NonNull final byte[] networkHeader,
+                      @NonNull final byte[] decryptedNetworkPayload) {
         final Message message;
         try {
             message = mMeshTransport.parsePdu(node, pdu, networkHeader, decryptedNetworkPayload);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/DefaultNoOperationMessageState.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/DefaultNoOperationMessageState.java
@@ -50,10 +50,12 @@ class DefaultNoOperationMessageState extends MeshMessageState {
     void parseMeshPdu(@NonNull final ProvisionedMeshNode node,
                       @NonNull final byte[] pdu,
                       @NonNull final byte[] networkHeader,
-                      @NonNull final byte[] decryptedNetworkPayload) {
+                      @NonNull final byte[] decryptedNetworkPayload,
+                      final int ivIndex,
+                      @NonNull final byte[] sequenceNumber) {
         final Message message;
         try {
-            message = mMeshTransport.parsePdu(node, pdu, networkHeader, decryptedNetworkPayload);
+            message = mMeshTransport.parseMeshMessage(node, pdu, networkHeader, decryptedNetworkPayload, ivIndex, sequenceNumber);
             if (message != null) {
                 if (message instanceof AccessMessage) {
                     parseAccessMessage((AccessMessage) message);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshTransport.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshTransport.java
@@ -26,11 +26,12 @@ import android.content.Context;
 import android.os.Handler;
 import android.util.Log;
 
-import java.util.UUID;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+
+import java.util.UUID;
+
 import no.nordicsemi.android.meshprovisioner.ApplicationKey;
 import no.nordicsemi.android.meshprovisioner.MeshManagerApi;
 import no.nordicsemi.android.meshprovisioner.Provisioner;
@@ -344,20 +345,5 @@ final class MeshTransport extends NetworkLayer {
 
     final Message createRetransmitMeshMessage(final Message message, final int segment) {
         return createRetransmitNetworkLayerPDU(message, segment);
-    }
-
-    /**
-     * Parses the received pdu
-     *
-     * @param pdu pdu received
-     * @return Message
-     */
-    @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
-    final Message parsePdu(@NonNull final ProvisionedMeshNode node,
-                           @NonNull final byte[] pdu,
-                           @NonNull final byte[] networkHeader,
-                           @NonNull final byte[] decryptedNetworkPayload) throws ExtendedInvalidCipherTextException {
-
-        return parseMeshMessage(node, pdu, networkHeader, decryptedNetworkPayload);
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProvisionedMeshNode.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProvisionedMeshNode.java
@@ -78,8 +78,7 @@ public final class ProvisionedMeshNode extends ProvisionedBaseMeshNode {
 
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
     @RestrictTo(RestrictTo.Scope.LIBRARY)
-    public ProvisionedMeshNode() {
-    }
+    public ProvisionedMeshNode() { }
 
     /**
      * Constructor to be used only by hte library

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
@@ -26,6 +26,8 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.util.SparseArray;
 
+import androidx.annotation.NonNull;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.text.ParseException;
@@ -37,7 +39,6 @@ import java.util.Locale;
 import java.util.Random;
 import java.util.UUID;
 
-import androidx.annotation.NonNull;
 import no.nordicsemi.android.meshprovisioner.NodeKey;
 import no.nordicsemi.android.meshprovisioner.R;
 
@@ -555,9 +556,7 @@ public class MeshParserUtils {
     }
 
     public static byte[] intToBytes(int i) {
-        ByteBuffer b = ByteBuffer.allocate(4);
-        b.putInt(i);
-        return b.array();
+        return ByteBuffer.allocate(4).putInt(i).array();
     }
 
     /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/SecureUtils.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/SecureUtils.java
@@ -350,44 +350,16 @@ public class SecureUtils {
      * @param ivIndex   ivindex of the network
      */
     public static byte[] calculateAuthValueSecureNetBeacon(@NonNull final byte[] n,
-                                                           @NonNull final byte[] flags,
+                                                           final int flags,
                                                            @NonNull final byte[] networkId,
-                                                           @NonNull final byte[] ivIndex) {
-        final int inputLength = flags.length + networkId.length + ivIndex.length;
+                                                           final int ivIndex) {
+        final int inputLength = 1 + networkId.length + 4;
         final ByteBuffer pBuffer = ByteBuffer.allocate(inputLength);
-        pBuffer.put(flags);
+        pBuffer.put((byte) flags);
         pBuffer.put(networkId);
-        pBuffer.put(ivIndex);
+        pBuffer.putInt(ivIndex);
         final byte[] beaconKey = calculateBeaconKey(n);
         return calculateCMAC(pBuffer.array(), beaconKey);
-    }
-
-    /**
-     * Creates the secure network beacon from a given mesh network.
-     *
-     * @param network Mesh network
-     */
-    public static SecureNetworkBeacon createSecureNetworkBeacon(@NonNull final MeshNetwork network) {
-        final NetworkKey key = network.getPrimaryNetworkKey();
-        if (key == null) {
-            throw new IllegalArgumentException("Unable ot create a beacon, primary network key is null");
-        }
-        final byte[] n = key.getKey();
-        final byte[] flags = {(byte) network.getProvisioningFlags()};
-        final byte[] networkId = SecureUtils.calculateK3(n);
-        final byte[] ivIndex = ByteBuffer.allocate(4).putInt(network.getIvIndex()).array();
-        final byte[] authentication = calculateAuthValueSecureNetBeacon(n, flags, networkId, ivIndex);
-
-        final int inputLength = flags.length + networkId.length + ivIndex.length;
-        final ByteBuffer pBuffer = ByteBuffer.allocate(inputLength);
-        pBuffer.put(flags);
-        pBuffer.put(networkId);
-        pBuffer.put(ivIndex);
-        final ByteBuffer secNetBeaconBuffer = ByteBuffer.allocate(1 + inputLength + 8);
-        secNetBeaconBuffer.put((byte) 0x01);
-        secNetBeaconBuffer.put(pBuffer.array());
-        secNetBeaconBuffer.put(authentication, 0, 8);
-        return new SecureNetworkBeacon(secNetBeaconBuffer.array());
     }
 
     /**
@@ -399,16 +371,16 @@ public class SecureUtils {
      * @param ivIndex   iv index of the network
      */
     public static SecureNetworkBeacon createSecureNetworkBeacon(@NonNull final byte[] n,
-                                                                @NonNull final byte[] flags,
+                                                                final int flags,
                                                                 @NonNull final byte[] networkId,
-                                                                @NonNull final byte[] ivIndex) {
+                                                                final int ivIndex) {
         final byte[] authentication = calculateAuthValueSecureNetBeacon(n, flags, networkId, ivIndex);
 
-        final int inputLength = flags.length + networkId.length + ivIndex.length;
+        final int inputLength = 1 + networkId.length + 4;
         final ByteBuffer pBuffer = ByteBuffer.allocate(inputLength);
-        pBuffer.put(flags);
+        pBuffer.put((byte) flags);
         pBuffer.put(networkId);
-        pBuffer.put(ivIndex);
+        pBuffer.putInt(ivIndex);
         final ByteBuffer secNetBeaconBuffer = ByteBuffer.allocate(1 + inputLength + 8);
         secNetBeaconBuffer.put((byte) 0x01);
         secNetBeaconBuffer.put(pBuffer.array());
@@ -426,16 +398,16 @@ public class SecureUtils {
      */
     public static byte[] calculateSecureNetworkBeacon(@NonNull final byte[] n,
                                                       final int beaconType,
-                                                      @NonNull final byte[] flags,
+                                                      final int flags,
                                                       @NonNull final byte[] networkId,
-                                                      @NonNull final byte[] ivIndex) {
+                                                      final int ivIndex) {
         final byte[] authentication = calculateAuthValueSecureNetBeacon(n, flags, networkId, ivIndex);
 
-        final int inputLength = flags.length + networkId.length + ivIndex.length;
+        final int inputLength = 1 + networkId.length + 4;
         final ByteBuffer pBuffer = ByteBuffer.allocate(inputLength);
-        pBuffer.put(flags);
+        pBuffer.put((byte) flags);
         pBuffer.put(networkId);
-        pBuffer.put(ivIndex);
+        pBuffer.putInt(ivIndex);
         final ByteBuffer secNetBeaconBuffer = ByteBuffer.allocate(1 + inputLength + 8);
         secNetBeaconBuffer.put((byte) beaconType);
         secNetBeaconBuffer.put(pBuffer.array());

--- a/android-nrf-mesh-library/meshprovisioner/src/test/java/no/nordicsemi/android/meshprovisioner/transport/EncryptionTests.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/test/java/no/nordicsemi/android/meshprovisioner/transport/EncryptionTests.java
@@ -129,7 +129,7 @@ public class EncryptionTests {
     public void secure_network_beacon_isCorrect() {
         //8.2.6
         final byte[] ivIndex = MeshParserUtils.toByteArray("12345678");
-        final byte[] flags = new byte[]{0x00};
+        final int flags = 0x00;
         final byte[] networkId = MeshParserUtils.toByteArray("3ecaff672f673370");
         final byte[] authenticationValue = MeshParserUtils.toByteArray("8ea261582f364f6f3c74ef80336ca17e");
 
@@ -138,7 +138,7 @@ public class EncryptionTests {
 
         assertEquals(expectedSecureNetworkBeacon,
                 MeshParserUtils.bytesToHex(SecureUtils.calculateSecureNetworkBeacon(networkKey, 1,
-                        flags, networkId, ivIndex), false));
+                        flags, networkId, MeshParserUtils.bytesToInt(ivIndex)), false));
     }
 
     @Test


### PR DESCRIPTION
* Fixes issue #244 - The library now will handle the IV Update procedure based on a Secure Network Beacon received. Library will disregard beacons with a lower IV Index than the current iv index.
* Fixes an issue where the library was not supporting current iv index and current iv index - 1 as specified in the spec.
* Instead of having the network layer was drop messages that may have a sequence number lower than the last known sequence number, the lower transport layer now validates unsegmented and segmented messages based on the Sequence authentication value of each message.