### PR TITLE
Fix crash when receiving messages unknown segmented messages 

### DIFF
--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/viewmodels/NrfMeshRepository.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/viewmodels/NrfMeshRepository.java
@@ -503,7 +503,6 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
         }
     }
 
-    @SuppressWarnings("ConstantConditions")
     @Override
     public void onDeviceDisconnected(@NonNull final BluetoothDevice device) {
         Log.v(TAG, "Disconnected");
@@ -769,7 +768,6 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
         }
     }
 
-    @SuppressWarnings("ConstantConditions")
     @Override
     public void onMeshMessageReceived(final int src, @NonNull final MeshMessage meshMessage) {
         final ProvisionedMeshNode node = mMeshNetwork.getNode(src);
@@ -981,7 +979,7 @@ public class NrfMeshRepository implements MeshProvisioningStatusCallbacks, MeshS
      * We should only update the selected node, since sending messages to group address will notify with nodes that is not on the UI
      */
     private boolean updateNode(@NonNull final ProvisionedMeshNode node) {
-        if (mProvisionedMeshNode.getUnicastAddress() == node.getUnicastAddress()) {
+        if (mProvisionedMeshNode != null && mProvisionedMeshNode.getUnicastAddress() == node.getUnicastAddress()) {
             mProvisionedMeshNode = node;
             mExtendedMeshNode.postValue(node);
             return true;


### PR DESCRIPTION
* Fixes a major bug where the library was crashing when receiving an unknown/unexpected segmented message.
  - When receiving a random message for example a sensor publication with a segmented message, the library  assuming that the publication received was a status message received for a request that had been sent out. This caused a null pointer when accessing the TTL for this non-existent message.
* Spec states, section 3.5.2.4 page 77, if the received segments were sent with TTL set to 0, it is recommended that the
corresponding Segment Acknowledgment message is sent with TTL set to 0. This is the expected behavior and now is correctly implemented.
* This also adds further improvements for #373. Thank you @saty9!