### PR TITLE
Supports handling IV Index update process.

### DIFF
--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/SettingsFragment.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/SettingsFragment.java
@@ -35,21 +35,21 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Switch;
 import android.widget.TextView;
 import android.widget.Toast;
-
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.OutputStream;
-
-import javax.inject.Inject;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
-import androidx.lifecycle.ViewModelProviders;
+
+import java.io.FileNotFoundException;
+import java.io.OutputStream;
+
+import javax.inject.Inject;
+
 import no.nordicsemi.android.nrfmeshprovisioner.di.Injectable;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentMeshExportMsg;
 import no.nordicsemi.android.nrfmeshprovisioner.dialog.DialogFragmentMeshImport;
@@ -64,7 +64,6 @@ import no.nordicsemi.android.nrfmeshprovisioner.utils.Utils;
 import no.nordicsemi.android.nrfmeshprovisioner.viewmodels.SharedViewModel;
 
 import static android.app.Activity.RESULT_OK;
-import static no.nordicsemi.android.nrfmeshprovisioner.viewmodels.NrfMeshRepository.EXPORT_PATH;
 
 public class SettingsFragment extends Fragment implements Injectable,
         DialogFragmentNetworkName.DialogFragmentNetworkNameListener,
@@ -141,6 +140,25 @@ public class SettingsFragment extends Fragment implements Injectable,
         final TextView appKeySummary = containerAppKey.findViewById(R.id.text);
         appKeySummary.setVisibility(View.VISIBLE);
         containerAppKey.setOnClickListener(v -> {
+            final Intent intent = new Intent(requireContext(), AppKeysActivity.class);
+            startActivity(intent);
+        });
+
+
+        final View containerIvTestMode = rootView.findViewById(R.id.container_iv_test_mode);
+        containerIvTestMode.findViewById(R.id.image).
+                setBackground(ContextCompat.getDrawable(requireContext(), R.drawable.ic_folder_key_black_24dp_alpha));
+        ((TextView) containerIvTestMode.findViewById(R.id.title)).setText(R.string.title_iv_test_mode);
+        final TextView ivTestModeSummary = containerIvTestMode.findViewById(R.id.text);
+        ivTestModeSummary.setText(R.string.iv_test_mode_summary);
+        ivTestModeSummary.setVisibility(View.VISIBLE);
+        final Switch actionChangeIvTestMode = containerIvTestMode.findViewById(R.id.action_change_test_mode);
+        actionChangeIvTestMode.setVisibility(View.VISIBLE);
+        actionChangeIvTestMode.setChecked(mViewModel.getMeshManagerApi().isIvUpdateTestModeActive());
+        actionChangeIvTestMode.setOnClickListener(v -> {
+            mViewModel.getMeshManagerApi().setIvUpdateTestModeActive(actionChangeIvTestMode.isChecked());
+        });
+        containerIvTestMode.setOnClickListener(v -> {
             final Intent intent = new Intent(requireContext(), AppKeysActivity.class);
             startActivity(intent);
         });

--- a/Example/nrf-mesh/app/src/main/res/layout/fragment_settings.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/fragment_settings.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2018, Nordic Semiconductor
   ~ All rights reserved.
   ~
@@ -21,8 +20,7 @@
   ~ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   -->
 
-<ScrollView
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/container"
@@ -59,7 +57,7 @@
                     app:logo="@drawable/ic_certificate"
                     app:title="@string/network_settings"
                     app:titleMarginStart="@dimen/toolbar_title_margin"
-                    app:titleTextAppearance="@style/Toolbar.TitleText"/>
+                    app:titleTextAppearance="@style/Toolbar.TitleText" />
 
                 <include
                     android:id="@+id/container_network_name"
@@ -68,7 +66,7 @@
                     android:layout_height="wrap_content"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/network_settings_toolbar"/>
+                    app:layout_constraintTop_toBottomOf="@id/network_settings_toolbar" />
 
                 <include
                     android:id="@+id/container_provisioners"
@@ -77,7 +75,7 @@
                     android:layout_height="wrap_content"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/container_network_name"/>
+                    app:layout_constraintTop_toBottomOf="@id/container_network_name" />
 
                 <include
                     android:id="@+id/container_net_keys"
@@ -86,7 +84,7 @@
                     android:layout_height="wrap_content"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/container_provisioners"/>
+                    app:layout_constraintTop_toBottomOf="@id/container_provisioners" />
 
                 <include
                     android:id="@+id/container_app_keys"
@@ -95,7 +93,17 @@
                     android:layout_height="wrap_content"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/container_net_keys"/>
+                    app:layout_constraintTop_toBottomOf="@id/container_net_keys" />
+
+                <include
+                    android:id="@+id/container_iv_test_mode"
+                    layout="@layout/layout_container"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintLeft_toLeftOf="parent"
+                    app:layout_constraintRight_toRightOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/container_app_keys" />
+
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.cardview.widget.CardView>
 
@@ -123,7 +131,7 @@
                     app:logo="@drawable/ic_info_black_24dp_alpha"
                     app:title="@string/title_about"
                     app:titleMarginStart="@dimen/toolbar_title_margin"
-                    app:titleTextAppearance="@style/Toolbar.TitleText"/>
+                    app:titleTextAppearance="@style/Toolbar.TitleText" />
 
                 <include
                     android:id="@+id/container_version"
@@ -132,7 +140,7 @@
                     android:layout_height="wrap_content"
                     app:layout_constraintLeft_toLeftOf="parent"
                     app:layout_constraintRight_toRightOf="parent"
-                    app:layout_constraintTop_toBottomOf="@+id/about_tool_bar"/>
+                    app:layout_constraintTop_toBottomOf="@+id/about_tool_bar" />
 
             </androidx.constraintlayout.widget.ConstraintLayout>
         </androidx.cardview.widget.CardView>

--- a/Example/nrf-mesh/app/src/main/res/layout/layout_container.xml
+++ b/Example/nrf-mesh/app/src/main/res/layout/layout_container.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (c) 2018, Nordic Semiconductor
   ~ All rights reserved.
   ~
@@ -21,8 +20,7 @@
   ~ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   -->
 
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -43,7 +41,7 @@
         app:layout_constraintEnd_toStartOf="@id/title"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@id/title"
-        tools:ignore="ContentDescription,VectorDrawableCompat"/>
+        tools:ignore="ContentDescription,VectorDrawableCompat" />
 
     <TextView
         android:id="@+id/title"
@@ -56,7 +54,7 @@
         app:layout_constraintBaseline_toBaselineOf="@id/image"
         app:layout_constraintStart_toEndOf="@id/image"
         app:layout_goneMarginStart="@dimen/activity_horizontal_margin"
