### PR TITLE
Set TTL per message

### DIFF
--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ConfigMessageState.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ConfigMessageState.java
@@ -66,7 +66,8 @@ class ConfigMessageState extends MeshMessageState {
         final int aszmic = configMessage.getAszmic();
         final int opCode = configMessage.getOpCode();
         final byte[] parameters = configMessage.getParameters();
-        message = mMeshTransport.createMeshMessage(mSrc, mDst, mDeviceKey, akf, aid, aszmic, opCode, parameters);
+        message = mMeshTransport.createMeshMessage(mSrc, mDst, configMessage.messageTtl,
+                mDeviceKey, akf, aid, aszmic, opCode, parameters);
         configMessage.setMessage(message);
     }
 }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/GenericMessageState.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/GenericMessageState.java
@@ -73,7 +73,8 @@ class GenericMessageState extends MeshMessageState {
         final int aszmic = genericMessage.getAszmic();
         final int opCode = genericMessage.getOpCode();
         final byte[] parameters = genericMessage.getParameters();
-        message = mMeshTransport.createMeshMessage(mSrc, mDst, mLabel, key, akf, aid, aszmic, opCode, parameters);
+        message = mMeshTransport.createMeshMessage(mSrc, mDst, mLabel, genericMessage.messageTtl,
+                key, akf, aid, aszmic, opCode, parameters);
         genericMessage.setMessage(message);
     }
 

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/MeshMessage.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/MeshMessage.java
@@ -10,6 +10,7 @@ public abstract class MeshMessage {
     private final int mAszmic = 0;
     protected Message mMessage;
     byte[] mParameters;
+    protected Integer messageTtl = null;
 
     /**
      * Returns the application key flag used for this message.
@@ -78,4 +79,20 @@ public abstract class MeshMessage {
         return mMessage.getDst();
     }
 
+    /**
+     * Returns the TTL set for the mesh message
+     * @return TTL value or null if not set.
+     */
+    public Integer getMessageTtl() {
+        return messageTtl;
+    }
+
+    /**
+     * Sets the TTL for this message.
+     * If a TTL is not specified the message will use the default ttl set for the provisioner node.
+     * @param messageTtl
+     */
+    public void setMessageTtl(final Integer messageTtl) {
+        this.messageTtl = messageTtl;
+    }
 }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/MeshTransport.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/MeshTransport.java
@@ -26,12 +26,11 @@ import android.content.Context;
 import android.os.Handler;
 import android.util.Log;
 
+import java.util.UUID;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-
-import java.util.UUID;
-
 import no.nordicsemi.android.mesh.ApplicationKey;
 import no.nordicsemi.android.mesh.MeshManagerApi;
 import no.nordicsemi.android.mesh.utils.MeshAddress;
