### PR TITLE
Add a method for adding nodes to the network

### DIFF
--- a/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java
@@ -1157,12 +1157,16 @@ abstract class BaseMeshNetwork {
         for (ProvisionedMeshNode node : nodes) {
             if (node.getUuid().equalsIgnoreCase(meshNode.getUuid())) {
                 nodes.set(index, meshNode); //replace a node if uuid matches
+                notifyNodeUpdated(meshNode);
                 return true;
             }
             index++;
         }
-
-        return nodes.add(meshNode);
+        if (nodes.add(meshNode)) {
+            notifyNodeAdded(meshNode);
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java
@@ -1137,6 +1137,35 @@ abstract class BaseMeshNetwork {
     }
 
     /**
+     * Adds a mesh node to the list of provisioned nodes
+     *
+     * <p>
+     * Note that This method should only be used to add debug Nodes, or Nodes
+     * that have already been provisioned.
+     * </p>
+     *
+     * @param meshNode node to be added
+     * @return true if added and false otherwise
+     */
+    public boolean addNode(@NonNull final ProvisionedMeshNode meshNode) {
+        ProvisionedMeshNode sameAddressNode = getNode(meshNode.getUnicastAddress());
+        if (sameAddressNode != null) {
+            throw new IllegalStateException("cant add node with conflicting unicast address");
+        }
+
+        int index = 0;
+        for (ProvisionedMeshNode node : nodes) {
+            if (node.getUuid().equalsIgnoreCase(meshNode.getUuid())) {
+                nodes.set(index, meshNode); //replace a node if uuid matches
+                return true;
+            }
+            index++;
+        }
+
+        return nodes.add(meshNode);
+    }
+
+    /**
      * Deletes a mesh node from the list of provisioned nodes
      *
      * <p>

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java
@@ -1152,6 +1152,17 @@ abstract class BaseMeshNetwork {
         if (sameAddressNode != null) {
             throw new IllegalStateException("cant add node with conflicting unicast address");
         }
+        boolean hasMatchingKey = false;
+        for (NodeKey key: meshNode.getAddedNetKeys()){
+            for (NetworkKey key2: this.netKeys){
+                hasMatchingKey = key.getIndex() == key2.getKeyIndex();
+                if (hasMatchingKey) break;
+            }
+            if (hasMatchingKey) break;
+        }
+        if (!hasMatchingKey) {
+            throw new IllegalStateException("can't add node with no overlapping network keys");
+        }
 
         int index = 0;
         for (ProvisionedMeshNode node : nodes) {


### PR DESCRIPTION
Currently there is not a way to add nodes to the network as there is in the [ios version](https://github.com/NordicSemiconductor/IOS-nRF-Mesh-Library/blob/f9a09aafe091e9597b99c6d615278a681d79561c/nRFMeshProvision/Classes/Mesh%20API/MeshNetwork%2BNodes.swift#L127-L156). This adds a method that:
* errors if the address of the node being added conflicts with pre-existing nodes
* updates an existing node if their uuids match
* appends the node to the end of the list if there were no matches

This is useful in the case where you are interacting with a network that contains already provisioned nodes.