### PR TITLE
Allows for having device MAC Address in the exported JSON.

### DIFF
--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/ProvisioningActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/ProvisioningActivity.java
@@ -125,6 +125,7 @@ public class ProvisioningActivity extends AppCompatActivity implements Injectabl
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
         mViewModel = new ViewModelProvider(this, mViewModelFactory).get(ProvisioningViewModel.class);
+        mViewModel.getNetworkLiveData().setMacAddress(deviceAddress);
         if (savedInstanceState == null)
             mViewModel.connect(this, device, false);
 
@@ -250,6 +251,7 @@ public class ProvisioningActivity extends AppCompatActivity implements Injectabl
             final UnprovisionedMeshNode node = mViewModel.getUnprovisionedMeshNode().getValue();
             if (node == null) {
                 device.setName(mViewModel.getNetworkLiveData().getNodeName());
+
                 mViewModel.getNrfMeshRepository().identifyNode(device);
                 return;
             }
@@ -548,6 +550,7 @@ public class ProvisioningActivity extends AppCompatActivity implements Injectabl
         if (node != null) {
             try {
                 node.setNodeName(mViewModel.getNetworkLiveData().getNodeName());
+                node.setMacAddress(mViewModel.getNetworkLiveData().getMacAddress());
                 setupProvisionerStateObservers(provisioningStatusContainer);
                 mProvisioningProgressBar.setVisibility(View.VISIBLE);
                 mViewModel.getMeshManagerApi().startProvisioning(node);
@@ -563,6 +566,7 @@ public class ProvisioningActivity extends AppCompatActivity implements Injectabl
         if (node != null) {
             try {
                 node.setNodeName(mViewModel.getNetworkLiveData().getNodeName());
+                node.setMacAddress(mViewModel.getNetworkLiveData().getMacAddress());
                 setupProvisionerStateObservers(provisioningStatusContainer);
                 mProvisioningProgressBar.setVisibility(View.VISIBLE);
                 mViewModel.getMeshManagerApi().startProvisioningWithStaticOOB(node);
@@ -578,6 +582,7 @@ public class ProvisioningActivity extends AppCompatActivity implements Injectabl
         if (node != null) {
             try {
                 node.setNodeName(mViewModel.getNetworkLiveData().getNodeName());
+                node.setMacAddress(mViewModel.getNetworkLiveData().getMacAddress());
                 setupProvisionerStateObservers(provisioningStatusContainer);
                 mProvisioningProgressBar.setVisibility(View.VISIBLE);
                 mViewModel.getMeshManagerApi().startProvisioningWithOutputOOB(node, action);
@@ -593,6 +598,7 @@ public class ProvisioningActivity extends AppCompatActivity implements Injectabl
         if (node != null) {
             try {
                 node.setNodeName(mViewModel.getNetworkLiveData().getNodeName());
+                node.setMacAddress(mViewModel.getNetworkLiveData().getMacAddress());
                 setupProvisionerStateObservers(provisioningStatusContainer);
                 mProvisioningProgressBar.setVisibility(View.VISIBLE);
                 mViewModel.getMeshManagerApi().startProvisioningWithInputOOB(node, action);

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/viewmodels/MeshNetworkLiveData.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/viewmodels/MeshNetworkLiveData.java
@@ -41,6 +41,7 @@ public class MeshNetworkLiveData extends LiveData<MeshNetworkLiveData> {
     private MeshNetwork meshNetwork;
     private ApplicationKey selectedAppKey;
     private String nodeName;
+    private String macAddress;
 
     MeshNetworkLiveData() {
 
@@ -149,5 +150,22 @@ public class MeshNetworkLiveData extends LiveData<MeshNetworkLiveData> {
      */
     public String getNodeName() {
         return nodeName;
+    }
+
+    /**
+     * Returns the node MAC Address
+     */
+    public String getMacAddress() {
+        return macAddress;
+    }
+
+    /**
+     * Sets the node MAC Address
+     *
+     * @param macAddress node mac address
+     */
+    public void setMacAddress(String macAddress) {
+        this.macAddress = macAddress;
+        postValue(this);
     }
 }

--- a/mesh/schemas/no.nordicsemi.android.mesh.MeshNetworkDb/9.json
+++ b/mesh/schemas/no.nordicsemi.android.mesh.MeshNetworkDb/9.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 9,
-    "identityHash": "dc74c1727a65404e3d1795816f05be43",
+    "identityHash": "1f01ef21443ee8b4019502ac5283b926",
     "entities": [
       {
         "tableName": "mesh_network",
@@ -311,7 +311,7 @@
       },
       {
         "tableName": "nodes",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`timestamp` INTEGER NOT NULL, `name` TEXT, `ttl` INTEGER, `blacklisted` INTEGER NOT NULL, `secureNetworkBeacon` INTEGER, `mesh_uuid` TEXT, `uuid` TEXT NOT NULL, `security` INTEGER NOT NULL, `unicast_address` INTEGER NOT NULL, `configured` INTEGER NOT NULL, `device_key` BLOB, `seq_number` INTEGER NOT NULL, `cid` INTEGER, `pid` INTEGER, `vid` INTEGER, `crpl` INTEGER, `netKeys` TEXT, `appKeys` TEXT, `mElements` TEXT, `networkTransmitCount` INTEGER, `networkIntervalSteps` INTEGER, `relayTransmitCount` INTEGER, `relayIntervalSteps` INTEGER, `friend` INTEGER, `lowPower` INTEGER, `proxy` INTEGER, `relay` INTEGER, PRIMARY KEY(`uuid`), FOREIGN KEY(`mesh_uuid`) REFERENCES `mesh_network`(`mesh_uuid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`timestamp` INTEGER NOT NULL, `name` TEXT, `MAC` TEXT, `ttl` INTEGER, `blacklisted` INTEGER NOT NULL, `secureNetworkBeacon` INTEGER, `mesh_uuid` TEXT, `uuid` TEXT NOT NULL, `security` INTEGER NOT NULL, `unicast_address` INTEGER NOT NULL, `configured` INTEGER NOT NULL, `device_key` BLOB, `seq_number` INTEGER NOT NULL, `cid` INTEGER, `pid` INTEGER, `vid` INTEGER, `crpl` INTEGER, `netKeys` TEXT, `appKeys` TEXT, `mElements` TEXT, `networkTransmitCount` INTEGER, `networkIntervalSteps` INTEGER, `relayTransmitCount` INTEGER, `relayIntervalSteps` INTEGER, `friend` INTEGER, `lowPower` INTEGER, `proxy` INTEGER, `relay` INTEGER, PRIMARY KEY(`uuid`), FOREIGN KEY(`mesh_uuid`) REFERENCES `mesh_network`(`mesh_uuid`) ON UPDATE CASCADE ON DELETE CASCADE )",
         "fields": [
           {
             "fieldPath": "mTimeStampInMillis",
@@ -322,6 +322,12 @@
           {
             "fieldPath": "nodeName",
             "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "macAddr",
+            "columnName": "MAC",
             "affinity": "TEXT",
             "notNull": false
           },
@@ -646,7 +652,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'dc74c1727a65404e3d1795816f05be43')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '1f01ef21443ee8b4019502ac5283b926')"
     ]
   }
 }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/provisionerstates/UnprovisionedBaseMeshNode.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/provisionerstates/UnprovisionedBaseMeshNode.java
@@ -44,6 +44,7 @@ abstract class UnprovisionedBaseMeshNode implements Parcelable {
     boolean isProvisioned;
     boolean isConfigured;
     protected String nodeName = "My Node";
+    protected String macAddress = "00:00:00:00:00:00";
     byte[] provisionerPublicKeyXY;
     byte[] provisioneePublicKeyXY;
     byte[] sharedECDHSecret;
@@ -100,6 +101,14 @@ abstract class UnprovisionedBaseMeshNode implements Parcelable {
     public final void setNodeName(@NonNull final String nodeName) {
         if (!TextUtils.isEmpty(nodeName))
             this.nodeName = nodeName;
+    }
+
+    public String getMacAddress() {
+        return macAddress;
+    }
+
+    public void setMacAddress(String macAddress) {
+        this.macAddress = macAddress;
     }
 
     public final int getUnicastAddress() {

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/provisionerstates/UnprovisionedMeshNode.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/provisionerstates/UnprovisionedMeshNode.java
@@ -41,6 +41,7 @@ public final class UnprovisionedMeshNode extends UnprovisionedBaseMeshNode {
         isProvisioned = in.readByte() != 0;
         isConfigured = in.readByte() != 0;
         nodeName = in.readString();
+        macAddress = in.readString();
         provisionerPublicKeyXY = in.createByteArray();
         provisioneePublicKeyXY = in.createByteArray();
         sharedECDHSecret = in.createByteArray();
@@ -74,6 +75,7 @@ public final class UnprovisionedMeshNode extends UnprovisionedBaseMeshNode {
         dest.writeByte((byte) (isProvisioned ? 1 : 0));
         dest.writeByte((byte) (isConfigured ? 1 : 0));
         dest.writeString(nodeName);
+        dest.writeString(macAddress);
         dest.writeByteArray(provisionerPublicKeyXY);
         dest.writeByteArray(provisioneePublicKeyXY);
         dest.writeByteArray(sharedECDHSecret);

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/NodeDeserializer.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/NodeDeserializer.java
@@ -112,6 +112,10 @@ public final class NodeDeserializer implements JsonSerializer<List<ProvisionedMe
 
             if (jsonObject.has("name"))
                 node.nodeName = jsonObject.get("name").getAsString();
+
+            if (jsonObject.has("MAC"))
+                node.macAddr = jsonObject.get("MAC").getAsString();
+
             deserializeHeartbeat(context, jsonObject, node);
             nodes.add(node);
         }
@@ -126,6 +130,7 @@ public final class NodeDeserializer implements JsonSerializer<List<ProvisionedMe
             final JsonObject nodeJson = new JsonObject();
             nodeJson.addProperty("UUID", MeshParserUtils.uuidToHex(node.getUuid()));
             nodeJson.addProperty("name", node.getNodeName());
+            nodeJson.addProperty("MAC", node.getMacAddr());
             nodeJson.addProperty("deviceKey", MeshParserUtils.bytesToHex(node.getDeviceKey(), false));
             nodeJson.addProperty("unicastAddress", MeshParserUtils.bytesToHex(MeshAddress.addressIntToBytes(node.getUnicastAddress()), false));
             nodeJson.addProperty("security", (node.getSecurity() == ProvisionedBaseMeshNode.HIGH) ? "high" : "low");

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ProvisionedBaseMeshNode.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ProvisionedBaseMeshNode.java
@@ -64,6 +64,11 @@ abstract class ProvisionedBaseMeshNode implements Parcelable {
     @ColumnInfo(name = "name")
     @Expose
     protected String nodeName = "My Node";
+
+    @ColumnInfo(name =  "MAC")
+    @Expose
+    protected String macAddr = "00:00:00:00:00:00";
+
     @ColumnInfo(name = "ttl")
     @Expose
     protected Integer ttl = 5;
@@ -190,6 +195,19 @@ abstract class ProvisionedBaseMeshNode implements Parcelable {
     public final void setNodeName(final String nodeName) {
         if (!TextUtils.isEmpty(nodeName))
             this.nodeName = nodeName;
+    }
+
+    /**
+     * Sets the MAC address of the node
+     * This is to be used only by the library
+     */
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
+    public void setMacAddr(String macAddr) {
+        this.macAddr = macAddr;
+    }
+
+    public String getMacAddr() {
+        return macAddr;
     }
 
     public final int getUnicastAddress() {

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ProvisionedMeshNode.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ProvisionedMeshNode.java
@@ -92,6 +92,7 @@ public final class ProvisionedMeshNode extends ProvisionedBaseMeshNode {
         uuid = node.getDeviceUuid().toString();
         isConfigured = node.isConfigured();
         nodeName = node.getNodeName();
+        macAddr = node.getMacAddress();
         mAddedNetKeys.add(new NodeKey(node.getKeyIndex()));
         mFlags = node.getFlags();
         unicastAddress = node.getUnicastAddress();
@@ -147,6 +148,7 @@ public final class ProvisionedMeshNode extends ProvisionedBaseMeshNode {
         uuid = in.readString();
         isConfigured = in.readByte() != 1;
         nodeName = in.readString();
+        macAddr = in.readString();
         in.readList(mAddedNetKeys, NodeKey.class.getClassLoader());
         mFlags = in.createByteArray();
         unicastAddress = in.readInt();
@@ -175,6 +177,7 @@ public final class ProvisionedMeshNode extends ProvisionedBaseMeshNode {
         dest.writeString(uuid);
         dest.writeByte((byte) (isConfigured ? 1 : 0));
         dest.writeString(nodeName);
+        dest.writeString(macAddr);
         dest.writeList(mAddedNetKeys);
         dest.writeByteArray(mFlags);
         dest.writeInt(unicastAddress);


### PR DESCRIPTION
In a project that we are currently implementing, our nodes are not only LPNs,
But also open the scan window for a bit, to detect nearby LPNs
This allows for social distancing detection, which is a feature much requested during the pandemic.

However, when the scan window is open, only the device mac address is detected, as opposed to the unicast address.
This JSON file provides a viable way to link the device address with the unicast address.