### PR TITLE
Fix provisioner sequence number

### DIFF
--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/GroupControlsActivity.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/GroupControlsActivity.java
@@ -29,13 +29,6 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.Toast;
 
-import com.google.android.material.snackbar.Snackbar;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.inject.Inject;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
@@ -44,6 +37,15 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+
+import com.google.android.material.snackbar.Snackbar;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import javax.inject.Inject;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import no.nordicsemi.android.meshprovisioner.ApplicationKey;
@@ -206,7 +208,7 @@ public class GroupControlsActivity extends AppCompatActivity implements Injectab
 
     @Override
     public void onSubGroupItemClick(final int appKeyIndex, final int modelId) {
-        if(!isConnected())
+        if (!isConnected())
             return;
 
         if (MeshParserUtils.isVendorModel(modelId)) {
@@ -238,7 +240,7 @@ public class GroupControlsActivity extends AppCompatActivity implements Injectab
         final MeshMessage meshMessage;
         final MeshNetwork network = mViewModel.getNetworkLiveData().getMeshNetwork();
         final ApplicationKey applicationKey = network.getAppKey(appKeyIndex);
-        final int tid = network.getSelectedProvisioner().getSequenceNumber();
+        final int tid = new Random().nextInt();
         switch (modelId) {
             case SigModelParser.GENERIC_ON_OFF_SERVER:
                 meshMessage = new GenericOnOffSetUnacknowledged(applicationKey, isChecked, tid);
@@ -262,7 +264,7 @@ public class GroupControlsActivity extends AppCompatActivity implements Injectab
 
         final MeshNetwork network = mViewModel.getNetworkLiveData().getMeshNetwork();
         final ApplicationKey applicationKey = mViewModel.getNetworkLiveData().getMeshNetwork().getAppKey(keyIndex);
-        final int tid = network.getSelectedProvisioner().getSequenceNumber();
+        final int tid = new Random().nextInt();
         final MeshMessage meshMessage = new GenericOnOffSetUnacknowledged(applicationKey,
                 state, tid, transitionSteps, transitionStepResolution, delay);
         sendMessage(group.getAddress(), meshMessage);
@@ -280,7 +282,7 @@ public class GroupControlsActivity extends AppCompatActivity implements Injectab
         final MeshNetwork network = mViewModel.getNetworkLiveData().getMeshNetwork();
         if (network != null) {
             final ApplicationKey applicationKey = mViewModel.getNetworkLiveData().getMeshNetwork().getAppKey(keyIndex);
-            final int tid = mViewModel.getNetworkLiveData().getMeshNetwork().getSelectedProvisioner().getSequenceNumber();
+            final int tid = new Random().nextInt();
             final MeshMessage meshMessage = new GenericLevelSetUnacknowledged(applicationKey, transitionSteps, transitionStepResolution, delay, level, tid);
             sendMessage(group.getAddress(), meshMessage);
         }

--- a/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/node/adapter/NodeAdapter.java
+++ b/Example/nrf-mesh/app/src/main/java/no/nordicsemi/android/nrfmeshprovisioner/node/adapter/NodeAdapter.java
@@ -29,14 +29,15 @@ import android.view.ViewGroup;
 import android.widget.FrameLayout;
 import android.widget.TextView;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 import androidx.annotation.NonNull;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.LiveData;
 import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import no.nordicsemi.android.meshprovisioner.transport.Element;
@@ -96,7 +97,6 @@ public class NodeAdapter extends RecyclerView.Adapter<NodeAdapter.ViewHolder> {
                 holder.elements.setText(String.valueOf(node.getNumberOfElements()));
                 holder.models.setText(R.string.unknown);
             }
-            //holder.getSwipeableView().setTag(node);
         }
     }
 

--- a/android-nrf-mesh-library/meshprovisioner/schemas/no.nordicsemi.android.meshprovisioner.MeshNetworkDb/9.json
+++ b/android-nrf-mesh-library/meshprovisioner/schemas/no.nordicsemi.android.meshprovisioner.MeshNetworkDb/9.json
@@ -1,0 +1,652 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "dc74c1727a65404e3d1795816f05be43",
+    "entities": [
+      {
+        "tableName": "mesh_network",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`mesh_uuid` TEXT NOT NULL, `mesh_name` TEXT, `timestamp` INTEGER NOT NULL, `iv_index` TEXT NOT NULL, `last_selected` INTEGER NOT NULL, `sequence_numbers` TEXT NOT NULL, PRIMARY KEY(`mesh_uuid`))",
+        "fields": [
+          {
+            "fieldPath": "meshUUID",
+            "columnName": "mesh_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meshName",
+            "columnName": "mesh_name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ivIndex",
+            "columnName": "iv_index",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSelected",
+            "columnName": "last_selected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sequenceNumbers",
+            "columnName": "sequence_numbers",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "mesh_uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "network_key",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `mesh_uuid` TEXT, `index` INTEGER NOT NULL, `name` TEXT, `key` BLOB, `old_key` BLOB, `phase` INTEGER NOT NULL, `security` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, FOREIGN KEY(`mesh_uuid`) REFERENCES `mesh_network`(`mesh_uuid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meshUuid",
+            "columnName": "mesh_uuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "keyIndex",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "oldKey",
+            "columnName": "old_key",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "phase",
+            "columnName": "phase",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "minSecurity",
+            "columnName": "security",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_network_key_mesh_uuid",
+            "unique": false,
+            "columnNames": [
+              "mesh_uuid"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_network_key_mesh_uuid` ON `${TABLE_NAME}` (`mesh_uuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "mesh_network",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "mesh_uuid"
+            ],
+            "referencedColumns": [
+              "mesh_uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "application_key",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `mesh_uuid` TEXT, `index` INTEGER NOT NULL, `name` TEXT, `key` BLOB, `old_key` BLOB, `bound_key_index` INTEGER NOT NULL, FOREIGN KEY(`mesh_uuid`) REFERENCES `mesh_network`(`mesh_uuid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "meshUuid",
+            "columnName": "mesh_uuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "keyIndex",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "oldKey",
+            "columnName": "old_key",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "boundNetKeyIndex",
+            "columnName": "bound_key_index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_application_key_mesh_uuid",
+            "unique": false,
+            "columnNames": [
+              "mesh_uuid"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_application_key_mesh_uuid` ON `${TABLE_NAME}` (`mesh_uuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "mesh_network",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "mesh_uuid"
+            ],
+            "referencedColumns": [
+              "mesh_uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "provisioner",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`mesh_uuid` TEXT NOT NULL, `provisioner_uuid` TEXT NOT NULL, `name` TEXT, `allocated_unicast_ranges` TEXT NOT NULL, `allocated_group_ranges` TEXT NOT NULL, `allocated_scene_ranges` TEXT NOT NULL, `provisioner_address` INTEGER, `global_ttl` INTEGER NOT NULL, `last_selected` INTEGER NOT NULL, PRIMARY KEY(`provisioner_uuid`), FOREIGN KEY(`mesh_uuid`) REFERENCES `mesh_network`(`mesh_uuid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "meshUuid",
+            "columnName": "mesh_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provisionerUuid",
+            "columnName": "provisioner_uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provisionerName",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "allocatedUnicastRanges",
+            "columnName": "allocated_unicast_ranges",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allocatedGroupRanges",
+            "columnName": "allocated_group_ranges",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allocatedSceneRanges",
+            "columnName": "allocated_scene_ranges",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "provisionerAddress",
+            "columnName": "provisioner_address",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "globalTtl",
+            "columnName": "global_ttl",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSelected",
+            "columnName": "last_selected",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "provisioner_uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_provisioner_mesh_uuid",
+            "unique": false,
+            "columnNames": [
+              "mesh_uuid"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_provisioner_mesh_uuid` ON `${TABLE_NAME}` (`mesh_uuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "mesh_network",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "mesh_uuid"
+            ],
+            "referencedColumns": [
+              "mesh_uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "nodes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`timestamp` INTEGER NOT NULL, `name` TEXT, `ttl` INTEGER, `blacklisted` INTEGER NOT NULL, `secureNetworkBeacon` INTEGER, `mesh_uuid` TEXT, `uuid` TEXT NOT NULL, `security` INTEGER NOT NULL, `unicast_address` INTEGER NOT NULL, `configured` INTEGER NOT NULL, `device_key` BLOB, `seq_number` INTEGER NOT NULL, `cid` INTEGER, `pid` INTEGER, `vid` INTEGER, `crpl` INTEGER, `netKeys` TEXT, `appKeys` TEXT, `mElements` TEXT, `networkTransmitCount` INTEGER, `networkIntervalSteps` INTEGER, `relayTransmitCount` INTEGER, `relayIntervalSteps` INTEGER, `friend` INTEGER, `lowPower` INTEGER, `proxy` INTEGER, `relay` INTEGER, PRIMARY KEY(`uuid`), FOREIGN KEY(`mesh_uuid`) REFERENCES `mesh_network`(`mesh_uuid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "mTimeStampInMillis",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nodeName",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "ttl",
+            "columnName": "ttl",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "blackListed",
+            "columnName": "blacklisted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "secureNetworkBeaconSupported",
+            "columnName": "secureNetworkBeacon",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "meshUuid",
+            "columnName": "mesh_uuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "uuid",
+            "columnName": "uuid",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "security",
+            "columnName": "security",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "unicastAddress",
+            "columnName": "unicast_address",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isConfigured",
+            "columnName": "configured",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceKey",
+            "columnName": "device_key",
+            "affinity": "BLOB",
+            "notNull": false
+          },
+          {
+            "fieldPath": "sequenceNumber",
+            "columnName": "seq_number",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "companyIdentifier",
+            "columnName": "cid",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "productIdentifier",
+            "columnName": "pid",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "versionIdentifier",
+            "columnName": "vid",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "crpl",
+            "columnName": "crpl",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mAddedNetKeys",
+            "columnName": "netKeys",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mAddedAppKeys",
+            "columnName": "appKeys",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mElements",
+            "columnName": "mElements",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "networkTransmitSettings.networkTransmitCount",
+            "columnName": "networkTransmitCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "networkTransmitSettings.networkIntervalSteps",
+            "columnName": "networkIntervalSteps",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "relaySettings.relayTransmitCount",
+            "columnName": "relayTransmitCount",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "relaySettings.relayIntervalSteps",
+            "columnName": "relayIntervalSteps",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nodeFeatures.friend",
+            "columnName": "friend",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nodeFeatures.lowPower",
+            "columnName": "lowPower",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nodeFeatures.proxy",
+            "columnName": "proxy",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "nodeFeatures.relay",
+            "columnName": "relay",
+            "affinity": "INTEGER",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "uuid"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_nodes_mesh_uuid",
+            "unique": false,
+            "columnNames": [
+              "mesh_uuid"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_nodes_mesh_uuid` ON `${TABLE_NAME}` (`mesh_uuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "mesh_network",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "mesh_uuid"
+            ],
+            "referencedColumns": [
+              "mesh_uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT, `group_address` INTEGER NOT NULL, `group_address_label` TEXT, `parent_address` INTEGER NOT NULL, `parent_address_label` TEXT, `mesh_uuid` TEXT, FOREIGN KEY(`mesh_uuid`) REFERENCES `mesh_network`(`mesh_uuid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "address",
+            "columnName": "group_address",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addressLabel",
+            "columnName": "group_address_label",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "parentAddress",
+            "columnName": "parent_address",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentAddressLabel",
+            "columnName": "parent_address_label",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "meshUuid",
+            "columnName": "mesh_uuid",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "id"
+          ],
+          "autoGenerate": true
+        },
+        "indices": [
+          {
+            "name": "index_groups_mesh_uuid",
+            "unique": false,
+            "columnNames": [
+              "mesh_uuid"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_groups_mesh_uuid` ON `${TABLE_NAME}` (`mesh_uuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "mesh_network",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "mesh_uuid"
+            ],
+            "referencedColumns": [
+              "mesh_uuid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "scene",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`mesh_uuid` TEXT, `name` TEXT, `addresses` TEXT, `number` INTEGER NOT NULL, PRIMARY KEY(`number`), FOREIGN KEY(`mesh_uuid`) REFERENCES `mesh_network`(`mesh_uuid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "meshUuid",
+            "columnName": "mesh_uuid",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "addresses",
+            "columnName": "addresses",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "number",
+            "columnName": "number",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "columnNames": [
+            "number"
+          ],
+          "autoGenerate": false
+        },
+        "indices": [
+          {
+            "name": "index_scene_mesh_uuid",
+            "unique": false,
+            "columnNames": [
+              "mesh_uuid"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_scene_mesh_uuid` ON `${TABLE_NAME}` (`mesh_uuid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "mesh_network",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "mesh_uuid"
+            ],
+            "referencedColumns": [
+              "mesh_uuid"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'dc74c1727a65404e3d1795816f05be43')"
+    ]
+  }
+}

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNetwork.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNetwork.java
@@ -736,7 +736,6 @@ abstract class BaseMeshNetwork {
                 ProvisionedMeshNode node = getNode(provisioner.getProvisionerUuid());
                 if (node == null) {
                     node = new ProvisionedMeshNode(provisioner, netKeys, appKeys);
-                    provisioner.setSequenceNumber(node.getSequenceNumber());
                     nodes.add(node);
                     notifyNodeAdded(node);
                 } else {
@@ -749,7 +748,6 @@ abstract class BaseMeshNetwork {
                             } else {
                                 sequenceNumber = sequenceNumbers.get(node.getUnicastAddress(), 0);
                             }
-                            provisioner.setSequenceNumber(sequenceNumber);
                             node = new ProvisionedMeshNode(provisioner, netKeys, appKeys);
                             nodes.set(i, node);
                             notifyNodeUpdated(node);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNetwork.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/BaseMeshNetwork.java
@@ -746,9 +746,10 @@ abstract class BaseMeshNetwork {
                             if (meshNode.getUnicastAddress() != provisioner.getProvisionerAddress()) {
                                 sequenceNumber = sequenceNumbers.get(provisioner.getProvisionerAddress());
                             } else {
-                                sequenceNumber = sequenceNumbers.get(node.getUnicastAddress(), 0);
+                                sequenceNumber = sequenceNumbers.get(node.getUnicastAddress(), node.getSequenceNumber());
                             }
                             node = new ProvisionedMeshNode(provisioner, netKeys, appKeys);
+                            node.setSequenceNumber(sequenceNumber);
                             nodes.set(i, node);
                             notifyNodeUpdated(node);
                             break;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
@@ -370,7 +370,7 @@ public class MeshManagerApi implements MeshMngrApi {
                                     final Provisioner provisioner = mMeshNetwork.getSelectedProvisioner();
                                     final ProvisionedMeshNode node = mMeshNetwork.getNode(provisioner.getProvisionerUuid());
                                     node.setSequenceNumber(0);
-                                    provisioner.setSequenceNumber(0);
+                                    //provisioner.setSequenceNumber(0);
                                 }
 
                                 //Updating the iv recovery flag

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshManagerApi.java
@@ -214,7 +214,7 @@ public class MeshManagerApi implements MeshMngrApi {
      * Allow Iv Index recovery over 42.
      * According to Bluetooth Mesh Profile 1.0.1, section 3.10.5, if the IV Index of the mesh
      * network increased by more than 42 since the last connection (which can take at least
-     * 48 weeks), the Node should be reprovisioned. However, as this library can be used to
+     * 48 weeks), the Node should be re-provisioned. However, as this library can be used to
      * provision other Nodes, it should not be blocked from sending messages to the network
      * only because the phone wasn't connected to the network for that time. This flag can
      * disable this check, effectively allowing such connection.
@@ -793,6 +793,8 @@ public class MeshManagerApi implements MeshMngrApi {
      */
     public final void resetMeshNetwork() {
         //We delete the existing network as the user has already given the
+        ivUpdateTestModeActive = false;
+        allowIvIndexRecoveryOver42 = false;
         final MeshNetwork meshNet = mMeshNetwork;
         deleteMeshNetworkFromDb(meshNet);
         final MeshNetwork newMeshNetwork = generateMeshNetwork();
@@ -825,6 +827,8 @@ public class MeshManagerApi implements MeshMngrApi {
         network.lastSelected = true;
         network.sequenceNumbers.clear(); //Clear the sequence numbers first
         network.loadSequenceNumbers();
+        ivUpdateTestModeActive = false;
+        allowIvIndexRecoveryOver42 = false;
         return network;
     }
 
@@ -1010,10 +1014,6 @@ public class MeshManagerApi implements MeshMngrApi {
 
     @SuppressWarnings("FieldCanBeLocal")
     private final NetworkLayerCallbacks networkLayerCallbacks = new NetworkLayerCallbacks() {
-        @Override
-        public ProvisionedMeshNode getNode(final int unicastAddress) {
-            return mMeshNetwork.getNode(unicastAddress);
-        }
 
         @Override
         public Provisioner getProvisioner() {
@@ -1047,6 +1047,11 @@ public class MeshManagerApi implements MeshMngrApi {
 
     @SuppressWarnings("FieldCanBeLocal")
     private final UpperTransportLayerCallbacks upperTransportLayerCallbacks = new UpperTransportLayerCallbacks() {
+
+        @Override
+        public ProvisionedMeshNode getNode(final int unicastAddress) {
+            return mMeshNetwork.getNode(unicastAddress);
+        }
 
         @Override
         public byte[] getIvIndex() {

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshNetworkDb.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/MeshNetworkDb.java
@@ -51,7 +51,7 @@ import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
         ProvisionedMeshNode.class,
         Group.class,
         Scene.class},
-        version = 8)
+        version = 9)
 abstract class MeshNetworkDb extends RoomDatabase {
 
     private static String TAG = MeshNetworkDb.class.getSimpleName();
@@ -102,6 +102,7 @@ abstract class MeshNetworkDb extends RoomDatabase {
                             .addMigrations(MIGRATION_5_6)
                             .addMigrations(MIGRATION_6_7)
                             .addMigrations(MIGRATION_7_8)
+                            .addMigrations(MIGRATION_8_9)
                             .build();
                 }
 
@@ -820,6 +821,13 @@ abstract class MeshNetworkDb extends RoomDatabase {
         }
     };
 
+    private static final Migration MIGRATION_8_9 = new Migration(8, 9) {
+        @Override
+        public void migrate(@NonNull SupportSQLiteDatabase database) {
+            migrateProvisioner8_9(database);
+        }
+    };
+
     private static void migrateMeshNetwork(final SupportSQLiteDatabase database) {
         database.execSQL("CREATE TABLE `mesh_network_temp` " +
                 "(`mesh_uuid` TEXT NOT NULL, " +
@@ -1142,7 +1150,6 @@ abstract class MeshNetworkDb extends RoomDatabase {
                         meshUuid);
                 provisioner.setProvisionerName(name);
                 provisioner.setProvisionerAddress(unicast);
-                provisioner.setSequenceNumber(sequenceNumber);
                 provisioner.setLastSelected(lastSelected);
                 provisioner.setGlobalTtl(globalTtl);
                 provisioners.add(provisioner);
@@ -1206,7 +1213,8 @@ abstract class MeshNetworkDb extends RoomDatabase {
         return keys;
     }
 
-    private static void addProvisionerNodes(@NonNull final SupportSQLiteDatabase database, @NonNull List<Provisioner> provisioners) {
+    private static void addProvisionerNodes(@NonNull final SupportSQLiteDatabase database,
+                                            @NonNull List<Provisioner> provisioners) {
         if (!provisioners.isEmpty()) {
             final List<NetworkKey> netKeys = getNetKeys(database);
             final List<ApplicationKey> appKeys = getAppKeys(database);
@@ -1336,7 +1344,7 @@ abstract class MeshNetworkDb extends RoomDatabase {
         }
     }
 
-    private static void migrateMeshNetwork7_8(final SupportSQLiteDatabase database) {
+    private static void migrateMeshNetwork7_8(@NonNull final SupportSQLiteDatabase database) {
         database.execSQL("ALTER TABLE mesh_network RENAME TO mesh_network_temp");
         database.execSQL("CREATE TABLE `mesh_network` " +
                 "(`mesh_uuid` TEXT NOT NULL, " +
@@ -1369,5 +1377,29 @@ abstract class MeshNetworkDb extends RoomDatabase {
             cursor.close();
         }
         database.execSQL("DROP TABLE mesh_network_temp");
+    }
+
+    private static void migrateProvisioner8_9(@NonNull final SupportSQLiteDatabase database) {
+        database.execSQL("ALTER TABLE provisioner RENAME TO provisioner_temp");
+        database.execSQL("CREATE TABLE `provisioner` " +
+                "(`provisioner_uuid` TEXT NOT NULL, " +
+                "`mesh_uuid` TEXT NOT NULL, " +
+                "`name` TEXT, " +
+                "`allocated_unicast_ranges` TEXT NOT NULL, " +
+                "`allocated_group_ranges` TEXT NOT NULL, " +
+                "`allocated_scene_ranges` TEXT NOT NULL, " +
+                "`provisioner_address` INTEGER," +
+                "`global_ttl` INTEGER NOT NULL, " +
+                "`last_selected` INTEGER NOT NULL, PRIMARY KEY(`provisioner_uuid`), " +
+                "FOREIGN KEY(`mesh_uuid`) REFERENCES `mesh_network`(`mesh_uuid`) ON UPDATE CASCADE ON DELETE CASCADE )");
+
+        database.execSQL("INSERT INTO provisioner (provisioner_uuid,  mesh_uuid, name,  " +
+                "allocated_unicast_ranges, allocated_group_ranges, allocated_scene_ranges, " +
+                "provisioner_address, global_ttl, last_selected) " +
+                "SELECT provisioner_uuid, mesh_uuid, name," +
+                "allocated_unicast_ranges, allocated_group_ranges, allocated_scene_ranges," +
+                "provisioner_address, global_ttl, last_selected FROM provisioner_temp");
+        database.execSQL("DROP TABLE provisioner_temp");
+        database.execSQL("CREATE INDEX index_provisioner_mesh_uuid ON `provisioner` (mesh_uuid)");
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/Provisioner.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/Provisioner.java
@@ -4,14 +4,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.text.TextUtils;
 
-import com.google.gson.annotations.Expose;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Locale;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
@@ -22,6 +14,15 @@ import androidx.room.Ignore;
 import androidx.room.Index;
 import androidx.room.PrimaryKey;
 import androidx.room.TypeConverters;
+
+import com.google.gson.annotations.Expose;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
 import no.nordicsemi.android.meshprovisioner.transport.ProvisionedMeshNode;
 import no.nordicsemi.android.meshprovisioner.utils.MeshAddress;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
@@ -74,10 +75,6 @@ public class Provisioner implements Parcelable {
     @Expose
     List<AllocatedSceneRange> allocatedSceneRanges = new ArrayList<>();
 
-    @ColumnInfo(name = "sequence_number")
-    @Expose
-    private int sequenceNumber;
-
     @ColumnInfo(name = "provisioner_address")
     @Expose
     private Integer provisionerAddress = null;
@@ -121,7 +118,6 @@ public class Provisioner implements Parcelable {
         in.readTypedList(allocatedUnicastRanges, AllocatedUnicastRange.CREATOR);
         in.readTypedList(allocatedGroupRanges, AllocatedGroupRange.CREATOR);
         in.readTypedList(allocatedSceneRanges, AllocatedSceneRange.CREATOR);
-        sequenceNumber = in.readInt();
         provisionerAddress = in.readInt();
         globalTtl = in.readInt();
         lastSelected = in.readByte() != 0;
@@ -246,15 +242,6 @@ public class Provisioner implements Parcelable {
         this.allocatedSceneRanges = allocatedSceneRanges;
     }
 
-
-    public int getSequenceNumber() {
-        return sequenceNumber;
-    }
-
-    public void setSequenceNumber(final int sequenceNumber) {
-        this.sequenceNumber = sequenceNumber;
-    }
-
     @Nullable
     public Integer getProvisionerAddress() {
         return provisionerAddress;
@@ -323,11 +310,6 @@ public class Provisioner implements Parcelable {
         this.lastSelected = lastSelected;
     }
 
-    public int incrementSequenceNumber() {
-        sequenceNumber = sequenceNumber + 1;
-        return sequenceNumber;
-    }
-
     @Override
     public int describeContents() {
         return 0;
@@ -341,7 +323,6 @@ public class Provisioner implements Parcelable {
         parcel.writeTypedList(allocatedUnicastRanges);
         parcel.writeTypedList(allocatedGroupRanges);
         parcel.writeTypedList(allocatedSceneRanges);
-        parcel.writeInt(sequenceNumber);
         parcel.writeInt(provisionerAddress);
         parcel.writeInt(globalTtl);
         parcel.writeByte((byte) (lastSelected ? 1 : 0));

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LowerTransportLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LowerTransportLayer.java
@@ -742,7 +742,7 @@ abstract class LowerTransportLayer extends UpperTransportLayer {
         controlMessage.setSrc(src);
         controlMessage.setDst(dst);
         controlMessage.setIvIndex(mUpperTransportLayerCallbacks.getIvIndex());
-        final int sequenceNumber = mMeshNode.incrementSequenceNumber();//(controlMessage.getSrc());
+        final int sequenceNumber = mUpperTransportLayerCallbacks.getNode(controlMessage.getSrc()).incrementSequenceNumber();//mMeshNode.incrementSequenceNumber();//(controlMessage.getSrc());
         final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(sequenceNumber);
         controlMessage.setSequenceNumber(sequenceNum);
         mBlockAckSent = true;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LowerTransportLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/LowerTransportLayer.java
@@ -32,7 +32,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 import no.nordicsemi.android.meshprovisioner.MeshManagerApi;
-import no.nordicsemi.android.meshprovisioner.Provisioner;
 import no.nordicsemi.android.meshprovisioner.control.BlockAcknowledgementMessage;
 import no.nordicsemi.android.meshprovisioner.opcodes.TransportLayerOpCodes;
 import no.nordicsemi.android.meshprovisioner.utils.ExtendedInvalidCipherTextException;
@@ -86,31 +85,6 @@ abstract class LowerTransportLayer extends UpperTransportLayer {
      * @param callbacks {@link LowerTransportLayerCallbacks} callbacks
      */
     abstract void setLowerTransportLayerCallbacks(@NonNull final LowerTransportLayerCallbacks callbacks);
-
-    /**
-     * Increments the sequence number and returns the new sequence number.
-     *
-     * @param src source address, which is the address of the provisioner
-     * @return Incremented sequence number.
-     */
-    protected abstract int incrementSequenceNumber(final int src);
-
-    /**
-     * Increments the sequence number and returns the new sequence number.
-     *
-     * @param provisioner provisioner
-     * @return Incremented sequence number.
-     */
-    protected abstract int incrementSequenceNumber(final Provisioner provisioner);
-
-    /**
-     * Increments the given sequence number.
-     *
-     * @param provisioner    provisioner
-     * @param sequenceNumber Sequence number to be incremented.
-     * @return Incremented sequence number.
-     */
-    protected abstract int incrementSequenceNumber(final Provisioner provisioner, @NonNull final byte[] sequenceNumber);
 
     /**
      * Creates the network layer pdu
@@ -768,7 +742,7 @@ abstract class LowerTransportLayer extends UpperTransportLayer {
         controlMessage.setSrc(src);
         controlMessage.setDst(dst);
         controlMessage.setIvIndex(mUpperTransportLayerCallbacks.getIvIndex());
-        final int sequenceNumber = incrementSequenceNumber(controlMessage.getSrc());
+        final int sequenceNumber = mMeshNode.incrementSequenceNumber();//(controlMessage.getSrc());
         final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(sequenceNumber);
         controlMessage.setSequenceNumber(sequenceNum);
         mBlockAckSent = true;

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshTransport.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshTransport.java
@@ -90,30 +90,6 @@ final class MeshTransport extends NetworkLayer {
         this.mUpperTransportLayerCallbacks = callbacks;
     }
 
-    @Override
-    protected int incrementSequenceNumber(final int src) {
-        return incrementSequenceNumber(mNetworkLayerCallbacks.getProvisioner(src));
-    }
-
-    @SuppressWarnings("ConstantConditions")
-    @Override
-    protected final int incrementSequenceNumber(final Provisioner provisioner) {
-        final int seqNumber = provisioner.incrementSequenceNumber();
-        final ProvisionedMeshNode node = mNetworkLayerCallbacks.getNode(provisioner.getProvisionerAddress());
-        node.setSequenceNumber(seqNumber);
-        return seqNumber;
-    }
-
-    @SuppressWarnings("ConstantConditions")
-    @Override
-    protected final int incrementSequenceNumber(final Provisioner provisioner, @NonNull final byte[] sequenceNumber) {
-        provisioner.setSequenceNumber(MeshParserUtils.getSequenceNumber(sequenceNumber));
-        final int seqNumber = provisioner.incrementSequenceNumber();
-        final ProvisionedMeshNode node = mNetworkLayerCallbacks.getNode(provisioner.getProvisionerAddress());
-        node.setSequenceNumber(seqNumber);
-        return seqNumber;
-    }
-
     /**
      * Creates the an acknowledgement message for the received segmented messages
      *
@@ -149,8 +125,8 @@ final class MeshTransport extends NetworkLayer {
                                           final int aid,
                                           final int aszmic,
                                           final int accessOpCode, final byte[] accessMessageParameters) {
-        final Provisioner provisioner = mNetworkLayerCallbacks.getProvisioner(src);
-        final int sequenceNumber = incrementSequenceNumber(provisioner);
+        final ProvisionedMeshNode node = mNetworkLayerCallbacks.getNode(src);
+        final int sequenceNumber = node.incrementSequenceNumber();
         final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(sequenceNumber);
 
         Log.v(TAG, "Src address: " + MeshAddress.formatAddress(src, false));
@@ -166,7 +142,7 @@ final class MeshTransport extends NetworkLayer {
         final AccessMessage message = new AccessMessage();
         message.setSrc(src);
         message.setDst(dst);
-        message.setTtl(provisioner.getGlobalTtl());
+        message.setTtl(node.getTtl());
         message.setIvIndex(mUpperTransportLayerCallbacks.getIvIndex());
         message.setSequenceNumber(sequenceNum);
         message.setDeviceKey(key);
@@ -208,7 +184,7 @@ final class MeshTransport extends NetworkLayer {
                                           final int accessOpCode,
                                           @Nullable final byte[] accessMessageParameters) {
         final Provisioner provisioner = mNetworkLayerCallbacks.getProvisioner(src);
-        final int sequenceNumber = incrementSequenceNumber(provisioner);
+        final int sequenceNumber = mMeshNode.incrementSequenceNumber();
         final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(sequenceNumber);
 
         Log.v(TAG, "Src address: " + MeshAddress.formatAddress(src, false));
@@ -270,7 +246,7 @@ final class MeshTransport extends NetworkLayer {
                                                 final int accessOpCode,
                                                 @Nullable final byte[] accessMessageParameters) {
         final Provisioner provisioner = mNetworkLayerCallbacks.getProvisioner(src);
-        final int sequenceNumber = incrementSequenceNumber(provisioner);
+        final int sequenceNumber = mMeshNode.incrementSequenceNumber();
         final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(sequenceNumber);
 
         Log.v(TAG, "Src address: " + MeshAddress.formatAddress(src, false));
@@ -318,7 +294,7 @@ final class MeshTransport extends NetworkLayer {
                                                          final int dst,
                                                          final int opcode, final byte[] parameters) {
         final Provisioner provisioner = mNetworkLayerCallbacks.getProvisioner(src);
-        final int sequenceNumber = incrementSequenceNumber(provisioner);
+        final int sequenceNumber = mMeshNode.incrementSequenceNumber();
         final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(sequenceNumber);
 
         Log.v(TAG, "Src address: " + MeshAddress.formatAddress(src, false));

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshTransport.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/MeshTransport.java
@@ -34,7 +34,6 @@ import java.util.UUID;
 
 import no.nordicsemi.android.meshprovisioner.ApplicationKey;
 import no.nordicsemi.android.meshprovisioner.MeshManagerApi;
-import no.nordicsemi.android.meshprovisioner.Provisioner;
 import no.nordicsemi.android.meshprovisioner.utils.MeshAddress;
 import no.nordicsemi.android.meshprovisioner.utils.MeshParserUtils;
 
@@ -125,7 +124,7 @@ final class MeshTransport extends NetworkLayer {
                                           final int aid,
                                           final int aszmic,
                                           final int accessOpCode, final byte[] accessMessageParameters) {
-        final ProvisionedMeshNode node = mNetworkLayerCallbacks.getNode(src);
+        final ProvisionedMeshNode node = mUpperTransportLayerCallbacks.getNode(src);
         final int sequenceNumber = node.incrementSequenceNumber();
         final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(sequenceNumber);
 
@@ -183,8 +182,8 @@ final class MeshTransport extends NetworkLayer {
                                           final int aszmic,
                                           final int accessOpCode,
                                           @Nullable final byte[] accessMessageParameters) {
-        final Provisioner provisioner = mNetworkLayerCallbacks.getProvisioner(src);
-        final int sequenceNumber = mMeshNode.incrementSequenceNumber();
+        final ProvisionedMeshNode node = mUpperTransportLayerCallbacks.getNode(src);
+        final int sequenceNumber = node.incrementSequenceNumber();
         final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(sequenceNumber);
 
         Log.v(TAG, "Src address: " + MeshAddress.formatAddress(src, false));
@@ -200,7 +199,7 @@ final class MeshTransport extends NetworkLayer {
         final AccessMessage message = new AccessMessage();
         message.setSrc(src);
         message.setDst(dst);
-        message.setTtl(provisioner.getGlobalTtl());
+        message.setTtl(node.getTtl());
         if (label != null) {
             message.setLabel(label);
         }
@@ -245,8 +244,8 @@ final class MeshTransport extends NetworkLayer {
                                                 final int aszmic,
                                                 final int accessOpCode,
                                                 @Nullable final byte[] accessMessageParameters) {
-        final Provisioner provisioner = mNetworkLayerCallbacks.getProvisioner(src);
-        final int sequenceNumber = mMeshNode.incrementSequenceNumber();
+        final ProvisionedMeshNode node = mUpperTransportLayerCallbacks.getNode(src);
+        final int sequenceNumber = node.incrementSequenceNumber();
         final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(sequenceNumber);
 
         Log.v(TAG, "Src address: " + MeshAddress.formatAddress(src, false));
@@ -263,7 +262,7 @@ final class MeshTransport extends NetworkLayer {
         message.setCompanyIdentifier(companyIdentifier);
         message.setSrc(src);
         message.setDst(dst);
-        message.setTtl(provisioner.getGlobalTtl());
+        message.setTtl(node.getTtl());
         if (label != null) {
             message.setLabel(label);
         }
@@ -293,8 +292,8 @@ final class MeshTransport extends NetworkLayer {
     final ControlMessage createProxyConfigurationMessage(final int src,
                                                          final int dst,
                                                          final int opcode, final byte[] parameters) {
-        final Provisioner provisioner = mNetworkLayerCallbacks.getProvisioner(src);
-        final int sequenceNumber = mMeshNode.incrementSequenceNumber();
+        final ProvisionedMeshNode node = mUpperTransportLayerCallbacks.getNode(src);
+        final int sequenceNumber = node.incrementSequenceNumber();
         final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(sequenceNumber);
 
         Log.v(TAG, "Src address: " + MeshAddress.formatAddress(src, false));
@@ -306,7 +305,7 @@ final class MeshTransport extends NetworkLayer {
         final ControlMessage message = new ControlMessage();
         message.setSrc(src);
         message.setDst(dst);
-        message.setTtl(provisioner.getGlobalTtl());
+        message.setTtl(node.getTtl());
         message.setTtl(PROXY_CONFIGURATION_TTL); //TTL for proxy configuration messages are set to 0
         message.setIvIndex(mUpperTransportLayerCallbacks.getIvIndex());
         message.setSequenceNumber(sequenceNum);

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NetworkLayer.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NetworkLayer.java
@@ -111,7 +111,7 @@ abstract class NetworkLayer extends LowerTransportLayer {
         final SparseArray<byte[]> encryptedPduPayload = new SparseArray<>();
         final List<byte[]> sequenceNumbers = new ArrayList<>();
 
-        final ProvisionedMeshNode node = mNetworkLayerCallbacks.getNode(message.getSrc());
+        final ProvisionedMeshNode node = mUpperTransportLayerCallbacks.getNode(message.getSrc());
 
         final int pduType = message.getPduType();
         switch (message.getPduType()) {
@@ -124,8 +124,9 @@ abstract class NetworkLayer extends LowerTransportLayer {
                 for (int i = 0; i < lowerTransportPduMap.size(); i++) {
                     final byte[] lowerTransportPdu = lowerTransportPduMap.get(i);
                     if (i != 0) {
-                        final int sequenceNumber = node.incrementSequenceNumber();
-                        message.setSequenceNumber(MeshParserUtils.getSequenceNumberBytes(sequenceNumber));
+                        node.setSequenceNumber(MeshParserUtils.getSequenceNumber(message.getSequenceNumber()));
+                        final byte[] sequenceNumber = MeshParserUtils.getSequenceNumberBytes(node.incrementSequenceNumber());
+                        message.setSequenceNumber(sequenceNumber);
                     }
                     sequenceNumbers.add(message.getSequenceNumber());
                     Log.v(TAG, "Sequence Number: " + MeshParserUtils.bytesToHex(sequenceNumbers.get(i), false));
@@ -139,7 +140,6 @@ abstract class NetworkLayer extends LowerTransportLayer {
                 lowerTransportPduMap = ((ControlMessage) message).getLowerTransportControlPdu();
                 for (int i = 0; i < lowerTransportPduMap.size(); i++) {
                     final byte[] lowerTransportPdu = lowerTransportPduMap.get(i);
-                    mNetworkLayerCallbacks.getProvisioner(message.getSrc());
                     final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(node.incrementSequenceNumber());
                     message.setSequenceNumber(sequenceNum);
                     sequenceNumbers.add(message.getSequenceNumber());
@@ -200,9 +200,10 @@ abstract class NetworkLayer extends LowerTransportLayer {
         byte[] encryptedNetworkPayload = null;
         final int pduType = message.getPduType();
         if (message.getPduType() == MeshManagerApi.PDU_TYPE_NETWORK) {
-            final ProvisionedMeshNode node = mNetworkLayerCallbacks.getNode(message.getSrc());
+            final ProvisionedMeshNode node = mUpperTransportLayerCallbacks.getNode(message.getSrc());
             final byte[] lowerTransportPdu = lowerTransportPduMap.get(segment);
-            final int sequenceNumber = node.incrementSequenceNumber();//incrementSequenceNumber(mNetworkLayerCallbacks.getProvisioner(), message.getSequenceNumber());
+            node.setSequenceNumber(MeshParserUtils.getSequenceNumber(message.getSequenceNumber()));
+            //final int sequenceNumber = node.incrementSequenceNumber();//incrementSequenceNumber(mNetworkLayerCallbacks.getProvisioner(), message.getSequenceNumber());
             final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(node.incrementSequenceNumber());
             message.setSequenceNumber(sequenceNum);
 

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NetworkLayerCallbacks.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/NetworkLayerCallbacks.java
@@ -30,13 +30,6 @@ import no.nordicsemi.android.meshprovisioner.Provisioner;
 public interface NetworkLayerCallbacks {
 
     /**
-     * Callback to get the mesh node from the list of provisioned mesh node.
-     *
-     * @param unicastAddress unicast address of the mesh node
-     */
-    ProvisionedMeshNode getNode(final int unicastAddress);
-
-    /**
      * Callback to retrieve the current provisioner of the network
      */
     Provisioner getProvisioner();

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProvisionedMeshNode.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProvisionedMeshNode.java
@@ -25,13 +25,6 @@ package no.nordicsemi.android.meshprovisioner.transport;
 import android.annotation.SuppressLint;
 import android.os.Parcel;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.RestrictTo;
 import androidx.annotation.VisibleForTesting;
@@ -39,6 +32,14 @@ import androidx.room.Entity;
 import androidx.room.ForeignKey;
 import androidx.room.Ignore;
 import androidx.room.Index;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import no.nordicsemi.android.meshprovisioner.ApplicationKey;
 import no.nordicsemi.android.meshprovisioner.Features;
 import no.nordicsemi.android.meshprovisioner.MeshNetwork;
@@ -126,7 +127,7 @@ public final class ProvisionedMeshNode extends ProvisionedBaseMeshNode {
         }
         if (provisioner.getProvisionerAddress() != null)
             unicastAddress = provisioner.getProvisionerAddress();
-        sequenceNumber = provisioner.getSequenceNumber();
+        sequenceNumber = 0;
         deviceKey = SecureUtils.generateRandomNumber();
         ttl = provisioner.getGlobalTtl();
         mTimeStampInMillis = System.currentTimeMillis();
@@ -572,5 +573,12 @@ public final class ProvisionedMeshNode extends ProvisionedBaseMeshNode {
             }
         }
         return false;
+    }
+
+    /**
+     * Increments the sequence number
+     */
+    public int incrementSequenceNumber(){
+        return sequenceNumber++;
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProvisionedMeshNode.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProvisionedMeshNode.java
@@ -241,11 +241,13 @@ public final class ProvisionedMeshNode extends ProvisionedBaseMeshNode {
 
     /**
      * Sets the sequence number
-     * <p>This is only meant to be used internally within the library, hence the Restricted</p>
+     * <p>
+     *     This is only meant to be used internally within the library.
+     *     However this is open now for users to set the sequence number manually in provisioner node.
+     * </p>
      *
      * @param sequenceNumber sequence number of the node
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY)
     public final void setSequenceNumber(final int sequenceNumber) {
         this.sequenceNumber = sequenceNumber;
     }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProvisionedMeshNode.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/ProvisionedMeshNode.java
@@ -581,6 +581,6 @@ public final class ProvisionedMeshNode extends ProvisionedBaseMeshNode {
      * Increments the sequence number
      */
     public int incrementSequenceNumber(){
-        return sequenceNumber++;
+        return sequenceNumber = sequenceNumber + 1;
     }
 }

--- a/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/UpperTransportLayerCallbacks.java
+++ b/android-nrf-mesh-library/meshprovisioner/src/main/java/no/nordicsemi/android/meshprovisioner/transport/UpperTransportLayerCallbacks.java
@@ -22,14 +22,22 @@
 
 package no.nordicsemi.android.meshprovisioner.transport;
 
-import java.util.UUID;
-
 import androidx.annotation.Nullable;
+
+import java.util.UUID;
 
 /**
  * Upper transport layer call backs
  */
 public interface UpperTransportLayerCallbacks {
+
+
+    /**
+     * Callback to get the mesh node from the list of provisioned mesh node.
+     *
+     * @param unicastAddress unicast address of the mesh node
+     */
+    ProvisionedMeshNode getNode(final int unicastAddress);
 
     /**
      * Returns the IV Index of the mesh network


### PR DESCRIPTION
 This fixes the following.
* Removes the duplicate sequence number field in the provisioner table. 
* If needed to change the sequence number of a provisioner, select the provisioner node from the nodes list using the `provisionerUuid` and use `node.setSequenceNumber(sequenceNumber)` 