### PR TITLE
fix: don't acknowledge segmented packets sent from broadcast addresses

### DIFF
--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/LowerTransportLayer.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/LowerTransportLayer.java
@@ -510,7 +510,9 @@ abstract class LowerTransportLayer extends UpperTransportLayer {
                     } else {
                         mSegmentedAccessBlockAck = BlockAcknowledgementMessage.calculateBlockAcknowledgement(mSegmentedAccessBlockAck, segO);
                         Log.v(TAG, "SEG O BLOCK ACK VAL: " + mSegmentedAccessBlockAck);
-                        handleImmediateBlockAcks(seqZero, ttl, blockAckSrc, blockAckDst, segN);
+                        if (MeshAddress.isValidUnicastAddress(dst)) {
+                            handleImmediateBlockAcks(seqZero, ttl, blockAckSrc, blockAckDst, segN);
+                        }
 
                         final AccessMessage accessMessage = new AccessMessage();
                         accessMessage.setAszmic(szmic);


### PR DESCRIPTION
some segmented packets were being acknowledged if they came from a broadcast address causing a crash when there was not a node for that address found in the network.