### PR TITLE
Fix GATT Layer segmentation

### DIFF
--- a/mesh/src/main/java/no/nordicsemi/android/mesh/MeshManagerApi.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/MeshManagerApi.java
@@ -541,7 +541,6 @@ public class MeshManagerApi implements MeshMngrApi {
     }
 
     private byte[] removeSegmentation(final int mtuSize, final byte[] data) {
-        Log.d(TAG, "Data: " + MeshParserUtils.bytesToHex(data, false));
         int srcOffset = 0;
         int dstOffset = 0;
         final int chunks = (data.length + (mtuSize - 1)) / mtuSize;

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/MeshManagerApi.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/MeshManagerApi.java
@@ -541,6 +541,7 @@ public class MeshManagerApi implements MeshMngrApi {
     }
 
     private byte[] removeSegmentation(final int mtuSize, final byte[] data) {
+        Log.d(TAG, "Data: " + MeshParserUtils.bytesToHex(data, false));
         int srcOffset = 0;
         int dstOffset = 0;
         final int chunks = (data.length + (mtuSize - 1)) / mtuSize;
@@ -557,7 +558,8 @@ public class MeshManagerApi implements MeshMngrApi {
                 } else if (i == chunks - 1) {
                     System.arraycopy(data, srcOffset + 1, buffer, dstOffset, length);
                 } else {
-                    System.arraycopy(data, srcOffset + 1, buffer, dstOffset, length - 1);
+                    length = length - 1;
+                    System.arraycopy(data, srcOffset + 1, buffer, dstOffset, length);
                 }
                 srcOffset += mtuSize;
                 dstOffset += length;


### PR DESCRIPTION
*  Fixes issue #306 and #322 causing the provisioning to fail with firmware that support lower MTU(23). The GATT layer was reassembling messages with an invalid index causing some data to be ignored. This bug had been introduced while some refactoring going back to version 2.1.4.