### PR TITLE
Add callback to handle missing mesh node

### DIFF
--- a/mesh/src/main/java/no/nordicsemi/android/mesh/MeshStatusCallbacks.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/MeshStatusCallbacks.java
@@ -26,6 +26,7 @@ import androidx.annotation.NonNull;
 
 import no.nordicsemi.android.mesh.transport.ControlMessage;
 import no.nordicsemi.android.mesh.transport.MeshMessage;
+import no.nordicsemi.android.mesh.transport.ProvisionedMeshNode;
 
 /**
  * Callbacks to notify the status of the mesh messages
@@ -44,6 +45,15 @@ public interface MeshStatusCallbacks {
      * @param hasIncompleteTimerExpired Flag that notifies if the incomplete timer had expired
      */
     void onTransactionFailed(final int dst, final boolean hasIncompleteTimerExpired);
+
+    /**
+     * Called when a message is received from a node that isn't in the database.
+     *
+     * @param addr  Address of the node
+     * @return A ProvisionedMeshNode (which must have been added to the MeshNetwork), or null if the
+     *         message should be discarded.
+     */
+    ProvisionedMeshNode onUnknownNode(final int addr);
 
     /**
      * Notifies if an unknown pdu was received

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/BaseMeshMessageHandler.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/BaseMeshMessageHandler.java
@@ -118,7 +118,12 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
                     Log.v(TAG, "TTL for received message: " + ttl);
                     final int src = MeshParserUtils.unsignedBytesToInt(networkHeader[5], networkHeader[4]);
 
-                    final ProvisionedMeshNode node = network.getNode(src);
+                    ProvisionedMeshNode node = network.getNode(src);
+
+                    if (node == null) {
+                        node = this.mStatusCallbacks.onUnknownNode(src);
+                    }
+
                     if (node == null) {
                         continue;
                     }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/BaseMeshMessageHandler.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/BaseMeshMessageHandler.java
@@ -105,62 +105,79 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
         final int nid = pdu[1] & 0x7F;
         final int acceptedIvIndex = network.getIvIndex().getIvIndex();
         int ivIndex = acceptedIvIndex == 0 ? 0 : acceptedIvIndex - 1;
+
+        NetworkKey networkKey = null;
+        SecureUtils.K2Output k2Output = null;
+        byte[] decryptedPayload = null;
+        MeshMessageState state = null;
+        ProvisionedMeshNode node = null;
+        byte[] sequenceNumber = null;
+        Integer src = null;
+        byte[] networkHeader = null;
+
+        //Here we go through all the network keys and filter out network keys based on the nid.
+        for (int i = 0; i < networkKeys.size(); i++) {
+            networkKey = networkKeys.get(i);
+            k2Output = SecureUtils.calculateK2(networkKey.getKey(), SecureUtils.K2_MASTER_INPUT);
+            if (nid == k2Output.getNid()) {
+                break;
+            }
+        }
+
+        if(networkKey == null || k2Output == null) {
+            // TODO: We should probably throw a helpful error here?
+            // I don't know when this could happen.
+            return;
+        }
+
         while (ivIndex <= ivIndex + 1) {
-            //Here we go through all the network keys and filter out network keys based on the nid.
-            for (int i = 0; i < networkKeys.size(); i++) {
-                NetworkKey networkKey = networkKeys.get(i);
-                final SecureUtils.K2Output k2Output = SecureUtils.calculateK2(networkKey.getKey(), SecureUtils.K2_MASTER_INPUT);
-                if (nid == k2Output.getNid()) {
-                    final byte[] networkHeader = deObfuscateNetworkHeader(pdu, MeshParserUtils.intToBytes(ivIndex), k2Output.getPrivacyKey());
-                    final int ctlTtl = networkHeader[0];
-                    final int ctl = (ctlTtl >> 7) & 0x01;
-                    final int ttl = ctlTtl & 0x7F;
-                    Log.v(TAG, "TTL for received message: " + ttl);
-                    final int src = MeshParserUtils.unsignedBytesToInt(networkHeader[5], networkHeader[4]);
+            networkHeader = deObfuscateNetworkHeader(pdu, MeshParserUtils.intToBytes(ivIndex), k2Output.getPrivacyKey());
+            final int ctlTtl = networkHeader[0];
+            final int ctl = (ctlTtl >> 7) & 0x01;
+            final int ttl = ctlTtl & 0x7F;
+            Log.v(TAG, "TTL for received message: " + ttl);
+            src = MeshParserUtils.unsignedBytesToInt(networkHeader[5], networkHeader[4]);
 
-                    ProvisionedMeshNode node = network.getNode(src);
+            node = network.getNode(src);
 
-                    if (node == null) {
-                        node = this.mStatusCallbacks.onUnknownNode(src);
-                    }
+            if (node == null) {
+                continue;
+            }
 
-                    if (node == null) {
-                        continue;
-                    }
+            sequenceNumber = ByteBuffer.allocate(3).order(ByteOrder.BIG_ENDIAN).put(networkHeader, 1, 3).array();
+            Log.v(TAG, "Sequence number of received access message: " + MeshParserUtils.getSequenceNumber(sequenceNumber));
+            //TODO validate ivi
+            byte[] nonce;
+            try {
+                final int networkPayloadLength = pdu.length - (2 + networkHeader.length);
+                final byte[] transportPdu = new byte[networkPayloadLength];
+                System.arraycopy(pdu, 8, transportPdu, 0, networkPayloadLength);
 
-                    final byte[] sequenceNumber = ByteBuffer.allocate(3).order(ByteOrder.BIG_ENDIAN).put(networkHeader, 1, 3).array();
-                    Log.v(TAG, "Sequence number of received access message: " + MeshParserUtils.getSequenceNumber(sequenceNumber));
-                    //TODO validate ivi
-                    byte[] nonce;
-                    try {
-                        final int networkPayloadLength = pdu.length - (2 + networkHeader.length);
-                        final byte[] transportPdu = new byte[networkPayloadLength];
-                        System.arraycopy(pdu, 8, transportPdu, 0, networkPayloadLength);
-                        final byte[] decryptedPayload;
-                        final MeshMessageState state;
-                        if (pdu[0] == MeshManagerApi.PDU_TYPE_NETWORK) {
-                            nonce = createNetworkNonce((byte) ctlTtl, sequenceNumber, src, MeshParserUtils.intToBytes(ivIndex));
-                            decryptedPayload = SecureUtils.decryptCCM(transportPdu, k2Output.getEncryptionKey(), nonce, SecureUtils.getNetMicLength(ctl));
-                            state = getState(src);
-                        } else {
-                            nonce = createProxyNonce(sequenceNumber, src, MeshParserUtils.intToBytes(ivIndex));
-                            decryptedPayload = SecureUtils.decryptCCM(transportPdu, k2Output.getEncryptionKey(), nonce, SecureUtils.getNetMicLength(ctl));
-                            state = getState(MeshAddress.UNASSIGNED_ADDRESS);
-                        }
-                        if (state != null) {
-                            //TODO look in to proxy filter messages
-                            ((DefaultNoOperationMessageState) state).parseMeshPdu(node, pdu, networkHeader, decryptedPayload, ivIndex, sequenceNumber);
-                            return;
-                        }
-                    } catch (InvalidCipherTextException ex) {
-                        if (i == networkKeys.size() - 1) {
-                            throw new ExtendedInvalidCipherTextException(ex.getMessage(), ex.getCause(), TAG);
-                        }
-                    }
+                if (pdu[0] == MeshManagerApi.PDU_TYPE_NETWORK) {
+                    nonce = createNetworkNonce((byte) ctlTtl, sequenceNumber, src, MeshParserUtils.intToBytes(ivIndex));
+                    decryptedPayload = SecureUtils.decryptCCM(transportPdu, k2Output.getEncryptionKey(), nonce, SecureUtils.getNetMicLength(ctl));
+                    state = getState(src);
+                } else {
+                    nonce = createProxyNonce(sequenceNumber, src, MeshParserUtils.intToBytes(ivIndex));
+                    decryptedPayload = SecureUtils.decryptCCM(transportPdu, k2Output.getEncryptionKey(), nonce, SecureUtils.getNetMicLength(ctl));
+                    state = getState(MeshAddress.UNASSIGNED_ADDRESS);
                 }
+            } catch (InvalidCipherTextException ex) {
+                throw new ExtendedInvalidCipherTextException(ex.getMessage(), ex.getCause(), TAG);
             }
             ivIndex++;
         }
+
+        if (node == null) {
+            node = this.mStatusCallbacks.onUnknownNode(src);
+        }
+
+        if (node == null || state == null) {
+            return;
+        }
+
+        //TODO look in to proxy filter messages
+        ((DefaultNoOperationMessageState) state).parseMeshPdu(node, pdu, networkHeader, decryptedPayload, ivIndex, sequenceNumber);
     }
 
     @Override


### PR DESCRIPTION
For our application, we have a need for different instances of the application to be able to join an existing network. The network and application key(s) can be shared out of band, but on joining we receive no messages from nodes.

This PR allows an application to respond to messages which have been received from unknown nodes. The implementing application can then chose to create a new `ProvisionedMeshNode` object (see https://github.com/NordicSemiconductor/Android-nRF-Mesh-Library/pull/366), then continue to process the received message.