-        tools:ignore="HardcodedText"/>
+        tools:ignore="HardcodedText" />
 
     <TextView
         android:id="@+id/text"
@@ -69,7 +67,17 @@
         app:layout_constraintStart_toStartOf="@id/title"
         app:layout_constraintTop_toBottomOf="@id/title"
         tools:ignore="HardcodedText"
-        tools:visibility="visible"/>
+        tools:visibility="visible" />
+
+    <Switch
+        android:id="@+id/action_change_test_mode"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@id/title"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@id/text"
+        android:layout_marginEnd="@dimen/activity_horizontal_margin"/>
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/Example/nrf-mesh/app/src/main/res/values/strings.xml
+++ b/Example/nrf-mesh/app/src/main/res/values/strings.xml
@@ -544,4 +544,7 @@
     <string name="title_subscription_status">Subscription Status</string>
     <string name="set_as_current_provisioner">Set as current provisioner</string>
     <string name="title_error_network_import">Network Import Error</string>
+
+    <string name="title_iv_test_mode">IV Test Mode</string>
+    <string name="iv_test_mode_summary">Note this is setting is not restored upon restart.</string>
 </resources>

--- a/Example/nrf-mesh/build.gradle
+++ b/Example/nrf-mesh/build.gradle
@@ -29,7 +29,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.2'
+        classpath 'com.android.tools.build:gradle:3.6.3'
         
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/android-nrf-mesh-library/meshprovisioner/schemas/no.nordicsemi.android.meshprovisioner.MeshNetworkDb/8.json
+++ b/android-nrf-mesh-library/meshprovisioner/schemas/no.nordicsemi.android.meshprovisioner.MeshNetworkDb/8.json
@@ -1,12 +1,12 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 7,
-    "identityHash": "ea6117f95cf47ac680089ce774a8055c",
+    "version": 8,
+    "identityHash": "e952aa95f68d7d78fb61ba2d3681ad38",
     "entities": [
       {
         "tableName": "mesh_network",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`mesh_uuid` TEXT NOT NULL, `mesh_name` TEXT, `timestamp` INTEGER NOT NULL, `iv_index` TEXT, `last_selected` INTEGER NOT NULL, `sequence_numbers` TEXT NOT NULL, PRIMARY KEY(`mesh_uuid`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`mesh_uuid` TEXT NOT NULL, `mesh_name` TEXT, `timestamp` INTEGER NOT NULL, `iv_index` TEXT NOT NULL, `last_selected` INTEGER NOT NULL, `sequence_numbers` TEXT NOT NULL, PRIMARY KEY(`mesh_uuid`))",
         "fields": [
           {
             "fieldPath": "meshUUID",
@@ -30,7 +30,7 @@
             "fieldPath": "ivIndex",
             "columnName": "iv_index",
             "affinity": "TEXT",
-            "notNull": false
+            "notNull": true
           },
           {
             "fieldPath": "lastSelected",
@@ -652,7 +652,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ea6117f95cf47ac680089ce774a8055c')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e952aa95f68d7d78fb61ba2d3681ad38')"
     ]
   }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNetwork.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNetwork.java
@@ -20,6 +20,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -71,11 +72,10 @@ abstract class BaseMeshNetwork {
     @Expose
     long timestamp = System.currentTimeMillis();
     @ColumnInfo(name = "iv_index")
+    @TypeConverters(MeshTypeConverters.class)
     @Expose
-    int ivIndex = 0;
-    @ColumnInfo(name = "iv_update_state")
-    @Expose
-    int ivUpdateState = NORMAL_OPERATION;
+    @NonNull
+    IvIndex ivIndex = new IvIndex(0, false, Calendar.getInstance());
     @Ignore
     @SerializedName("netKeys")
     @Expose

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/IvIndex.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/IvIndex.java
@@ -1,0 +1,115 @@
+package no.nordicsemi.android.meshprovisioner;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import androidx.annotation.NonNull;
+
+import java.util.Calendar;
+
+/**
+ * Class containing the current IV Index State of the network.
+ * <p>
+ * Created by Roshan Rajaratnam on 21/04/2020.
+ */
+@SuppressWarnings("WeakerAccess")
+public class IvIndex implements Parcelable {
+
+    private int ivIndex;
+    private boolean isIvUpdateActive; // False: Normal Operation, True: IV Update in progress
+    private boolean ivRecoveryFlag = false;
+    private Calendar transitionDate;
+
+    /**
+     * Construct the IV Index state of the mesh network
+     *
+     * @param ivIndex          IV Index of the network.
+     * @param isIvUpdateActive If true IV Update is in progress and false the network is in Normal operation.
+     * @param transitionDate   Time when the last IV Update happened
+     */
+    public IvIndex(final int ivIndex, final boolean isIvUpdateActive, final Calendar transitionDate) {
+        this.ivIndex = ivIndex;
+        this.isIvUpdateActive = isIvUpdateActive;
+        this.transitionDate = transitionDate;
+    }
+
+    protected IvIndex(Parcel in) {
+        ivIndex = in.readInt();
+        isIvUpdateActive = in.readByte() != 0;
+        ivRecoveryFlag = in.readByte() != 0;
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "IV Index: " + ivIndex + ", IV Update Active: " + isIvUpdateActive;
+    }
+
+    public static final Creator<IvIndex> CREATOR = new Creator<IvIndex>() {
+        @Override
+        public IvIndex createFromParcel(Parcel in) {
+            return new IvIndex(in);
+        }
+
+        @Override
+        public IvIndex[] newArray(int size) {
+            return new IvIndex[size];
+        }
+    };
+
+    /**
+     * Returns current iv index
+     */
+    public int getIvIndex() {
+        return ivIndex;
+    }
+
+    /**
+     * Returns the current iv update flag.
+     */
+    public boolean isIvUpdateActive() {
+        return isIvUpdateActive;
+    }
+
+    /**
+     * Returns iv index used when transmitting messages.
+     */
+    public int getTransmitIvIndex() {
+        return (isIvUpdateActive && ivIndex != 0) ? ivIndex - 1 : ivIndex;
+    }
+
+    public boolean getIvRecoveryFlag() {
+        return ivRecoveryFlag;
+    }
+
+    public void setIvRecoveryFlag(boolean ivRecoveryFlag) {
+        this.ivRecoveryFlag = ivRecoveryFlag;
+    }
+
+    public Calendar getTransitionDate() {
+        return transitionDate;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeInt(ivIndex);
+        dest.writeByte((byte) (isIvUpdateActive ? 1 : 0));
+        dest.writeByte((byte) (ivRecoveryFlag ? 1 : 0));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        IvIndex ivIndex1 = (IvIndex) o;
+        return ivIndex == ivIndex1.ivIndex &&
+                isIvUpdateActive == ivIndex1.isIvUpdateActive &&
+                ivRecoveryFlag == ivIndex1.ivRecoveryFlag &&
+                (transitionDate.getTimeInMillis() == ivIndex1.transitionDate.getTimeInMillis());
+    }
+}

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
@@ -35,6 +35,7 @@ import java.nio.ByteOrder;
 import java.security.Security;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
@@ -64,9 +65,6 @@ import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 import no.nordicsemi.android.meshprovisioner.utils.OutputOOBAction;
 import no.nordicsemi.android.meshprovisioner.utils.ProxyFilter;
 import no.nordicsemi.android.meshprovisioner.utils.SecureUtils;
-
-import static no.nordicsemi.android.meshprovisioner.MeshNetwork.IV_UPDATE_ACTIVE;
-import static no.nordicsemi.android.meshprovisioner.MeshNetwork.NORMAL_OPERATION;
 
 
 @SuppressWarnings("WeakerAccess")
@@ -112,6 +110,8 @@ public class MeshManagerApi implements MeshMngrApi {
     private byte[] mOutgoingBuffer;
     private int mOutgoingBufferOffset;
     private MeshNetwork mMeshNetwork;
+    private boolean ivUpdateTestModeActive = false;
+    private boolean allowIvIndexRecoveryOver42 = false;
 
     private MeshNetworkDb mMeshNetworkDb;
     private MeshNetworkDao mMeshNetworkDao;
@@ -185,6 +185,46 @@ public class MeshManagerApi implements MeshMngrApi {
 
     private void initBouncyCastle() {
         Security.insertProviderAt(new org.spongycastle.jce.provider.BouncyCastleProvider(), 1);
+    }
+
+    /**
+     * Returns the current IV Test mode.
+     * IV Update Test Mode enables efficient testing of the IV Update procedure.
+     * The IV Update test mode removes the 96-hour limit; all other behavior of the device are unchanged.
+     * - seeAlso: Bluetooth Mesh Profile 1.0.1, section 3.10.5.1.
+     */
+    public boolean isIvUpdateTestModeActive() {
+        return ivUpdateTestModeActive;
+    }
+
+    /**
+     * Set IV Update test mode.
+     * IV Update Test Mode enables efficient testing of the IV Update procedure.
+     * * The IV Update test mode removes the 96-hour limit; all other behavior of the device are unchanged.
+     * * - seeAlso: Bluetooth Mesh Profile 1.0.1, section 3.10.5.1.
+     *
+     * @param ivUpdateTestMode True if the test mode is active or false otherwise.
+     */
+    public void setIvUpdateTestModeActive(final boolean ivUpdateTestMode) {
+        ivUpdateTestModeActive = ivUpdateTestMode;
+    }
+
+    /**
+     *
+     * Allow Iv Index recovery over 42.
+     * According to Bluetooth Mesh Profile 1.0.1, section 3.10.5, if the IV Index of the mesh
+     * network increased by more than 42 since the last connection (which can take at least
+     * 48 weeks), the Node should be reprovisioned. However, as this library can be used to
+     * provision other Nodes, it should not be blocked from sending messages to the network
+     * only because the phone wasn't connected to the network for that time. This flag can
+     * disable this check, effectively allowing such connection.
+     * The same can be achieved by clearing the app data (uninstalling and reinstalling the
+     * app) and importing the mesh network. With no "previous" IV Index, the library will
+     * accept any IV Index received in the Secure Network beacon upon connection to the
+     * GATT Proxy Node.
+     */
+    public void allowIvIndexRecoveryOver42(final boolean allowIvIndexRecoveryOver42) {
+        this.allowIvIndexRecoveryOver42 = allowIvIndexRecoveryOver42;
     }
 
     private void initDb(final Context context) {
@@ -277,26 +317,68 @@ public class MeshManagerApi implements MeshMngrApi {
                             final byte[] n = networkKey.getKey();
                             final int flags = receivedBeacon.getFlags();
                             final byte[] networkId = SecureUtils.calculateK3(n);
-                            final int ivIndex = receivedBeacon.getIvIndex();
+                            final int ivIndex = receivedBeacon.getIvIndex().getIvIndex();
                             Log.d(TAG, "Received mesh beacon: " + receivedBeacon.toString());
 
                             final SecureNetworkBeacon localSecureNetworkBeacon = SecureUtils.createSecureNetworkBeacon(n, flags, networkId, ivIndex);
-                            //Let's check the the beacon received is a valid one by matching the authentication values
+                            //Check the the beacon received is a valid by matching the authentication values
                             if (Arrays.equals(receivedBeacon.getAuthenticationValue(), localSecureNetworkBeacon.getAuthenticationValue())) {
-                                Log.d(TAG, "Secure Network Beacon beacon is valid");
-                                if (mMeshNetwork.ivIndex < receivedBeacon.getIvIndex())
-                                    mMeshNetwork.ivIndex = receivedBeacon.getIvIndex();
-                                // If the last known state of the network was IV_UPDATE_ACTIVE and received beacon
-                                // has the state as Normal operation the sequence number must be reset to 0.
-                                if (mMeshNetwork.getIvUpdateState() == IV_UPDATE_ACTIVE && !receivedBeacon.isIvUpdateActive()) {
+                                Log.d(TAG, "Secure Network Beacon beacon authenticated.");
+
+                                //  The library does not retransmit Secure Network Beacon.
+                                //  If this node is a member of a primary subnet and receives a Secure Network
+                                //  beacon on a secondary subnet, it will disregard it.
+                                if (mMeshNetwork.getPrimaryNetworkKey() != null && networkKey.keyIndex != 0) {
+                                    Log.d(TAG, "Discarding beacon for secondary subnet with network key index: " + networkKey.keyIndex);
+                                    return;
+                                }
+
+                                // Get the last IV Index.
+                                /// The last used IV Index for this mesh network.
+                                final IvIndex lastIvIndex = mMeshNetwork.getIvIndex();
+                                Log.d(TAG, "Last IV Index: " + lastIvIndex.getIvIndex());
+                                /// The date of the last change of IV Index or IV Update Flag.
+                                final Calendar lastTransitionDate = lastIvIndex.getTransitionDate();
+                                /// A flag whether the IV has recently been updated using IV Recovery procedure.
+                                /// The at-least-96h requirement for the duration of the current state will not apply.
+                                /// The node shall not execute more than one IV Index Recovery within a period of 192 hours.
+                                final boolean isIvRecoveryActive = lastIvIndex.getIvRecoveryFlag();
+                                /// The test mode disables the 96h rule, leaving all other behavior unchanged.
+                                final boolean isIvTestModeActive = ivUpdateTestModeActive;
+
+                                final boolean flag = allowIvIndexRecoveryOver42;
+                                if (!receivedBeacon.canOverwrite(lastIvIndex, lastTransitionDate, isIvRecoveryActive, isIvTestModeActive, flag)) {
+                                    String numberOfHoursSinceDate = ((Calendar.getInstance().getTimeInMillis() -
+                                            lastTransitionDate.getTimeInMillis()) / (3600 * 1000)) + "h";
+                                    Log.w(TAG, "Discarding beacon " + receivedBeacon.getIvIndex() +
+                                            ", last " + lastIvIndex.getIvIndex() + ", changed: "
+                                            + numberOfHoursSinceDate + "ago, test mode: " + ivUpdateTestModeActive);
+                                    return;
+                                }
+
+                                final IvIndex receivedIvIndex = receivedBeacon.getIvIndex();
+                                mMeshNetwork.ivIndex = new IvIndex(receivedIvIndex.getIvIndex(), receivedIvIndex.isIvUpdateActive(), lastTransitionDate);
+
+                                if (mMeshNetwork.ivIndex.getIvIndex() > lastIvIndex.getIvIndex()) {
+                                    Log.i(TAG, "Applying: " + mMeshNetwork.ivIndex.getIvIndex());
+                                }
+
+                                // If the IV Index used for transmitting messages effectively increased,
+                                // the Node shall reset the sequence number to 0x000000.
+                                if (mMeshNetwork.ivIndex.getTransmitIvIndex() > lastIvIndex.getTransmitIvIndex()) {
+                                    Log.i(TAG, "Resetting local sequence numbers to 0");
                                     final Provisioner provisioner = mMeshNetwork.getSelectedProvisioner();
                                     final ProvisionedMeshNode node = mMeshNetwork.getNode(provisioner.getProvisionerUuid());
                                     node.setSequenceNumber(0);
                                     provisioner.setSequenceNumber(0);
                                 }
-                                // Update the Networks IV Update state to the corresponding state received via the Secure network beacon.
-                                mMeshNetwork.setIvUpdateState(receivedBeacon.isIvUpdateActive() ? IV_UPDATE_ACTIVE : NORMAL_OPERATION);
-                                return;
+
+                                //Updating the iv recovery flag
+                                if (lastIvIndex != mMeshNetwork.ivIndex) {
+                                    final boolean ivRecovery = mMeshNetwork.getIvIndex().getIvIndex() > lastIvIndex.getIvIndex() + 1
+                                            && !receivedBeacon.getIvIndex().isIvUpdateActive();
+                                    mMeshNetwork.getIvIndex().setIvRecoveryFlag(ivRecovery);
+                                }
                             }
                         }
                     }
@@ -498,7 +580,7 @@ public class MeshManagerApi implements MeshMngrApi {
         final NetworkKey networkKey = mMeshNetwork.getPrimaryNetworkKey();
         if (networkKey != null) {
             mMeshProvisioningHandler.identify(deviceUuid, networkKey, mMeshNetwork.getProvisioningFlags(),
-                    mMeshNetwork.getIvIndex(), mMeshNetwork.getGlobalTtl(), attentionTimer);
+                    mMeshNetwork.getIvIndex().getIvIndex(), mMeshNetwork.getGlobalTtl(), attentionTimer);
         }
     }
 
@@ -966,14 +1048,9 @@ public class MeshManagerApi implements MeshMngrApi {
     @SuppressWarnings("FieldCanBeLocal")
     private final UpperTransportLayerCallbacks upperTransportLayerCallbacks = new UpperTransportLayerCallbacks() {
 
-
         @Override
         public byte[] getIvIndex() {
-            int ivIndex = mMeshNetwork.getIvIndex();
-            if (mMeshNetwork.ivUpdateState == IV_UPDATE_ACTIVE) {
-                if (ivIndex != 0)
-                    ivIndex--;
-            }
+            int ivIndex = mMeshNetwork.getIvIndex().getTransmitIvIndex();
             return ByteBuffer.allocate(4).putInt(ivIndex).array();
         }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshNetwork.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshNetwork.java
@@ -32,12 +32,12 @@ public final class MeshNetwork extends BaseMeshNetwork {
         this.mCallbacks = mCallbacks;
     }
 
-    public void setIvIndex(final int ivIndex) {
+    public void setIvIndex(final IvIndex ivIndex) {
         this.ivIndex = ivIndex;
         notifyNetworkUpdated();
     }
 
-    public int getIvIndex() {
+    public IvIndex getIvIndex() {
         return ivIndex;
     }
 
@@ -617,30 +617,6 @@ public final class MeshNetwork extends BaseMeshNetwork {
         this.appKeys = appKeys;
     }
 
-
-    /**
-     * Returns the current iv update state {@link IvUpdateStates}
-     *
-     * @return 1 if iv update is active or 0 otherwise
-     */
-    @IvUpdateStates
-    public int getIvUpdateState() {
-        return ivUpdateState;
-    }
-
-    /**
-     * Sets the iv update state.
-     * <p>
-     * This is not currently supported by the library
-     * </p>
-     *
-     * @param ivUpdateState 0 if normal operation and 1 if iv update is active
-     */
-    @RestrictTo(RestrictTo.Scope.LIBRARY)
-    public void setIvUpdateState(@IvUpdateStates final int ivUpdateState) {
-        this.ivUpdateState = ivUpdateState;
-    }
-
     /**
      * Returns the provisioning flags
      */
@@ -652,7 +628,7 @@ public final class MeshNetwork extends BaseMeshNetwork {
                 flags |= 1 << 7;
             }
 
-            if (ivUpdateState == IV_UPDATE_ACTIVE) {
+            if (ivIndex.isIvUpdateActive()) {
                 flags |= 1 << 6;
             }
         }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshTypeConverters.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshTypeConverters.java
@@ -2,6 +2,10 @@ package no.nordicsemi.android.meshprovisioner;
 
 import android.util.SparseIntArray;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
+import androidx.room.TypeConverter;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.reflect.TypeToken;
@@ -11,9 +15,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.RestrictTo;
-import androidx.room.TypeConverter;
 import no.nordicsemi.android.meshprovisioner.transport.Element;
 import no.nordicsemi.android.meshprovisioner.transport.ElementDbMigrator;
 import no.nordicsemi.android.meshprovisioner.transport.InternalMeshModelDeserializer;
@@ -137,5 +138,17 @@ public class MeshTypeConverters {
         final Type keys = new TypeToken<List<NodeKey>>() {
         }.getType();
         return new Gson().fromJson(nodeKeys, keys);
+    }
+
+    @TypeConverter
+    public static String ivIndexToJson(@NonNull final IvIndex ivIndex) {
+        return new Gson().toJson(ivIndex);
+    }
+
+    @TypeConverter
+    public static IvIndex fromJsonToIvIndex(final String ivIndex){
+        final Type newIvIndex = new TypeToken<IvIndex>(){
+        }.getType();
+        return new Gson().fromJson(ivIndex, newIvIndex);
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/SecureNetworkBeacon.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/SecureNetworkBeacon.java
@@ -6,6 +6,7 @@ import android.os.Parcelable;
 import androidx.annotation.NonNull;
 
 import java.nio.ByteBuffer;
+import java.util.Calendar;
 
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 
@@ -17,11 +18,9 @@ public class SecureNetworkBeacon extends MeshBeacon {
     public static final int BEACON_DATA_LENGTH = 22;
     private final int flags;
     private boolean isKeyRefreshActive;
-    private boolean isIvUpdateActive;
     private final byte[] networkId = new byte[8];
-    private final int ivIndex;
+    private final IvIndex ivIndex;
     private final byte[] authenticationValue = new byte[8];
-
 
     /**
      * Constructs a {@link SecureNetworkBeacon} object
@@ -39,20 +38,19 @@ public class SecureNetworkBeacon extends MeshBeacon {
         byteBuffer.position(1);
         flags = byteBuffer.get();
         isKeyRefreshActive = (flags & 0x01) == 1;
-        isIvUpdateActive = ((flags & 0x02) >> 1) == BaseMeshNetwork.IV_UPDATE_ACTIVE;
+        final boolean isIvUpdateActive = ((flags & 0x02) >> 1) == BaseMeshNetwork.IV_UPDATE_ACTIVE;
         byteBuffer.get(networkId, 0, 8);
-        ivIndex = byteBuffer.getInt();
+        ivIndex = new IvIndex(byteBuffer.getInt(), isIvUpdateActive, Calendar.getInstance());
         byteBuffer.get(authenticationValue, 0, 8);
     }
 
     @NonNull
     @Override
     public String toString() {
-        return "SecureNetworkBeacon" +
+        return "SecureNetworkBeacon {" +
                 " KeyRefreshActive: " + isKeyRefreshActive +
-                " IvUpdateActive: " + isIvUpdateActive +
-                " IV Index: " + ivIndex +
-                " Authentication Value: " + MeshParserUtils.bytesToHex(authenticationValue, true);
+                ", IV Index: " + ivIndex +
+                ", Authentication Value: " + MeshParserUtils.bytesToHex(authenticationValue, true) + "}";
     }
 
     @Override
@@ -75,13 +73,6 @@ public class SecureNetworkBeacon extends MeshBeacon {
     }
 
     /**
-     * Returns true is IV Update is active.
-     */
-    public boolean isIvUpdateActive() {
-        return isIvUpdateActive;
-    }
-
-    /**
      * Returns the network id of the beacon or the node
      */
     public byte[] getNetworkId() {
@@ -91,7 +82,7 @@ public class SecureNetworkBeacon extends MeshBeacon {
     /**
      * Returns the iv index of the beacon or the node
      */
-    public int getIvIndex() {
+    public IvIndex getIvIndex() {
         return ivIndex;
     }
 
@@ -124,5 +115,95 @@ public class SecureNetworkBeacon extends MeshBeacon {
             return new SecureNetworkBeacon[size];
         }
     };
+
+    /**
+     * This method returns whether the received Secure Network Beacon can override
+     * the current IV Index.
+     * <p>
+     * The following restrictions apply:
+     * 1. Normal Operation state must last for at least 96 hours.
+     * 2. IV Update In Progress state must take at least 96 hours and may not be longer than 144h.
+     * 3. IV Index must not decrease.
+     * 4. If received Secure Network Beacon has IV Index greater than current IV Index + 1, the
+     * device will go into IV Index Recovery procedure. In this state, the 96h rule does not apply
+     * and the IV Index or IV Update Active flag may change before 96 hours.
+     * 5. If received Secure Network Beacon has IV Index greater than current IV Index + 42, the
+     * beacon should be ignored (unless a setting in MeshNetworkManager is set to disable this rule).
+     * 6. The node shall not execute more than one IV Index Recovery within a period of 192 hours.
+     * <p>
+     * Note: Library versions before 2.2.2 did not store the last IV Index, so the date and IV Recovery
+     * flag are optional.
+     * <p>
+     * - parameters:
+     * - target: The IV Index to compare.
+     * - date: The date of the most recent transition to the current IV Index.
+     * - ivRecoveryActive: True if the IV Recovery procedure was used to restore
+     * the IV Index on the previous connection.
+     * - ivTestMode: True, if IV Update test mode is enabled; false otherwise.
+     * - ivRecoveryOver42Allowed: Whether the IV Index Recovery procedure should be limited
+     * to allow maximum increase of IV Index by 42.
+     * - returns: True, if the Secure Network beacon can be applied; false otherwise.
+     * - since: 2.2.2
+     * - seeAlso: Bluetooth Mesh Profile 1.0.1, section 3.10.5.
+     */
+    protected boolean canOverwrite(final IvIndex ivIndex, final Calendar updatedAt,
+                                   final boolean ivRecoveryActive,
+                                   final boolean isTestMode,
+                                   final boolean ivRecoveryOver42Allowed) {
+        // IV Index must increase, or, in case it's equal to the current one,
+        // the IV Update Active flag must change from true to false.
+        // The new index must not be greater than the current one + 42,
+        // unless this rule is disabled.
+        if ((this.ivIndex.getIvIndex() > ivIndex.getIvIndex() &&
+                (ivRecoveryOver42Allowed || this.ivIndex.getIvIndex() <= ivIndex.getIvIndex() + 42)) ||
+                (this.ivIndex.getIvIndex() == ivIndex.getIvIndex() &&
+                        (ivIndex.isIvUpdateActive() || !this.ivIndex.isIvUpdateActive()))) {
+
+            // Before version 2.2.2 the timestamp was not stored. The initial
+            // Secure Network Beacon is assumed to be valid.
+            return isMinimumTimeRequirementCompleted(ivIndex, updatedAt, ivRecoveryActive, isTestMode);
+        } else {
+            return false;
+        }
+    }
+
+    private boolean isMinimumTimeRequirementCompleted(final IvIndex ivIndex,
+                                                      final Calendar updatedAt,
+                                                      final boolean isIvRecoveryActive,
+                                                      final boolean isTestMode) {
+        // Let's define a "state" as a pair of IV and IV Update Active flag.
+        // "States" change as follows:
+        // 1. IV = X,   IVUA = false (Normal Operation)
+        // 2. IV = X+1, IVUA = true  (Update In Progress)
+        // 3. IV = X+1, IVUA = false (Normal Operation)
+        // 4. IV = X+2, IVUA = true  (Update In Progress)
+        // 5. ...
+
+        // Calculate number of states between the state defined by the target
+        // IV Index and this Secure Network Beacon.
+        int stateDiff = (this.ivIndex.getIvIndex() - ivIndex.getIvIndex()) * 2 - 1
+                + (ivIndex.isIvUpdateActive() ? 1 : 0)
+                + (this.ivIndex.isIvUpdateActive() ? 0 : 1)
+                - (isIvRecoveryActive || isTestMode ? 1 : 0); // this may set stateDiff = -1
+
+        // Each "state" must last for at least 96 hours.
+        // Calculate the minimum number of hours that had to pass since last state
+        // change for the Secure Network Beacon to be assumed valid.
+        // If more has passed, it's also valid, as Normal Operation has no maximum
+        // time duration.
+        int numberOfHoursRequired = stateDiff * 96;
+
+        // Get the number of hours since the state changed last time.
+        final long timeDifference = Calendar.getInstance().getTimeInMillis() - updatedAt.getTimeInMillis();
+        final int numberOfHoursSinceDate = (int) (timeDifference / (3600 * 1000));
+
+        // The node shall not execute more than one IV Index Recovery within a
+        // period of 192 hours.
+        if (isIvRecoveryActive && stateDiff > 1 && numberOfHoursSinceDate < 192) {
+            return false;
+        }
+
+        return numberOfHoursSinceDate >= numberOfHoursRequired;
+    }
 
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/AccessLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/AccessLayer.java
@@ -123,12 +123,13 @@ abstract class AccessLayer {
         //MSB of the first octet defines the length of opcodes.
         //if MSB = 0 length is 1 and so forth
         final byte[] accessPayload = message.getAccessPdu();
-        final int opCodeLength = (accessPayload[0] & 0xC0) >> 6;
-        final int opcode = MeshParserUtils.getOpCode(accessPayload, opCodeLength);
-        message.setOpCode(opcode);
+        final int opCodeBits = (accessPayload[0] & 0xC0) >> 6;
+        final int opCodeLength = MeshParserUtils.getOpCodeLength(accessPayload[0] & 0xFF);
+        final int opCode = MeshParserUtils.getOpCode(accessPayload, opCodeLength);
+        message.setOpCode(opCode);
         final int length = accessPayload.length - opCodeLength;
         final ByteBuffer paramsBuffer = ByteBuffer.allocate(length).order(ByteOrder.BIG_ENDIAN);
-        paramsBuffer.put(accessPayload, opCodeLength, length);
+        paramsBuffer.put(accessPayload, opCodeBits, length);
         message.setParameters(paramsBuffer.array());
         Log.v(TAG, "Received Access PDU " + MeshParserUtils.bytesToHex(accessPayload, false));
     }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/BaseMeshMessageHandler.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/BaseMeshMessageHandler.java
@@ -103,9 +103,8 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
         final List<NetworkKey> networkKeys = network.getNetKeys();
         final int ivi = ((pdu[1] & 0xFF) >>> 7) & 0x01;
         final int nid = pdu[1] & 0x7F;
-        final int tempIvIndex = network.getIvIndex();
-        int ivIndex = tempIvIndex == 0 ? 0 : tempIvIndex - 1;
-        boolean isParsingComplete = false;
+        final int acceptedIvIndex = network.getIvIndex().getIvIndex();
+        int ivIndex = acceptedIvIndex == 0 ? 0 : acceptedIvIndex - 1;
         while (ivIndex <= ivIndex + 1) {
             //Here we go through all the network keys and filter out network keys based on the nid.
             for (int i = 0; i < networkKeys.size(); i++) {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LowerTransportLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LowerTransportLayer.java
@@ -413,7 +413,7 @@ abstract class LowerTransportLayer extends UpperTransportLayer {
         final int akf = (header >> 6) & 0x01;
         final int aid = header & 0x3F;
         if (seg == 0) { //Unsegmented message
-            Log.d(TAG, "IV Index: " + ivIndex);
+            Log.d(TAG, "IV Index of received message: " + ivIndex);
             final int seqAuth = (ivIndex << 24) | MeshParserUtils.getSequenceNumber(sequenceNumber);
             final byte[] src = MeshParserUtils.getSrcAddress(pdu);
             final int srcAdd = MeshParserUtils.unsignedBytesToInt(src[1], src[0]);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshTransport.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshTransport.java
@@ -35,7 +35,6 @@ import java.util.UUID;
 import no.nordicsemi.android.meshprovisioner.ApplicationKey;
 import no.nordicsemi.android.meshprovisioner.MeshManagerApi;
 import no.nordicsemi.android.meshprovisioner.Provisioner;
-import no.nordicsemi.android.meshprovisioner.utils.ExtendedInvalidCipherTextException;
 import no.nordicsemi.android.meshprovisioner.utils.MeshAddress;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/utils/MeshParserUtils.java
@@ -240,7 +240,6 @@ public class MeshParserUtils {
      * @throws IllegalArgumentException in case of an invalid was entered as an input and the message containing the error
      */
     public static boolean validateIvIndexInput(final Context context, final Integer ivIndex) throws IllegalArgumentException {
-
         if (ivIndex == null) {
             throw new IllegalArgumentException(context.getString(R.string.error_empty_iv_index));
         }
@@ -344,13 +343,12 @@ public class MeshParserUtils {
     }
 
     /**
-     * Returns the length of the opcode.
+     * Returns an array of opcodes.
      * If the MSB = 0 then the length is 1
      * If the MSB = 1 then the length is 2
      * If the MSB = 2 then the length is 3
      *
      * @param opCode operation code
-     * @return length of opcodes
      */
     public static byte[] getOpCode(final int opCode) {
         if (opCode < 0x80) {
@@ -361,6 +359,25 @@ public class MeshParserUtils {
             return new byte[]{(byte) (0xC0 | ((opCode >> 16) & 0x3F)),
                     (byte) ((opCode >> 8) & 0xFF),
                     (byte) (opCode & 0xFF)};
+        }
+    }
+
+    /**
+     * Returns the length of the opcode.
+     * If the MSB = 0 then the length is 1
+     * If the MSB = 1 then the length is 2
+     * If the MSB = 2 then the length is 3
+     *
+     * @param opCode operation code
+     * @return length of opcodes
+     */
+    public static int getOpCodeLength(final int opCode) {
+        if (opCode < 0x80) {
+            return 1;
+        } else if (opCode < 0x4000 || (opCode & 0xFFFC00) == 0x8000) {
+            return 2;
+        } else {
+            return 3;
         }
     }
 

--- a/android-nrf-mesh-library/meshprovisioner/src/test/java/no/nordicsemi/android/meshprovisioner/SecureNetworkBeaconTest.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/test/java/no/nordicsemi/android/meshprovisioner/SecureNetworkBeaconTest.java
@@ -1,0 +1,241 @@
+package no.nordicsemi.android.meshprovisioner;
+
+import org.junit.Test;
+
+import java.util.Calendar;
+
+import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by Roshan Rajaratnam on 24/04/2020.
+ */
+public class SecureNetworkBeaconTest {
+
+
+    @Test
+    public void testOverwritingWithTheSameIvIndex() {
+        final byte[] data = MeshParserUtils.toByteArray("0102EE6C0EFF5298ECFF000000025E5AA7B268B5E044");
+        final SecureNetworkBeacon snb = new SecureNetworkBeacon(data);
+        final IvIndex ivIndex = new IvIndex(2, true, Calendar.getInstance());
+
+        final Calendar rightNow = Calendar.getInstance();
+        rightNow.add(Calendar.HOUR, -1);
+        final boolean result = snb.canOverwrite(ivIndex, rightNow, false,
+                false, false);
+
+        assertTrue("Cannot overrwrite iv index with a baecon with same index", result);
+    }
+
+    @Test
+    public void testOverwritingWithNextIvIndex() {
+        final byte[] data = MeshParserUtils.toByteArray("0102EE6C0EFF5298ECFF000000025E5AA7B268B5E044");
+        final SecureNetworkBeacon snb = new SecureNetworkBeacon(data);
+        final IvIndex ivIndex = new IvIndex(1, false, Calendar.getInstance());
+
+        final Calendar ninetySixHoursAgo = Calendar.getInstance();
+        final Calendar almostNinetySixHoursAgo = (Calendar) ninetySixHoursAgo.clone();
+        final Calendar moreThanNinetySixHoursAgo = (Calendar) ninetySixHoursAgo.clone();
+
+        ninetySixHoursAgo.add(Calendar.HOUR, -96);
+        almostNinetySixHoursAgo.add(Calendar.HOUR, -96);
+        almostNinetySixHoursAgo.add(Calendar.SECOND, 10);
+        moreThanNinetySixHoursAgo.add(Calendar.HOUR, -96);
+        moreThanNinetySixHoursAgo.add(Calendar.SECOND, -10);
+
+        // Less than 96 hours - test should fail
+        final boolean result0 = snb.canOverwrite(ivIndex, almostNinetySixHoursAgo,
+                false, false, false);
+
+        // When previous IV Index was updated using IV Recovery, 96h requirement
+        // does not apply. Test should pass.
+        final boolean result1 = snb.canOverwrite(ivIndex, almostNinetySixHoursAgo,
+                true, false, false);
+
+        // It's ok. 96 hours have passed.
+        final boolean result2 = snb.canOverwrite(ivIndex, ninetySixHoursAgo,
+                false, false, false);
+
+        // Now even more time passed, so updating IV Index is ok.
+        final boolean result3 = snb.canOverwrite(ivIndex, moreThanNinetySixHoursAgo,
+                false, false, false);
+
+        assertFalse(result0);
+        assertTrue(result1);
+        assertTrue(result2);
+        assertTrue(result3);
+    }
+
+    @Test
+    public void testOverwritingWithNextIvIndexInTestMode() {
+        final byte[] data = MeshParserUtils.toByteArray("0102EE6C0EFF5298ECFF000000025E5AA7B268B5E044");
+        final SecureNetworkBeacon snb = new SecureNetworkBeacon(data);
+        final IvIndex ivIndex = new IvIndex(1, false, Calendar.getInstance());
+
+        final Calendar ninetySixHoursAgo = Calendar.getInstance();
+        final Calendar almostNinetySixHoursAgo = (Calendar) ninetySixHoursAgo.clone();
+        final Calendar moreThanNinetySixHoursAgo = (Calendar) ninetySixHoursAgo.clone();
+
+        ninetySixHoursAgo.add(Calendar.HOUR, -96);
+        almostNinetySixHoursAgo.add(Calendar.HOUR, -96);
+        almostNinetySixHoursAgo.add(Calendar.SECOND, 10);
+        moreThanNinetySixHoursAgo.add(Calendar.HOUR, -96);
+        moreThanNinetySixHoursAgo.add(Calendar.SECOND, -10);
+
+        // In test mode the 96h requirement does not apply.
+        final boolean result0 = snb.canOverwrite(ivIndex, almostNinetySixHoursAgo,
+                false, true, false);
+
+        final boolean result1 = snb.canOverwrite(ivIndex, ninetySixHoursAgo,
+                false, true, false);
+
+        final boolean result2 = snb.canOverwrite(ivIndex, moreThanNinetySixHoursAgo,
+                false, true, false);
+
+        assertTrue(result0);
+        assertTrue(result1);
+        assertTrue(result2);
+    }
+
+    @Test
+    public void testOverwritingWithFarIvIndex() {
+        final byte[] data = MeshParserUtils.toByteArray("0102EE6C0EFF5298ECFF000000025E5AA7B268B5E044");
+        final SecureNetworkBeacon snb = new SecureNetworkBeacon(data);
+        final IvIndex ivIndex = new IvIndex(0, false, Calendar.getInstance());
+        final Calendar currentTime = Calendar.getInstance();
+
+        final Calendar ninetySixHoursAgo = (Calendar) currentTime.clone();
+        ninetySixHoursAgo.add(Calendar.HOUR, -96);
+        final Calendar almostNinetySixHoursAgo = (Calendar) ninetySixHoursAgo.clone();
+        almostNinetySixHoursAgo.add(Calendar.SECOND, 10);
+        final Calendar moreThanNinetySixHoursAgo = (Calendar) ninetySixHoursAgo.clone();
+        moreThanNinetySixHoursAgo.add(Calendar.SECOND, -10);
+
+        final Calendar twoHundredEightyEightHoursAgo = (Calendar) currentTime.clone();
+        twoHundredEightyEightHoursAgo.add(Calendar.HOUR, -288);
+        final Calendar almostTwoHundredEightyEightHoursAgo = (Calendar) twoHundredEightyEightHoursAgo.clone();
+        almostTwoHundredEightyEightHoursAgo.add(Calendar.SECOND, 10);
+        final Calendar moreThanTwoHundredEightyEightHoursAgo = (Calendar) twoHundredEightyEightHoursAgo.clone();
+        moreThanTwoHundredEightyEightHoursAgo.add(Calendar.SECOND, -10);
+
+        // 3 * 96 = 288 hours are required to pass since last IV Index update
+        // for the IV Index to change from 0 (normal operation) to 2 (update active).
+        // The following tests check if SNB cannot be updated before that.
+        final boolean result0 = snb.canOverwrite(ivIndex, almostNinetySixHoursAgo,
+                false, false, false);
+
+        final boolean result1 = snb.canOverwrite(ivIndex, ninetySixHoursAgo,
+                false, false, false);
+
+        final boolean result2 = snb.canOverwrite(ivIndex, moreThanNinetySixHoursAgo,
+                false, false, false);
+
+        final boolean result3 = snb.canOverwrite(ivIndex, almostTwoHundredEightyEightHoursAgo,
+                false, false, false);
+
+        // 3 * 96 = 288 hours have passed. IV Index can be updated
+        // from 0 (normal operation) to 2 (update active) using IV Recovery
+        // procedure.
+        final boolean result4 = snb.canOverwrite(ivIndex, twoHundredEightyEightHoursAgo,
+                false, false, false);
+
+        // Even more time has passed.
+        final boolean result5 = snb.canOverwrite(ivIndex, moreThanTwoHundredEightyEightHoursAgo,
+                false, false, false);
+
+        assertFalse(result0);
+        assertFalse(result1);
+        assertFalse(result2);
+        assertFalse(result3);
+        assertTrue(result4);
+        assertTrue(result5);
+    }
+
+    @Test
+    public void testOverwritingWithFarIvIndexInTestMode() {
+        final byte[] data = MeshParserUtils.toByteArray("0102EE6C0EFF5298ECFF000000025E5AA7B268B5E044");
+        final SecureNetworkBeacon snb = new SecureNetworkBeacon(data);
+        final IvIndex ivIndex = new IvIndex(0, false, Calendar.getInstance());
+
+        final Calendar ninetySixHoursAgo = Calendar.getInstance();
+        final Calendar almostNinetySixHoursAgo = (Calendar) ninetySixHoursAgo.clone();
+        final Calendar moreThanNinetySixHoursAgo = (Calendar) ninetySixHoursAgo.clone();
+
+        ninetySixHoursAgo.add(Calendar.HOUR, -96);
+        almostNinetySixHoursAgo.add(Calendar.HOUR, -96);
+        almostNinetySixHoursAgo.add(Calendar.SECOND, 10);
+        moreThanNinetySixHoursAgo.add(Calendar.HOUR, -96);
+        moreThanNinetySixHoursAgo.add(Calendar.SECOND, -10);
+
+        // Test mode only removes 96h requirements to transition to the next
+        // IV Index. Here we are updating from 0 (normal operation) to
+        // 2 (update active), which is 3 steps. Test mode cannot help.
+        final boolean result0 = snb.canOverwrite(ivIndex, almostNinetySixHoursAgo,
+                false, true, false);
+
+        final boolean result1 = snb.canOverwrite(ivIndex, ninetySixHoursAgo,
+                false, true, false);
+
+        final boolean result2 = snb.canOverwrite(ivIndex, moreThanNinetySixHoursAgo,
+                false, true, false);
+
+        assertFalse(result0);
+        assertFalse(result1);
+        assertFalse(result2);
+    }
+
+    @Test
+    public void testOverwritingWithVeryFarIvIndex() {
+        // This Secure Network Beacon has IV Index 52 (update active)
+        final byte[] data = MeshParserUtils.toByteArray("0102EE6C0EFF5298ECFF00000034A53312BF9198C86F");
+        final SecureNetworkBeacon snb = new SecureNetworkBeacon(data);
+        final IvIndex ivIndex = new IvIndex(9, false, Calendar.getInstance());
+
+        // The IV Index changes from 9 to 52, that is by 43. Also, the update active
+        // flag changes from false to true, which adds one more step.
+        // At least 43 * 192h + additional 96h are required for the IV Index to be
+        // assumed valid.
+
+        final Calendar longTimeAgo = Calendar.getInstance();
+        longTimeAgo.add(Calendar.HOUR, -(42 * 192 + 96));
+
+        final Calendar notThatLongTimeAgo = (Calendar) longTimeAgo.clone();
+        notThatLongTimeAgo.add(Calendar.SECOND, 10);
+
+        final Calendar longLongTimeAgo = (Calendar) longTimeAgo.clone();
+        longLongTimeAgo.add(Calendar.SECOND, -10);
+
+        final boolean result0 = snb.canOverwrite(ivIndex, notThatLongTimeAgo,
+                false, false, false);
+
+        final boolean result1 = snb.canOverwrite(ivIndex, longTimeAgo,
+                false, false, false);
+
+        final boolean result2 = snb.canOverwrite(ivIndex, longLongTimeAgo,
+                false, false, false);
+
+        final boolean result3 = snb.canOverwrite(ivIndex, notThatLongTimeAgo,
+                false, false, true);
+
+        final boolean result4 = snb.canOverwrite(ivIndex, longTimeAgo,
+                false, false, true);
+
+        final boolean result5 = snb.canOverwrite(ivIndex, longLongTimeAgo,
+                false, false, true);
+
+        // This test fails for 2 reasons: not enough time and IV Index change
+        // exceeds limit of 42.
+        assertFalse(result0);
+        // Those tests should fails, as IV Index changed by more than 42.
+        assertFalse(result1);
+        assertFalse(result2);
+        // This test returns false, as the time difference is not long enough.
+        assertFalse(result3);
+        // Those tests pass, as more than 43 * 192h + 96h have passed, and
+        // the IV Index + 42 limit was turned off.
+        assertTrue(result4);
+        assertTrue(result5);
+    }
+}


### PR DESCRIPTION
IV Index related Improvements:
* IV Index and IV Update state has been merged in to an object that contains all iv related properties.
* IV Index updates fixed. The library will now handle the Secure Network beacon with `isIvUpdateActive` flag set or high IV Index. The spec-defined time requirements are checked, so at least 96h need to pass in *IV Index Normal Operation* state and at least 96h in *IV Index Update In Progress*. The node will not execute more than one IV Index Recovery within a period of 192 hours.
* IV Index Test Mode added: see `MeshManagerApi.isIvUpdateTestModeActive` flag.
* A flag to disable limit of 42 when doing IV Recovery. This allows to connect to a network after IV Index changed by more than 42, which can happen at least in 48 weeks since last connection.

**Note I:** The IV Index changes only when a Secure Network beacon is received. This happens usually when you connect to a Proxy Node, but the Proxy may also relay a SNB sent by another Node.
**Note II:** To test IV Index Update enabled IV Test Mode. A switch has been added to Settings screen in the sample app. Test Mode allows you to transition IV Index by 1, or change the IV Index Update flag from *true* to *false* without the need to wait 96h. It will, however, not allow to transition to higher IV Index without passing the min-time requirement.
**Note III:** The library will not send Secure Network beacons. It fully relies on other Nodes to initiate the process of updating IV Index. In most applications it will not be a case, as other nodes will reach half sequence number before the app, unless it's constantly connected to the network and sends messages in a loop, which doesn't seem to be probable scenario.