### PR TITLE
Improve opcode access layer opcode parsing

### DIFF
--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/AccessLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/AccessLayer.java
@@ -123,15 +123,7 @@ abstract class AccessLayer {
         //MSB of the first octet defines the length of opcodes.
         //if MSB = 0 length is 1 and so forth
         final byte[] accessPayload = message.getAccessPdu();
-        final int msb = ((accessPayload[0] & 0xF0) >> 6);
-        final int opCodeLength;
-        if (msb == 0)
-            opCodeLength = 1;
-        else {
-            opCodeLength = msb;
-        }
-        Log.v(TAG, "Opcode length: " + opCodeLength + " Octets");
-
+        final int opCodeLength = (accessPayload[0] & 0xC0) >> 6;
         final int opcode = MeshParserUtils.getOpCode(accessPayload, opCodeLength);
         message.setOpCode(opcode);
         final int length = accessPayload.length - opCodeLength;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/AccessLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/AccessLayer.java
@@ -24,9 +24,10 @@ package no.nordicsemi.android.meshprovisioner.transport;
 
 import android.content.Context;
 import android.os.Handler;
+import android.util.Log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
-import android.util.Log;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -73,8 +74,7 @@ abstract class AccessLayer {
      */
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
     final void createAccessMessage(@NonNull final AccessMessage accessMessage) {
-        final int opCode = accessMessage.getOpCode();
-        final byte[] opCodes = MeshParserUtils.getOpCodes(opCode);
+        final byte[] opCodes = MeshParserUtils.getOpCode(accessMessage.getOpCode());
         final byte[] parameters = accessMessage.getParameters();
         final ByteBuffer accessMessageBuffer;
         if (parameters != null) {
@@ -95,21 +95,19 @@ abstract class AccessLayer {
      *
      * @param accessMessage Access message containing the required opcodes and parameters to create access message pdu.
      */
-    @SuppressWarnings("ConstantConditions")
     @VisibleForTesting(otherwise = VisibleForTesting.PROTECTED)
     final void createCustomAccessMessage(@NonNull final AccessMessage accessMessage) {
-        final int opCode = accessMessage.getOpCode();
-        final int companyIdentifier = accessMessage.getCompanyIdentifier();
         final byte[] parameters = accessMessage.getParameters();
-        final byte[] opCodesCompanyIdentifier = MeshParserUtils.createVendorOpCode(opCode, companyIdentifier);
+        final byte[] vendorOpcode = MeshParserUtils.createVendorOpCode(accessMessage.getOpCode(),
+                accessMessage.getCompanyIdentifier());
         final ByteBuffer accessMessageBuffer;
         if (parameters != null) {
-            accessMessageBuffer = ByteBuffer.allocate(opCodesCompanyIdentifier.length + parameters.length);
-            accessMessageBuffer.put(opCodesCompanyIdentifier);
+            accessMessageBuffer = ByteBuffer.allocate(vendorOpcode.length + parameters.length);
+            accessMessageBuffer.put(vendorOpcode);
             accessMessageBuffer.put(parameters);
         } else {
-            accessMessageBuffer = ByteBuffer.allocate(opCodesCompanyIdentifier.length);
-            accessMessageBuffer.put(opCodesCompanyIdentifier);
+            accessMessageBuffer = ByteBuffer.allocate(vendorOpcode.length);
+            accessMessageBuffer.put(vendorOpcode);
         }
         final byte[] accessPdu = accessMessageBuffer.array();
         Log.v(TAG, "Created Access PDU " + MeshParserUtils.bytesToHex(accessPdu, false));

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageAcked.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageAcked.java
@@ -34,7 +34,8 @@ public class VendorModelMessageAcked extends GenericMessage {
         super(appKey);
         this.mModelIdentifier = modelId;
         this.mCompanyIdentifier = companyIdentifier;
-        this.mOpCode = opCode;
+        //Set the opCode to a 3-bit opCode
+        this.mOpCode = (0xC0 | opCode) << 16;
         mParameters = parameters;
         assembleMessageParameters();
     }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageUnacked.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/VendorModelMessageUnacked.java
@@ -16,7 +16,7 @@ public class VendorModelMessageUnacked extends GenericMessage {
 
     private final int mModelIdentifier;
     private final int mCompanyIdentifier;
-    private final int opCode;
+    private final int mOpCode;
 
     /**
      * Constructs VendorModelMessageAcked message.
@@ -29,12 +29,13 @@ public class VendorModelMessageUnacked extends GenericMessage {
     public VendorModelMessageUnacked(@NonNull final ApplicationKey appKey,
                                      final int modelId,
                                      final int companyIdentifier,
-                                     final int opCode,
+                                     final int mOpCode,
                                      @Nullable final byte[] parameters) {
         super(appKey);
         this.mModelIdentifier = modelId;
         this.mCompanyIdentifier = companyIdentifier;
-        this.opCode = opCode;
+        //Set the opCode to a 3-bit opCode
+        this.mOpCode = (0xC0 | mOpCode) << 16;
         mParameters = parameters;
         assembleMessageParameters();
     }
@@ -46,7 +47,7 @@ public class VendorModelMessageUnacked extends GenericMessage {
 
     @Override
     public int getOpCode() {
-        return opCode;
+        return mOpCode;
     }
 
     /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
@@ -355,14 +355,15 @@ public class MeshParserUtils {
      * @param opCode operation code
      * @return length of opcodes
      */
-    public static byte[] getOpCodes(final int opCode) {
-        if ((opCode & 0xC00000) == 0xC00000) {
-            return new byte[]{(byte) ((opCode >> 16) & 0xFF), (byte) ((opCode >> 8) & 0xFF), (byte) (opCode & 0xFF)};
-        } else if ((opCode & 0xFF8000) == 0x8000) {
-            return new byte[]{(byte) ((opCode >> 8) & 0xFF), (byte) (opCode & 0xFF)};
+    public static byte[] getOpCode(final int opCode) {
+        if (opCode < 0x80) {
+            return new byte[]{(byte) (opCode & 0xFF)};
+        } else if (opCode < 0x4000 || (opCode & 0xFFFC00) == 0x8000) {
+            return new byte[]{(byte) (0x80 | ((opCode >> 8) & 0x3F)), (byte) (opCode & 0xFF)};
         } else {
-            //return new byte[]{ (byte) ((opCode >> 8) & 0xFF), (byte) (opCode & 0xFF)};
-            return new byte[]{(byte) opCode};
+            return new byte[]{(byte) (0xC0 | ((opCode >> 16) & 0x3F)),
+                    (byte) ((opCode >> 8) & 0xFF),
+                    (byte) (opCode & 0xFF)};
         }
     }
 
@@ -376,10 +377,10 @@ public class MeshParserUtils {
      * @return length of opcodes
      */
     public static byte[] createVendorOpCode(final int opCode, final int companyIdentifier) {
-        if (companyIdentifier != 0xFFFF) {
-            return new byte[]{(byte) (0xC0 | (opCode & 0x3F)), (byte) (companyIdentifier & 0xFF), (byte) ((companyIdentifier >> 8) & 0xFF)};
-        }
-        return null;
+        final byte[] opCodes = getOpCode(opCode);
+        opCodes[1] = (byte) (companyIdentifier & 0xFF);
+        opCodes[2] = (byte) ((companyIdentifier >> 8) & 0xFF);
+        return opCodes;
     }
 
     /**

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
@@ -32,7 +32,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -329,21 +328,19 @@ public class MeshParserUtils {
      * Returns the opcode within the access payload
      *
      * @param accessPayload payload
-     * @param opcodeCount   number of opcodes
      * @return array of opcodes
      */
-    public static int getOpCode(final byte[] accessPayload, final int opcodeCount) {
-        switch (opcodeCount) {
+    public static int getOpCode(final byte[] accessPayload, final int opCodeCount) {
+        switch (opCodeCount) {
             case 1:
                 return accessPayload[0];
             case 2:
                 return MeshParserUtils.unsignedBytesToInt(accessPayload[1], accessPayload[0]);
-            case 3:
+            default:
                 return ((byte) (MeshParserUtils.unsignedByteToInt(accessPayload[1]))
                         | (byte) ((MeshParserUtils.unsignedByteToInt(accessPayload[0]) << 8)
                         | (byte) ((MeshParserUtils.unsignedByteToInt(accessPayload[2]) << 16))));
         }
-        return -1;
     }
 
     /**
@@ -568,21 +565,6 @@ public class MeshParserUtils {
             unsigned = -1 * ((1 << size - 1) - (unsigned & ((1 << size - 1) - 1)));
         }
         return unsigned;
-    }
-
-    /**
-     * Returns the international atomic time (TAI) in seconds
-     * <p>
-     * TAI seconds and is the number of seconds after 00:00:00 TAI on 2000-01-01
-     * </p>
-     *
-     * @param currentTime current time in milliseconds
-     */
-    public static long getInternationalAtomicTime(final long currentTime) {
-        final Calendar calendar = Calendar.getInstance();
-        calendar.set(TAI_YEAR, TAI_MONTH, TAI_DATE, 0, 0, 0);
-        final long millisSinceEpoch = calendar.getTimeInMillis();
-        return (currentTime - millisSinceEpoch) / 1000;
     }
 
     /**


### PR DESCRIPTION
* Fixes #293 - Improvements to how the Vendor model opcode is constructed. Now the ser may or or may not enter the opcode in the UI with the 3-octet opcode bits set. This is to make both implementations look similar to a certain extent.
* Fixes #287  by improving how the opcode is being parsed.