@@ -119,11 +118,13 @@ final class MeshTransport extends NetworkLayer {
      */
     final AccessMessage createMeshMessage(final int src,
                                           final int dst,
+                                          @Nullable final Integer ttl,
                                           final byte[] key,
                                           final int akf,
                                           final int aid,
                                           final int aszmic,
-                                          final int accessOpCode, final byte[] accessMessageParameters) {
+                                          final int accessOpCode,
+                                          final byte[] accessMessageParameters) {
         final ProvisionedMeshNode node = mUpperTransportLayerCallbacks.getNode(src);
         final int sequenceNumber = node.incrementSequenceNumber();
         final byte[] sequenceNum = MeshParserUtils.getSequenceNumberBytes(sequenceNumber);
@@ -141,7 +142,7 @@ final class MeshTransport extends NetworkLayer {
         final AccessMessage message = new AccessMessage();
         message.setSrc(src);
         message.setDst(dst);
-        message.setTtl(node.getTtl());
+        message.setTtl(ttl == null ? node.getTtl() : ttl);
         message.setIvIndex(mUpperTransportLayerCallbacks.getIvIndex());
         message.setSequenceNumber(sequenceNum);
         message.setDeviceKey(key);
@@ -176,6 +177,7 @@ final class MeshTransport extends NetworkLayer {
     final AccessMessage createMeshMessage(final int src,
                                           final int dst,
                                           @Nullable final UUID label,
+                                          @Nullable final Integer ttl,
                                           @NonNull final ApplicationKey key,
                                           final int akf,
                                           final int aid,
@@ -199,7 +201,7 @@ final class MeshTransport extends NetworkLayer {
         final AccessMessage message = new AccessMessage();
         message.setSrc(src);
         message.setDst(dst);
-        message.setTtl(node.getTtl());
+        message.setTtl(ttl == null ? node.getTtl() : ttl);
         if (label != null) {
             message.setLabel(label);
         }
@@ -238,6 +240,7 @@ final class MeshTransport extends NetworkLayer {
                                                 final int src,
                                                 final int dst,
                                                 @Nullable final UUID label,
+                                                @Nullable final Integer ttl,
                                                 @NonNull final ApplicationKey key,
                                                 final int akf,
                                                 final int aid,
@@ -262,7 +265,7 @@ final class MeshTransport extends NetworkLayer {
         message.setCompanyIdentifier(companyIdentifier);
         message.setSrc(src);
         message.setDst(dst);
-        message.setTtl(node.getTtl());
+        message.setTtl(ttl == null ? node.getTtl() : ttl);
         if (label != null) {
             message.setLabel(label);
         }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/VendorModelMessageAckedState.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/VendorModelMessageAckedState.java
@@ -61,16 +61,17 @@ class VendorModelMessageAckedState extends GenericMessageState {
 
     @Override
     protected final void createAccessMessage() {
-        final VendorModelMessageAcked vendorModelMessageAcked = (VendorModelMessageAcked) mMeshMessage;
-        final ApplicationKey key = vendorModelMessageAcked.getAppKey();
-        final int akf = vendorModelMessageAcked.getAkf();
-        final int aid = vendorModelMessageAcked.getAid();
-        final int aszmic = vendorModelMessageAcked.getAszmic();
-        final int opCode = vendorModelMessageAcked.getOpCode();
-        final byte[] parameters = vendorModelMessageAcked.getParameters();
-        final int companyIdentifier = vendorModelMessageAcked.getCompanyIdentifier();
-        message = mMeshTransport.createVendorMeshMessage(companyIdentifier, mSrc, mDst, mLabel, key, akf, aid, aszmic, opCode, parameters);
-        vendorModelMessageAcked.setMessage(message);
+        final VendorModelMessageAcked message = (VendorModelMessageAcked) mMeshMessage;
+        final ApplicationKey key = message.getAppKey();
+        final int akf = message.getAkf();
+        final int aid = message.getAid();
+        final int aszmic = message.getAszmic();
+        final int opCode = message.getOpCode();
+        final byte[] parameters = message.getParameters();
+        final int companyIdentifier = message.getCompanyIdentifier();
+        this.message = mMeshTransport.createVendorMeshMessage(companyIdentifier, mSrc, mDst, mLabel,
+                message.messageTtl, key, akf, aid, aszmic, opCode, parameters);
+        message.setMessage(this.message);
     }
 
     @Override

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/VendorModelMessageUnackedState.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/VendorModelMessageUnackedState.java
@@ -58,16 +58,17 @@ class VendorModelMessageUnackedState extends GenericMessageState {
 
     @Override
     protected final void createAccessMessage() {
-        final VendorModelMessageUnacked vendorModelMessageUnacked = (VendorModelMessageUnacked) mMeshMessage;
-        final ApplicationKey key = vendorModelMessageUnacked.getAppKey();
-        final int akf = vendorModelMessageUnacked.getAkf();
-        final int aid = vendorModelMessageUnacked.getAid();
-        final int aszmic = vendorModelMessageUnacked.getAszmic();
-        final int opCode = vendorModelMessageUnacked.getOpCode();
-        final byte[] parameters = vendorModelMessageUnacked.getParameters();
-        final int companyIdentifier = vendorModelMessageUnacked.getCompanyIdentifier();
-        message = mMeshTransport.createVendorMeshMessage(companyIdentifier, mSrc, mDst, mLabel, key, akf, aid, aszmic, opCode, parameters);
-        vendorModelMessageUnacked.setMessage(message);
+        final VendorModelMessageUnacked message = (VendorModelMessageUnacked) mMeshMessage;
+        final ApplicationKey key = message.getAppKey();
+        final int akf = message.getAkf();
+        final int aid = message.getAid();
+        final int aszmic = message.getAszmic();
+        final int opCode = message.getOpCode();
+        final byte[] parameters = message.getParameters();
+        final int companyIdentifier = message.getCompanyIdentifier();
+        this.message = mMeshTransport.createVendorMeshMessage(companyIdentifier, mSrc, mDst, mLabel, message.messageTtl,
+                key, akf, aid, aszmic, opCode, parameters);
+        message.setMessage(this.message);
     }
 
     @Override


### PR DESCRIPTION
* Adds support for setting a TTL per mesh message and if a custom TTL is not set the library will use the node's default TTL. TTL per message can be set by using `meshMessage.setMessageTtl(x)` on the message object.