### PR TITLE
Device list not being cleared on scanner activity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -61,14 +61,14 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     // Required -- JUnit 4 framework
     testImplementation 'junit:junit:4.13'
-    implementation 'androidx.test:runner:1.2.0'
+    implementation 'androidx.test:runner:1.3.0'
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.google.android.material:material:1.3.0-alpha01'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'com.google.android.material:material:1.3.0-alpha03'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta7'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.2'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
 
     // Butter Knife
@@ -79,10 +79,10 @@ dependencies {
     // Android BLE Library
     implementation 'no.nordicsemi.android:ble:2.1.1'
 
-    implementation 'com.google.dagger:dagger:2.27'
+    implementation 'com.google.dagger:dagger:2.28.1'
     implementation 'com.google.dagger:dagger-android:2.27'
     implementation 'com.google.dagger:dagger-android-support:2.27'
-    annotationProcessor 'com.google.dagger:dagger-compiler:2.27'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.28.1'
     annotationProcessor 'com.google.dagger:dagger-android-processor:2.27'
     //implementation 'no.nordicsemi.android:mesh:2.3.0'
     implementation project(':mesh')

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/ble/ScannerActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/ble/ScannerActivity.java
@@ -172,9 +172,9 @@ public class ScannerActivity extends AppCompatActivity implements Injectable,
     @Override
     public void onItemClick(final ExtendedBluetoothDevice device) {
         //We must disconnect from any nodes that we are connected to before we start scanning.
-        mViewModel.disconnect();
+        if (mViewModel.getBleMeshManager().isConnected())
+            mViewModel.disconnect();
         final Intent intent;
-        stopScan();
         if (mScanWithProxyService) {
             intent = new Intent(this, ProvisioningActivity.class);
             intent.putExtra(Utils.EXTRA_DEVICE, device);
@@ -184,6 +184,7 @@ public class ScannerActivity extends AppCompatActivity implements Injectable,
             intent.putExtra(Utils.EXTRA_DEVICE, device);
             startActivityForResult(intent, Utils.CONNECT_TO_NETWORK);
         }
+        //stopScan();
     }
 
     @Override

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/ble/adapter/DevicesAdapter.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/ble/adapter/DevicesAdapter.java
@@ -23,9 +23,6 @@
 package no.nordicsemi.android.nrfmesh.ble.adapter;
 
 import android.content.Context;
-import androidx.annotation.NonNull;
-import androidx.fragment.app.FragmentActivity;
-import androidx.recyclerview.widget.RecyclerView;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -35,6 +32,9 @@ import android.widget.TextView;
 
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.fragment.app.FragmentActivity;
+import androidx.recyclerview.widget.RecyclerView;
 import butterknife.BindView;
 import butterknife.ButterKnife;
 import no.nordicsemi.android.nrfmesh.R;
@@ -116,7 +116,7 @@ public class DevicesAdapter extends RecyclerView.Adapter<DevicesAdapter.ViewHold
 
             view.findViewById(R.id.device_container).setOnClickListener(v -> {
                 if (mOnItemClickListener != null) {
-                    if(getAdapterPosition() > -1) {
+                    if(getAdapterPosition() > -1 && mDevices.size() > 0) {
                         mOnItemClickListener.onItemClick(mDevices.get(getAdapterPosition()));
                     }
                 }

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/viewmodels/NrfMeshRepository.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/viewmodels/NrfMeshRepository.java
@@ -315,11 +315,11 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
         //clearExtendedMeshNode();
         final LogSession logSession = Logger.newSession(context, null, device.getAddress(), device.getName());
         mBleMeshManager.setLogger(logSession);
-        final BluetoothDevice bluetoothDevice = device.getDevice();
         initIsConnectedLiveData(connectToNetwork);
         mConnectionState.postValue("Connecting....");
-        //Added a 1 second delay for connection, mostly to wait for a disconnection to complete before connecting.
-        mHandler.postDelayed(() -> mBleMeshManager.connect(bluetoothDevice).retry(3, 200).enqueue(), 1000);
+        //Added a 1 second delay for connection, mostly to wait for a disconnection to complete before connecting, in case a device was previously connected.
+        Log.d("AA", "Connect issued");
+        mBleMeshManager.connect(device.getDevice()).retry(3, 200).enqueue();
     }
 
     /**

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/viewmodels/ScannerLiveData.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/viewmodels/ScannerLiveData.java
@@ -60,7 +60,7 @@ public class ScannerLiveData extends LiveData<ScannerLiveData> {
         }
         // Update RSSI and name
         device.setRssi(result.getRssi());
-        device.setName(result.getScanRecord().getDeviceName());
+        device.setName(getDeviceName(result));
 
         postValue(this);
     }
@@ -79,7 +79,7 @@ public class ScannerLiveData extends LiveData<ScannerLiveData> {
         }
         // Update RSSI and name
         device.setRssi(result.getRssi());
-        device.setName(result.getScanRecord().getDeviceName());
+        device.setName(getDeviceName(result));
 
         postValue(this);
     }

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/viewmodels/ScannerLiveData.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/viewmodels/ScannerLiveData.java
@@ -22,13 +22,12 @@
 
 package no.nordicsemi.android.nrfmesh.viewmodels;
 
-import androidx.lifecycle.LiveData;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.LiveData;
 import no.nordicsemi.android.mesh.MeshBeacon;
 import no.nordicsemi.android.nrfmesh.adapter.ExtendedBluetoothDevice;
 import no.nordicsemi.android.support.v18.scanner.ScanResult;
@@ -82,6 +81,27 @@ public class ScannerLiveData extends LiveData<ScannerLiveData> {
         device.setRssi(result.getRssi());
         device.setName(result.getScanRecord().getDeviceName());
 
+        postValue(this);
+    }
+
+    /**
+     * Returns the device name from a scan record
+     *
+     * @param result ScanResult
+     * @return Device name found in the scan record or unknown
+     */
+    private String getDeviceName(final ScanResult result) {
+        if (result.getScanRecord() != null)
+            return result.getScanRecord().getDeviceName();
+        return "Unknown";
+    }
+
+    /**
+     * Clears the list of devices found.
+     */
+    void clear() {
+        mDevices.clear();
+        mUpdatedDeviceIndex = null;
         postValue(this);
     }
 

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/viewmodels/ScannerRepository.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/viewmodels/ScannerRepository.java
@@ -242,6 +242,7 @@ public class ScannerRepository {
         final BluetoothLeScannerCompat scanner = BluetoothLeScannerCompat.getScanner();
         scanner.stopScan(mScanCallbacks);
         mScannerStateLiveData.scanningStopped();
+        mScannerLiveData.clear();
     }
 
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.0.0'
+        classpath 'com.android.tools.build:gradle:4.0.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/mesh/build.gradle
+++ b/mesh/build.gradle
@@ -59,7 +59,7 @@ android {
 dependencies {
     // Required -- JUnit 4 framework
     testImplementation 'junit:junit:4.13'
-    testImplementation 'org.mockito:mockito-core:2.19.0'
+    testImplementation 'org.mockito|:mockito-core:2.19.0'
     androidTestImplementation 'org.mockito:mockito-android:2.6.3'
     implementation 'androidx.annotation:annotation:1.1.0'
     api 'no.nordicsemi.android:log:2.2.0'


### PR DESCRIPTION
* Fixes an issue where the device list not being cleared when return to the scanner screen
* A connection delay was being used in addition to the retries provided by the BLE library. This delay has been now removed.