### PR TITLE
Feature/support key refresh procedure

### DIFF
--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/keys/AddAppKeyActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/keys/AddAppKeyActivity.java
@@ -96,16 +96,14 @@ public class AddAppKeyActivity extends AppCompatActivity implements
         adapter.setOnItemClickListener(this);
         netKeysRecyclerView.setAdapter(adapter);
 
-        binding.containerKey.getRoot().setOnClickListener(v -> {
-            final ApplicationKey appKey = mViewModel.getAppKeyLiveData().getValue();
-            final DialogFragmentEditAppKey fragment = DialogFragmentEditAppKey.newInstance(appKey.getKeyIndex(), appKey);
-            fragment.show(getSupportFragmentManager(), null);
-        });
+        binding.containerKey.getRoot().setOnClickListener(v ->
+                DialogFragmentEditAppKey.newInstance(mViewModel.getAppKeyLiveData().getValue())
+                        .show(getSupportFragmentManager(), null));
 
-        binding.containerKeyName.getRoot().setOnClickListener(v -> {
-            final DialogFragmentKeyName fragment = DialogFragmentKeyName.newInstance(mViewModel.getAppKeyLiveData().getValue().getName());
-            fragment.show(getSupportFragmentManager(), null);
-        });
+        binding.containerKeyName.getRoot().setOnClickListener(v ->
+                DialogFragmentKeyName.newInstance(mViewModel.getAppKeyLiveData().getValue().getName())
+                        .show(getSupportFragmentManager(), null));
+
         mViewModel.getAppKeyLiveData().observe(this, this::updateUi);
     }
 
@@ -124,10 +122,10 @@ public class AddAppKeyActivity extends AppCompatActivity implements
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         final int id = item.getItemId();
-        if(id == android.R.id.home){
+        if (id == android.R.id.home) {
             onBackPressed();
             return true;
-        } else if(id == R.id.action_save) {
+        } else if (id == R.id.action_save) {
             try {
                 if (mViewModel.addAppKey())
                     onBackPressed();
@@ -146,7 +144,7 @@ public class AddAppKeyActivity extends AppCompatActivity implements
     }
 
     @Override
-    public boolean onKeyUpdated(final int position, @NonNull final String key) {
+    public boolean onKeyUpdated(@NonNull final String key) {
         mViewModel.setKey(MeshParserUtils.toByteArray(key));
         return true;
     }

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/keys/AddNetKeyActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/keys/AddNetKeyActivity.java
@@ -79,16 +79,13 @@ public class AddNetKeyActivity extends AppCompatActivity implements MeshKeyListe
         binding.containerKeyIndex.title.setText(R.string.title_key_index);
         binding.containerKeyIndex.text.setVisibility(View.VISIBLE);
 
-        binding.containerKey.getRoot().setOnClickListener(v -> {
-            final NetworkKey netKey = mViewModel.getNetworkKeyLiveData().getValue();
-            final DialogFragmentEditNetKey fragment = DialogFragmentEditNetKey.newInstance(netKey.getKeyIndex(), netKey);
-            fragment.show(getSupportFragmentManager(), null);
-        });
+        binding.containerKey.getRoot().setOnClickListener(v ->
+                DialogFragmentEditNetKey.newInstance(mViewModel.getNetworkKeyLiveData().getValue())
+                        .show(getSupportFragmentManager(), null));
 
-        binding.containerKeyName.getRoot().setOnClickListener(v -> {
-            final DialogFragmentKeyName fragment = DialogFragmentKeyName.newInstance(mViewModel.getNetworkKeyLiveData().getValue().getName());
-            fragment.show(getSupportFragmentManager(), null);
-        });
+        binding.containerKeyName.getRoot().setOnClickListener(v ->
+                DialogFragmentKeyName.newInstance(mViewModel.getNetworkKeyLiveData().getValue().getName())
+                        .show(getSupportFragmentManager(), null));
 
         mViewModel.getNetworkKeyLiveData().observe(this, this::updateUi);
     }
@@ -110,10 +107,10 @@ public class AddNetKeyActivity extends AppCompatActivity implements MeshKeyListe
     @Override
     public boolean onOptionsItemSelected(final MenuItem item) {
         final int id = item.getItemId();
-        if(id == android.R.id.home){
+        if (id == android.R.id.home) {
             onBackPressed();
             return true;
-        } else if (id == R.id.action_save){
+        } else if (id == R.id.action_save) {
             try {
                 if (mViewModel.addNetKey())
                     onBackPressed();
@@ -132,7 +129,7 @@ public class AddNetKeyActivity extends AppCompatActivity implements MeshKeyListe
     }
 
     @Override
-    public boolean onKeyUpdated(final int position, @NonNull final String key) {
+    public boolean onKeyUpdated(@NonNull final String key) {
         mViewModel.setKey(MeshParserUtils.toByteArray(key));
         return true;
     }

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/keys/AddNetKeysActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/keys/AddNetKeysActivity.java
@@ -29,18 +29,11 @@ import com.google.android.material.snackbar.Snackbar;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import dagger.hilt.android.AndroidEntryPoint;
-import no.nordicsemi.android.mesh.MeshNetwork;
 import no.nordicsemi.android.mesh.NetworkKey;
-import no.nordicsemi.android.mesh.transport.ConfigKeyRefreshPhaseGet;
-import no.nordicsemi.android.mesh.transport.ConfigKeyRefreshPhaseSet;
 import no.nordicsemi.android.mesh.transport.ConfigNetKeyAdd;
 import no.nordicsemi.android.mesh.transport.ConfigNetKeyDelete;
 import no.nordicsemi.android.mesh.transport.ConfigNetKeyGet;
-import no.nordicsemi.android.mesh.transport.ConfigNetKeyUpdate;
 import no.nordicsemi.android.mesh.transport.MeshMessage;
-import no.nordicsemi.android.mesh.transport.ProvisionedMeshNode;
-import no.nordicsemi.android.mesh.utils.MeshParserUtils;
-import no.nordicsemi.android.mesh.utils.SecureUtils;
 import no.nordicsemi.android.nrfmesh.R;
 import no.nordicsemi.android.nrfmesh.keys.adapter.AddedNetKeyAdapter;
 import no.nordicsemi.android.nrfmesh.viewmodels.AddKeysViewModel;
@@ -50,8 +43,6 @@ public class AddNetKeysActivity extends AddKeysActivity implements
         AddedNetKeyAdapter.OnItemClickListener {
     private AddedNetKeyAdapter adapter;
 
-    NetworkKey key;
-
     @Override
     protected void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -60,27 +51,6 @@ public class AddNetKeysActivity extends AddKeysActivity implements
                 mViewModel.getNetworkLiveData().getMeshNetwork().getNetKeys(), mViewModel.getSelectedMeshNode());
         binding.recyclerViewKeys.setAdapter(adapter);
         adapter.setOnItemClickListener(this);
-
-        final MeshNetwork network = mViewModel.getNetworkLiveData().getMeshNetwork();
-
-        final ProvisionedMeshNode node = mViewModel.getSelectedMeshNode().getValue();
-        binding.krp.setOnClickListener(v -> {
-            key = mViewModel.getNetworkLiveData().getMeshNetwork().getNetKey(node.getAddedNetKeys().get(0).getIndex());
-            final byte[] nKey = MeshParserUtils.toByteArray(SecureUtils.generateRandomNetworkKey());
-            key = network.distributeNetKey(key, nKey);
-            mViewModel.getMeshManagerApi().createMeshPdu(node.getUnicastAddress(), new ConfigNetKeyUpdate(key));
-
-        });
-
-        binding.switchKey.setOnClickListener(v -> mViewModel.getMeshManagerApi().createMeshPdu(node.getUnicastAddress(), new ConfigKeyRefreshPhaseGet(key)));
-
-        binding.revokeOld.setOnClickListener(v -> {
-            if (mViewModel.getNetworkLiveData().getMeshNetwork().switchToNewKey(key)) {
-                mViewModel.getMeshManagerApi().createMeshPdu(node.getUnicastAddress(), new ConfigKeyRefreshPhaseSet(key, NetworkKey.PHASE_2));
-                network.revokeOldKey(key);
-                mViewModel.getMeshManagerApi().createMeshPdu(node.getUnicastAddress(), new ConfigKeyRefreshPhaseSet(key, NetworkKey.PHASE_3));
-            }
-        });
         updateClickableViews();
     }
 

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/keys/EditAppKeyActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/keys/EditAppKeyActivity.java
@@ -36,7 +36,6 @@ import androidx.lifecycle.ViewModelProvider;
 import androidx.recyclerview.widget.DefaultItemAnimator;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import dagger.hilt.android.AndroidEntryPoint;
-import no.nordicsemi.android.mesh.ApplicationKey;
 import no.nordicsemi.android.mesh.NetworkKey;
 import no.nordicsemi.android.mesh.utils.MeshParserUtils;
 import no.nordicsemi.android.nrfmesh.R;
@@ -93,16 +92,11 @@ public class EditAppKeyActivity extends AppCompatActivity implements
         mAdapter.setOnItemClickListener(this);
         binding.recyclerViewKeys.setAdapter(mAdapter);
 
-        binding.containerKey.getRoot().setOnClickListener(v -> {
-            final ApplicationKey appKey = mViewModel.getAppKeyLiveData().getValue();
-            final DialogFragmentEditAppKey fragment = DialogFragmentEditAppKey.newInstance(appKey.getKeyIndex(), appKey);
-            fragment.show(getSupportFragmentManager(), null);
-        });
+        binding.containerKey.getRoot().setOnClickListener(v -> DialogFragmentEditAppKey.newInstance(mViewModel.getAppKeyLiveData().getValue())
+                .show(getSupportFragmentManager(), null));
 
-        binding.containerKeyName.getRoot().setOnClickListener(v -> {
-            final DialogFragmentKeyName fragment = DialogFragmentKeyName.newInstance(mViewModel.getAppKeyLiveData().getValue().getName());
-            fragment.show(getSupportFragmentManager(), null);
-        });
+        binding.containerKeyName.getRoot().setOnClickListener(v -> DialogFragmentKeyName.
+                newInstance(mViewModel.getAppKeyLiveData().getValue().getName()).show(getSupportFragmentManager(), null));
 
         mViewModel.getAppKeyLiveData().observe(this, applicationKey -> {
             if (applicationKey != null) {
@@ -128,7 +122,7 @@ public class EditAppKeyActivity extends AppCompatActivity implements
     }
 
     @Override
-    public boolean onKeyUpdated(final int position, @NonNull final String key) {
+    public boolean onKeyUpdated(@NonNull final String key) {
         return mViewModel.setKey(key);
     }
 
@@ -137,7 +131,7 @@ public class EditAppKeyActivity extends AppCompatActivity implements
         try {
             mViewModel.setBoundNetKeyIndex(networkKey.getKeyIndex());
         } catch (IllegalArgumentException ex) {
-            mViewModel.displaySnackBar(this, binding.container,ex.getMessage(), Snackbar.LENGTH_LONG);
+            mViewModel.displaySnackBar(this, binding.container, ex.getMessage(), Snackbar.LENGTH_LONG);
         }
     }
 }

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/keys/EditNetKeyActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/keys/EditNetKeyActivity.java
@@ -32,7 +32,6 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
 import androidx.lifecycle.ViewModelProvider;
 import dagger.hilt.android.AndroidEntryPoint;
-import no.nordicsemi.android.mesh.NetworkKey;
 import no.nordicsemi.android.mesh.utils.MeshParserUtils;
 import no.nordicsemi.android.nrfmesh.R;
 import no.nordicsemi.android.nrfmesh.databinding.ActivityEditKeyBinding;
@@ -77,16 +76,13 @@ public class EditNetKeyActivity extends AppCompatActivity implements MeshKeyList
         binding.containerKeyIndex.title.setText(R.string.title_key_index);
         binding.containerKeyIndex.text.setVisibility(View.VISIBLE);
 
-        binding.containerKey.getRoot().setOnClickListener(v -> {
-            final NetworkKey networkKey = mViewModel.getNetworkKeyLiveData().getValue();
-            final DialogFragmentEditNetKey fragment = DialogFragmentEditNetKey.newInstance(networkKey.getKeyIndex(), networkKey);
-            fragment.show(getSupportFragmentManager(), null);
-        });
+        binding.containerKey.getRoot().setOnClickListener(v ->
+                DialogFragmentEditNetKey.newInstance(mViewModel.getNetworkKeyLiveData().getValue())
+                        .show(getSupportFragmentManager(), null));
 
-        binding.containerKeyName.getRoot().setOnClickListener(v -> {
-            final DialogFragmentKeyName fragment = DialogFragmentKeyName.newInstance(mViewModel.getNetworkKeyLiveData().getValue().getName());
-            fragment.show(getSupportFragmentManager(), null);
-        });
+        binding.containerKeyName.getRoot().setOnClickListener(v ->
+                DialogFragmentKeyName.newInstance(mViewModel.getNetworkKeyLiveData().getValue().getName())
+                        .show(getSupportFragmentManager(), null));
 
         mViewModel.getNetworkKeyLiveData().observe(this, networkKey -> {
             binding.containerKey.text.setText(MeshParserUtils.bytesToHex(networkKey.getKey(), false));
@@ -110,7 +106,7 @@ public class EditNetKeyActivity extends AppCompatActivity implements MeshKeyList
     }
 
     @Override
-    public boolean onKeyUpdated(final int position, @NonNull final String key) {
+    public boolean onKeyUpdated(@NonNull final String key) {
         return mViewModel.setKey(key);
     }
 }

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/keys/MeshKeyListener.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/keys/MeshKeyListener.java
@@ -15,9 +15,8 @@ public interface MeshKeyListener {
     /**
      * Invoked when the name of the key has been changed
      *
-     * @param position position of the key in the list
      * @param key      Updated key
      * @return true if the key was updated or false otherwise
      */
-    boolean onKeyUpdated(final int position, @NonNull final String key);
+    boolean onKeyUpdated(@NonNull final String key);
 }

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/keys/NetKeysActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/keys/NetKeysActivity.java
@@ -202,7 +202,6 @@ public class NetKeysActivity extends AppCompatActivity implements
         final NetworkKey key = (NetworkKey) viewHolder.getSwipeableView().getTag();
         try {
             if (removeNetKey(key)) {
-
                 displaySnackBar(key);
             }
         } catch (Exception ex) {

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/keys/dialogs/DialogFragmentEditAppKey.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/keys/dialogs/DialogFragmentEditAppKey.java
@@ -46,17 +46,14 @@ import static no.nordicsemi.android.mesh.utils.MeshParserUtils.validateKeyInput;
 
 public class DialogFragmentEditAppKey extends DialogFragment {
 
-    private static final String POSITION = "POSITION";
     private static final String APP_KEY = "APP_KEY";
 
     private DialogFragmentKeyInputBinding binding;
-    private int mPosition;
     private ApplicationKey mAppKey;
 
-    public static DialogFragmentEditAppKey newInstance(final int position, @NonNull final ApplicationKey appKey) {
+    public static DialogFragmentEditAppKey newInstance(final ApplicationKey appKey) {
         DialogFragmentEditAppKey fragmentNetworkKey = new DialogFragmentEditAppKey();
         final Bundle args = new Bundle();
-        args.putInt(POSITION, position);
         args.putParcelable(APP_KEY, appKey);
         fragmentNetworkKey.setArguments(args);
         return fragmentNetworkKey;
@@ -66,7 +63,6 @@ public class DialogFragmentEditAppKey extends DialogFragment {
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         if (getArguments() != null) {
-            mPosition = getArguments().getInt(POSITION);
             mAppKey = getArguments().getParcelable(APP_KEY);
         }
     }
@@ -114,7 +110,7 @@ public class DialogFragmentEditAppKey extends DialogFragment {
         alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {
             final String appKey = binding.textInput.getEditableText().toString().trim();
             try {
-                if (validateKeyInput(appKey) && ((MeshKeyListener) requireContext()).onKeyUpdated(mPosition, appKey))
+                if (validateKeyInput(appKey) && ((MeshKeyListener) requireContext()).onKeyUpdated(appKey))
                     dismiss();
             } catch (IllegalArgumentException ex) {
                 binding.textInputLayout.setError(ex.getMessage());

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/keys/dialogs/DialogFragmentEditNetKey.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/keys/dialogs/DialogFragmentEditNetKey.java
@@ -46,17 +46,14 @@ import static no.nordicsemi.android.mesh.utils.MeshParserUtils.validateKeyInput;
 
 public class DialogFragmentEditNetKey extends DialogFragment {
 
-    private static final String POSITION = "POSITION";
     private static final String NETWORK_KEY = "NETWORK_KEY";
 
     private DialogFragmentKeyInputBinding binding;
-    private int mPosition;
     private NetworkKey mNetworkKey;
 
-    public static DialogFragmentEditNetKey newInstance(final int position, @NonNull final NetworkKey networkKey) {
+    public static DialogFragmentEditNetKey newInstance(@NonNull final NetworkKey networkKey) {
         final DialogFragmentEditNetKey fragmentNetworkKey = new DialogFragmentEditNetKey();
         final Bundle args = new Bundle();
-        args.putInt(POSITION, position);
         args.putParcelable(NETWORK_KEY, networkKey);
         fragmentNetworkKey.setArguments(args);
         return fragmentNetworkKey;
@@ -66,7 +63,6 @@ public class DialogFragmentEditNetKey extends DialogFragment {
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         if (getArguments() != null) {
-            mPosition = getArguments().getInt(POSITION);
             mNetworkKey = getArguments().getParcelable(NETWORK_KEY);
         }
     }
@@ -115,7 +111,7 @@ public class DialogFragmentEditNetKey extends DialogFragment {
         alertDialog.getButton(DialogInterface.BUTTON_POSITIVE).setOnClickListener(v -> {
             final String networkKey = binding.textInput.getEditableText().toString().trim();
             try {
-                if (validateKeyInput(networkKey) && ((MeshKeyListener) requireActivity()).onKeyUpdated(mPosition, networkKey))
+                if (validateKeyInput(networkKey) && ((MeshKeyListener) requireActivity()).onKeyUpdated(networkKey))
                     dismiss();
             } catch (Exception ex) {
                 binding.textInputLayout.setError(ex.getMessage());

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/viewmodels/ScannerRepository.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/viewmodels/ScannerRepository.java
@@ -58,7 +58,6 @@ public class ScannerRepository {
     private static final String TAG = ScannerRepository.class.getSimpleName();
     private final Context mContext;
     private final MeshManagerApi mMeshManagerApi;
-    private String mNetworkId;
 
     /**
      * MutableLiveData containing the scanner state to notify MainActivity.
@@ -83,7 +82,7 @@ public class ScannerRepository {
                     final byte[] serviceData = Utils.getServiceData(result, BleMeshManager.MESH_PROXY_UUID);
                     if (mMeshManagerApi != null) {
                         if (mMeshManagerApi.isAdvertisingWithNetworkIdentity(serviceData)) {
-                            if (mMeshManagerApi.networkIdMatches(mNetworkId, serviceData)) {
+                            if (mMeshManagerApi.networkIdMatches(serviceData)) {
                                 updateScannerLiveData(result);
                             }
                         } else if (mMeshManagerApi.isAdvertisedWithNodeIdentity(serviceData)) {
@@ -204,15 +203,6 @@ public class ScannerRepository {
 
         if (mScannerStateLiveData.isScanning()) {
             return;
-        }
-
-        if (mFilterUuid.equals(BleMeshManager.MESH_PROXY_UUID)) {
-            final MeshNetwork network = mMeshManagerApi.getMeshNetwork();
-            if (network != null) {
-                if (!network.getNetKeys().isEmpty()) {
-                    mNetworkId = mMeshManagerApi.generateNetworkId(network.getNetKeys().get(0).getKey());
-                }
-            }
         }
 
         mScannerStateLiveData.scanningStarted();

--- a/app/src/main/res/layout/activity_node_configuration.xml
+++ b/app/src/main/res/layout/activity_node_configuration.xml
@@ -58,8 +58,8 @@
                 android:indeterminate="true"
                 android:indeterminateTint="@color/white"
                 android:visibility="invisible"
-                tools:visibility="visible"
-                tools:ignore="UnusedAttribute" />
+                tools:ignore="UnusedAttribute"
+                tools:visibility="visible" />
 
         </com.google.android.material.appbar.AppBarLayout>
 
@@ -396,6 +396,57 @@
                 </com.google.android.material.card.MaterialCardView>
 
                 <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/node_exclude_card"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/activity_vertical_margin"
+                    android:layout_marginBottom="@dimen/activity_vertical_margin"
+                    app:cardElevation="1dp">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical">
+
+                        <com.google.android.material.appbar.MaterialToolbar
+                            android:layout_width="match_parent"
+                            android:layout_height="?actionBarSize"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:logo="@drawable/ic_reset"
+                            app:title="@string/title_exclude_node"
+                            app:titleMarginStart="@dimen/toolbar_title_margin"
+                            app:titleTextAppearance="@style/Toolbar.TitleText" />
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="@dimen/activity_horizontal_margin"
+                            android:layout_marginEnd="@dimen/activity_horizontal_margin"
+                            android:paddingTop="@dimen/item_padding_top"
+                            android:paddingBottom="@dimen/item_padding_bottom"
+                            android:text="@string/node_exclusion_summary"
+                            android:textSize="16sp" />
+
+                        <include
+                            layout="@layout/layout_divider"
+                            android:layout_width="match_parent"
+                            android:layout_height="1dp" />
+
+                        <com.google.android.material.switchmaterial.SwitchMaterial
+                            style="@style/Widget.App.Switch"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="end"
+                            android:layout_marginStart="@dimen/item_padding_end"
+                            android:layout_marginEnd="@dimen/item_padding_start"
+                            android:padding="@dimen/item_padding_end"/>
+
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
                     android:id="@+id/node_reset_card"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
@@ -429,7 +480,7 @@
                             android:paddingTop="@dimen/item_padding_top"
                             android:paddingBottom="@dimen/item_padding_bottom"
                             android:text="@string/reset_node_rationale"
-                            android:textSize="16sp"/>
+                            android:textSize="16sp" />
 
                         <include
                             layout="@layout/layout_divider"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -650,9 +650,8 @@
     <string name="error_invalid_key_length">Error, key length must be 16-bytes</string>
     <string name="title_exclude_node">Exclude Node</string>
     <string name="exclude">Exclude</string>
-    <string name="node_exclusion_summary">Excluding will add the node to an exclusion list in the mesh network with the current IV Index.
-        The excluded node will be permanently removed once the Key Refresh Procedure is completed. IV Indexes in the exclusion list
-        will be cleared once the network transitions in to an IV Normal Operation after the IV Update procedure is completed and
-        the current IV Index of the network is greater by a count of two or more.</string>
+    <string name="excluded">Excluded</string>
+    <string name="node_exclusion_summary">If checked the node will be excluded from key exchange process. When the key refresh procedure is complete, this node will
+        no longer be able to receive or send messages to the mesh network.</string>
     <string name="continue_confirmation">This cannot be undone, do you want to continue?</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -24,13 +24,13 @@
 
 buildscript {
 
-    ext.hilt_version = '2.30.1-alpha'
+    ext.hilt_version = '2.31.2-alpha'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
 

--- a/mesh/build.gradle
+++ b/mesh/build.gradle
@@ -59,8 +59,8 @@ android {
 dependencies {
     // Required -- JUnit 4 framework
     testImplementation 'junit:junit:4.13.1'
-    testImplementation 'org.mockito:mockito-core:3.6.0'
-    androidTestImplementation 'org.mockito:mockito-android:3.6.0'
+    testImplementation 'org.mockito:mockito-core:3.7.7'
+    androidTestImplementation 'org.mockito:mockito-android:3.7.7'
     implementation 'androidx.annotation:annotation:1.1.0'
     api 'no.nordicsemi.android:log:2.3.0'
     // Spongycastle - Android implementation of Bouncy Castle

--- a/mesh/build.gradle
+++ b/mesh/build.gradle
@@ -68,9 +68,9 @@ dependencies {
     implementation 'com.madgag.spongycastle:prov:1.58.0.0'
     implementation 'com.google.code.gson:gson:2.8.6'
 
-    implementation 'androidx.room:room-runtime:2.2.6'
-    annotationProcessor 'androidx.room:room-compiler:2.2.6'
-    androidTestImplementation 'androidx.room:room-testing:2.2.6'
+    implementation 'androidx.room:room-runtime:2.3.0-beta01'
+    annotationProcessor 'androidx.room:room-compiler:2.3.0-beta01'
+    androidTestImplementation 'androidx.room:room-testing:2.3.0-beta01'
 
 }
 repositories {

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java
@@ -291,10 +291,8 @@ abstract class BaseMeshNetwork {
      * if the NetworkKey bound to the Application Key is in Phase 1 and the received app key value is different or when the received
      * AppKey value is the same as previously received value. Also note that sending a ConfigNetKeyUpdate during normal operation or
      * Phase 0 will switch the phase to phase 1.
-     * Once distribution is complete user MUST send {@link ConfigKeyRefreshPhaseSet}  message with phase set to Phase 2 before starting
-     * to use the new key by calling {@link #switchToNewKey(NetworkKey)}.
-     * <p>
-     * Please note to call distributeNetKey and update the provisioner nodes' keys before updating the other nodes.
+     * Once distribution is completed for provisioner call {@link #switchToNewKey(NetworkKey)} to start using the new key for sending messages
+     * and send {@link ConfigKeyRefreshPhaseSet} with phase set 2 to other nodes inorder to start seding messages using the new key.
      * </p>
      *
      * @param networkKey Network key

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java
@@ -555,9 +555,10 @@ abstract class BaseMeshNetwork {
      * <p>
      * This will only work if the NetworkKey bound to this ApplicationKey is in Phase 1 of the Key Refresh Procedure. Therefore the NetworkKey
      * must be updated first before updating it's bound application key. Call {@link #distributeNetKey(NetworkKey, byte[])} to initiate the
-     * Key Refresh Procedure to update a Network Key that's not in use by the provisioner or the nodes, if it has not been started already.
+     * Key Refresh Procedure to update a Network Key that's in use by the provisioner or the nodes, if it has not been started already.
+     * To update a key that's not in use call {@link #updateAppKey(ApplicationKey, String)}
      * <p>
-     * Once the provisioner nodes' AppKey is updated user must distribute the updated app key to the nodes. This can be done by sending
+     * Once the provisioner nodes' AppKey is updated user must distribute the updated AppKey to the nodes. This can be done by sending
      * {@link ConfigAppKeyUpdate} message with the new key.
      * </p>
      *

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java
@@ -291,8 +291,8 @@ abstract class BaseMeshNetwork {
      * if the NetworkKey bound to the Application Key is in Phase 1 and the received app key value is different or when the received
      * AppKey value is the same as previously received value. Also note that sending a ConfigNetKeyUpdate during normal operation or
      * Phase 0 will switch the phase to phase 1.
-     * Once distribution is completed for provisioner call {@link #switchToNewKey(NetworkKey)} to start using the new key for sending messages
-     * and send {@link ConfigKeyRefreshPhaseSet} with phase set 2 to other nodes inorder to start seding messages using the new key.
+     * Once distribution is completed, call {@link #switchToNewKey(NetworkKey)} and and send {@link ConfigKeyRefreshPhaseSet} to
+     * other nodes.
      * </p>
      *
      * @param networkKey Network key
@@ -319,12 +319,11 @@ abstract class BaseMeshNetwork {
     }
 
     /**
-     * Switches the new key, this will initiate the provisioner node transmitting  messages using the new keys but will
+     * Switches the new key, this will initiate the provisioner node transmitting messages using the new keys but will
      * support receiving messages using both old and the new key.
      *
      * <p>
-     * This is phase 2 of the Key Refresh Procedure and must be called ONLY after sending {@link ConfigKeyRefreshPhaseSet}
-     * message with phase set to Phase 2.
+     * This must be called after {@link #distributeNetKey(NetworkKey, byte[])}
      * </p>
      *
      * @param networkKey Network key to switch too
@@ -339,11 +338,11 @@ abstract class BaseMeshNetwork {
     }
 
     /**
-     * Revokes the old key making it unusable.
+     * Revokes the old key.
      * <p>
-     * This is phase 3 of the Key Refresh Procedure and must be called ONLY after sending {@link ConfigKeyRefreshPhaseSet}
-     * message with phase set to Phase 2 or 3. The library at this point will set the given Network Key's Phase to 0 which is
-     * Normal Operation.
+     * This initiates phase 3 of the Key Refresh Procedure in which user must send {@link ConfigKeyRefreshPhaseSet} message with phase set
+     * to Phase 3 to the other nodes going through the Key Refresh Procedure. The library at this point will set the given Network Key's
+     * Phase to 0 which is Normal Operation.
      * </p>
      *
      * @param networkKey Network key that was distributed
@@ -556,7 +555,7 @@ abstract class BaseMeshNetwork {
      * <p>
      * This will only work if the NetworkKey bound to this ApplicationKey is in Phase 1 of the Key Refresh Procedure. Therefore the NetworkKey
      * must be updated first before updating it's bound application key. Call {@link #distributeNetKey(NetworkKey, byte[])} to initiate the
-     * Key refresh procedure to update a Network Key that's not in use by the provisioner or the nodes, if it has not been started already.
+     * Key Refresh Procedure to update a Network Key that's not in use by the provisioner or the nodes, if it has not been started already.
      * <p>
      * Once the provisioner nodes' AppKey is updated user must distribute the updated app key to the nodes. This can be done by sending
      * {@link ConfigAppKeyUpdate} message with the new key.
@@ -1253,7 +1252,7 @@ abstract class BaseMeshNetwork {
     /**
      * Excludes a node from the mesh network.
      * The given node will marked as excluded and added to the exclusion list and the node will be removed once
-     * the Key refresh procedure is completed. After the IV update procedure, when the network transitions to an
+     * the Key Refresh Procedure is completed. After the IV update procedure, when the network transitions to an
      * IV Normal Operation state with a higher IV index, the exclusionList object that has the ivIndex property
      * value that is lower by a count of two (or more) than the current IV index of the network is removed from
      * the networkExclusions property array.

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/MeshKey.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/MeshKey.java
@@ -187,8 +187,8 @@ abstract class MeshKey implements Parcelable, Cloneable {
     }
 
     protected boolean distributeKey(@NonNull final byte[] key) {
-        if(!Arrays.equals(this.key, oldKey))
-            this.oldKey = this.key;
+        if (!Arrays.equals(this.key, oldKey))
+            setOldKey(this.key);
         setKey(key);
         return true;
     }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/MeshKey.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/MeshKey.java
@@ -114,9 +114,9 @@ abstract class MeshKey implements Parcelable, Cloneable {
      * @param key 16-byte network key
      */
     public void setKey(@NonNull final byte[] key) {
-        if (key.length != 16)
-            throw new IllegalArgumentException("Key must be of length 16!");
-        this.key = key;
+        if (valid(key)) {
+            this.key = key;
+        }
     }
 
     /**
@@ -178,5 +178,18 @@ abstract class MeshKey implements Parcelable, Cloneable {
     @Override
     public MeshKey clone() throws CloneNotSupportedException {
         return (MeshKey) super.clone();
+    }
+
+    protected boolean valid(@NonNull final byte[] key) {
+        if (key.length != 16)
+            throw new IllegalArgumentException("Key must be of length 16!");
+        return true;
+    }
+
+    protected boolean distributeKey(@NonNull final byte[] key) {
+        if(!Arrays.equals(this.key, oldKey))
+            this.oldKey = this.key;
+        this.key = key;
+        return true;
     }
 }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/MeshKey.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/MeshKey.java
@@ -189,7 +189,7 @@ abstract class MeshKey implements Parcelable, Cloneable {
     protected boolean distributeKey(@NonNull final byte[] key) {
         if(!Arrays.equals(this.key, oldKey))
             this.oldKey = this.key;
-        this.key = key;
+        setKey(key);
         return true;
     }
 }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/MeshManagerApi.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/MeshManagerApi.java
@@ -303,90 +303,91 @@ public class MeshManagerApi implements MeshMngrApi {
                     break;
                 case PDU_TYPE_MESH_BEACON:
                     //Validate SNBs against all network keys
+                    NetworkKey networkKey;
                     for (int i = 0; i < mMeshNetwork.getNetKeys().size(); i++) {
-                        final NetworkKey networkKey = mMeshNetwork.getNetKeys().get(i);
-                        if (networkKey != null) {
-                            final byte[] receivedBeaconData = new byte[unsegmentedPdu.length - 1];
-                            System.arraycopy(unsegmentedPdu, 1, receivedBeaconData, 0, receivedBeaconData.length);
-                            final SecureNetworkBeacon receivedBeacon = new SecureNetworkBeacon(receivedBeaconData);
+                        networkKey = mMeshNetwork.getNetKeys().get(i);
+                        final byte[] receivedBeaconData = new byte[unsegmentedPdu.length - 1];
+                        System.arraycopy(unsegmentedPdu, 1, receivedBeaconData, 0, receivedBeaconData.length);
+                        final SecureNetworkBeacon receivedBeacon = new SecureNetworkBeacon(receivedBeaconData);
 
-                            final byte[] n = networkKey.getKey();
-                            final int flags = receivedBeacon.getFlags();
-                            final byte[] networkId = SecureUtils.calculateK3(n);
-                            final int ivIndex = receivedBeacon.getIvIndex().getIvIndex();
-                            Log.d(TAG, "Received mesh beacon: " + receivedBeacon.toString());
+                        final byte[] n = networkKey.getTxNetworkKey();
+                        final int flags = receivedBeacon.getFlags();
+                        final byte[] networkId = SecureUtils.calculateK3(n);
+                        final int ivIndex = receivedBeacon.getIvIndex().getIvIndex();
+                        Log.d(TAG, "Received mesh beacon: " + receivedBeacon.toString());
 
-                            final SecureNetworkBeacon localSecureNetworkBeacon = SecureUtils.createSecureNetworkBeacon(n, flags, networkId, ivIndex);
-                            //Check the the beacon received is a valid by matching the authentication values
-                            if (Arrays.equals(receivedBeacon.getAuthenticationValue(), localSecureNetworkBeacon.getAuthenticationValue())) {
-                                Log.d(TAG, "Secure Network Beacon beacon authenticated.");
+                        final SecureNetworkBeacon localSecureNetworkBeacon = SecureUtils.createSecureNetworkBeacon(n, flags, networkId, ivIndex);
+                        //Check the the beacon received is a valid by matching the authentication values
+                        if (Arrays.equals(receivedBeacon.getAuthenticationValue(), localSecureNetworkBeacon.getAuthenticationValue())) {
+                            Log.d(TAG, "Secure Network Beacon beacon authenticated.");
 
-                                //  The library does not retransmit Secure Network Beacon.
-                                //  If this node is a member of a primary subnet and receives a Secure Network
-                                //  beacon on a secondary subnet, it will disregard it.
-                                if (mMeshNetwork.getPrimaryNetworkKey() != null && networkKey.keyIndex != 0) {
-                                    Log.d(TAG, "Discarding beacon for secondary subnet with network key index: " + networkKey.keyIndex);
-                                    return;
-                                }
+                            //  The library does not retransmit Secure Network Beacon.
+                            //  If this node is a member of a primary subnet and receives a Secure Network
+                            //  beacon on a secondary subnet, it will disregard it.
+                            if (mMeshNetwork.getPrimaryNetworkKey() != null && networkKey.keyIndex != 0) {
+                                Log.d(TAG, "Discarding beacon for secondary subnet with network key index: " + networkKey.keyIndex);
+                                return;
+                            }
 
-                                // Get the last IV Index.
-                                /// The last used IV Index for this mesh network.
-                                final IvIndex lastIvIndex = mMeshNetwork.getIvIndex();
-                                Log.d(TAG, "Last IV Index: " + lastIvIndex.getIvIndex());
-                                /// The date of the last change of IV Index or IV Update Flag.
-                                final Calendar lastTransitionDate = lastIvIndex.getTransitionDate();
-                                /// A flag whether the IV has recently been updated using IV Recovery procedure.
-                                /// The at-least-96h requirement for the duration of the current state will not apply.
-                                /// The node shall not execute more than one IV Index Recovery within a period of 192 hours.
-                                final boolean isIvRecoveryActive = lastIvIndex.getIvRecoveryFlag();
-                                /// The test mode disables the 96h rule, leaving all other behavior unchanged.
-                                final boolean isIvTestModeActive = ivUpdateTestModeActive;
+                            // Get the last IV Index.
+                            /// The last used IV Index for this mesh network.
+                            final IvIndex lastIvIndex = mMeshNetwork.getIvIndex();
+                            Log.d(TAG, "Last IV Index: " + lastIvIndex.getIvIndex());
+                            /// The date of the last change of IV Index or IV Update Flag.
+                            final Calendar lastTransitionDate = lastIvIndex.getTransitionDate();
+                            /// A flag whether the IV has recently been updated using IV Recovery procedure.
+                            /// The at-least-96h requirement for the duration of the current state will not apply.
+                            /// The node shall not execute more than one IV Index Recovery within a period of 192 hours.
+                            final boolean isIvRecoveryActive = lastIvIndex.getIvRecoveryFlag();
+                            /// The test mode disables the 96h rule, leaving all other behavior unchanged.
+                            final boolean isIvTestModeActive = ivUpdateTestModeActive;
 
-                                final boolean flag = allowIvIndexRecoveryOver42;
-                                if (!receivedBeacon.canOverwrite(lastIvIndex, lastTransitionDate, isIvRecoveryActive, isIvTestModeActive, flag)) {
-                                    String numberOfHoursSinceDate = ((Calendar.getInstance().getTimeInMillis() -
-                                            lastTransitionDate.getTimeInMillis()) / (3600 * 1000)) + "h";
-                                    Log.w(TAG, "Discarding beacon " + receivedBeacon.getIvIndex() +
-                                            ", last " + lastIvIndex.getIvIndex() + ", changed: "
-                                            + numberOfHoursSinceDate + "ago, test mode: " + ivUpdateTestModeActive);
-                                    return;
-                                }
+                            final boolean flag = allowIvIndexRecoveryOver42;
+                            if (!receivedBeacon.canOverwrite(lastIvIndex, lastTransitionDate, isIvRecoveryActive, isIvTestModeActive, flag)) {
+                                String numberOfHoursSinceDate = ((Calendar.getInstance().getTimeInMillis() -
+                                        lastTransitionDate.getTimeInMillis()) / (3600 * 1000)) + "h";
+                                Log.w(TAG, "Discarding beacon " + receivedBeacon.getIvIndex() +
+                                        ", last " + lastIvIndex.getIvIndex() + ", changed: "
+                                        + numberOfHoursSinceDate + "ago, test mode: " + ivUpdateTestModeActive);
+                                return;
+                            }
 
-                                final IvIndex receivedIvIndex = receivedBeacon.getIvIndex();
-                                mMeshNetwork.ivIndex = new IvIndex(receivedIvIndex.getIvIndex(), receivedIvIndex.isIvUpdateActive(), lastTransitionDate);
+                            final IvIndex receivedIvIndex = receivedBeacon.getIvIndex();
+                            mMeshNetwork.ivIndex = new IvIndex(receivedIvIndex.getIvIndex(), receivedIvIndex.isIvUpdateActive(), lastTransitionDate);
 
-                                if (mMeshNetwork.ivIndex.getIvIndex() > lastIvIndex.getIvIndex()) {
-                                    Log.i(TAG, "Applying: " + mMeshNetwork.ivIndex.getIvIndex());
-                                }
+                            if (mMeshNetwork.ivIndex.getIvIndex() > lastIvIndex.getIvIndex()) {
+                                Log.i(TAG, "Applying: " + mMeshNetwork.ivIndex.getIvIndex());
+                            }
 
-                                // If the IV Index used for transmitting messages effectively increased,
-                                // the Node shall reset the sequence number to 0x000000.
-                                if (mMeshNetwork.ivIndex.getTransmitIvIndex() > lastIvIndex.getTransmitIvIndex()) {
-                                    Log.i(TAG, "Resetting local sequence numbers to 0");
-                                    final Provisioner provisioner = mMeshNetwork.getSelectedProvisioner();
-                                    final ProvisionedMeshNode node = mMeshNetwork.getNode(provisioner.getProvisionerUuid());
-                                    node.setSequenceNumber(0);
-                                }
+                            // If the IV Index used for transmitting messages effectively increased,
+                            // the Node shall reset the sequence number to 0x000000.
+                            if (mMeshNetwork.ivIndex.getTransmitIvIndex() > lastIvIndex.getTransmitIvIndex()) {
+                                Log.i(TAG, "Resetting local sequence numbers to 0");
+                                final Provisioner provisioner = mMeshNetwork.getSelectedProvisioner();
+                                final ProvisionedMeshNode node = mMeshNetwork.getNode(provisioner.getProvisionerUuid());
+                                node.setSequenceNumber(0);
+                            }
 
-                                //Updating the iv recovery flag
-                                if (lastIvIndex != mMeshNetwork.ivIndex) {
-                                    final boolean ivRecovery = mMeshNetwork.getIvIndex().getIvIndex() > lastIvIndex.getIvIndex() + 1
-                                            && !receivedBeacon.getIvIndex().isIvUpdateActive();
-                                    mMeshNetwork.getIvIndex().setIvRecoveryFlag(ivRecovery);
-                                }
+                            //Updating the iv recovery flag
+                            if (lastIvIndex != mMeshNetwork.ivIndex) {
+                                final boolean ivRecovery = mMeshNetwork.getIvIndex().getIvIndex() > lastIvIndex.getIvIndex() + 1
+                                        && !receivedBeacon.getIvIndex().isIvUpdateActive();
+                                mMeshNetwork.getIvIndex().setIvRecoveryFlag(ivRecovery);
+                            }
 
-                                if (!mMeshNetwork.ivIndex.getIvRecoveryFlag()) {
-                                    final Iterator<Entry<Integer, ArrayList<Integer>>> iterator = mMeshNetwork.networkExclusions.entrySet().iterator();
-                                    while (iterator.hasNext()) {
-                                        final Entry<Integer, ArrayList<Integer>> exclusions = iterator.next();
-                                        final int expectedIncrement = exclusions.getKey() + 2;
-                                        if (mMeshNetwork.ivIndex.getIvIndex() >= expectedIncrement) {
-                                            // Clear the last known sequence number of addresses that are to be removed from the exclusion list.
-                                            for (Integer address : mMeshNetwork.networkExclusions.get(expectedIncrement)) {
-                                                mMeshNetwork.sequenceNumbers.removeAt(address);
-                                            }
-                                            iterator.remove();
-                                        }
+                            if (!mMeshNetwork.ivIndex.getIvRecoveryFlag()) {
+                                final Iterator<Entry<Integer, ArrayList<Integer>>> iterator = mMeshNetwork.networkExclusions.entrySet().iterator();
+                                while (iterator.hasNext()) {
+                                    final Entry<Integer, ArrayList<Integer>> exclusions = iterator.next();
+                                    final int expectedIncrement = exclusions.getKey() + 2;
+                                    if (mMeshNetwork.ivIndex.getIvIndex() >= expectedIncrement) {
+                                        // Clear the last known sequence number of addresses that are to be removed from the exclusion list.
+                                        // Decided to retain the last known sequence number as the IV Indexes increment the sequence number
+                                        // will be greater than the last known anyways
+                                        //for (Integer address : mMeshNetwork.networkExclusions.get(expectedIncrement)) {
+                                        //    mMeshNetwork.sequenceNumbers.removeAt(address);
+                                        //}
+                                        iterator.remove();
                                     }
                                 }
                             }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/MeshManagerApi.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/MeshManagerApi.java
@@ -768,6 +768,18 @@ public class MeshManagerApi implements MeshMngrApi {
     }
 
     @Override
+    public boolean networkIdMatches(@Nullable final byte[] serviceData) {
+        final byte[] advertisedNetworkId = getAdvertisedNetworkId(serviceData);
+        if (advertisedNetworkId != null) {
+            for (NetworkKey key : mMeshNetwork.getNetKeys()) {
+                if (Arrays.equals(key.getNetworkId(), advertisedNetworkId) || Arrays.equals(key.getOldNetworkId(), advertisedNetworkId))
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
     public boolean isAdvertisingWithNetworkIdentity(@Nullable final byte[] serviceData) {
         return serviceData != null && serviceData.length == 9
                 && serviceData[ADVERTISED_NETWORK_ID_OFFSET - 1] == ADVERTISEMENT_TYPE_NETWORK_ID;

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/MeshMngrApi.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/MeshMngrApi.java
@@ -190,8 +190,18 @@ interface MeshMngrApi {
      * @param networkId   network id of the mesh
      * @param serviceData advertised service data
      * @return returns true if the network ids match or false otherwise
+     * @deprecated use {@link #networkIdMatches(byte[])} instead.
      */
+    @Deprecated
     boolean networkIdMatches(@NonNull final String networkId, @NonNull final byte[] serviceData);
+
+    /**
+     * Checks if the generated network ids match. The network ID contained in the service data would be checked against a network id of each network key.
+     *
+     * @param serviceData advertised service data
+     * @return returns true if the network ids match or false otherwise
+     */
+    boolean networkIdMatches(@NonNull final byte[] serviceData);
 
     /**
      * Returns the advertised hash

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/MeshNetworkDb.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/MeshNetworkDb.java
@@ -83,8 +83,8 @@ abstract class MeshNetworkDb extends RoomDatabase {
 
     private static volatile MeshNetworkDb INSTANCE;
     private static final int NUMBER_OF_THREADS = 4;
-    static final ExecutorService databaseWriteExecutor =
-            Executors.newFixedThreadPool(NUMBER_OF_THREADS);
+    private static final ExecutorService databaseWriteExecutor =
+            Executors.newFixedThreadPool(4);
 
     /**
      * Returns the mesh database
@@ -157,14 +157,6 @@ abstract class MeshNetworkDb extends RoomDatabase {
                 scenesDao.insert(meshNetwork.scenes);
             }
         });
-        /*new InsertNetworkAsyncTask(meshNetworkDao,
-                netKeysDao,
-                appKeysDao,
-                provisionersDao,
-                nodesDao,
-                groupsDao,
-                scenesDao,
-                meshNetwork).execute();*/
     }
 
     void loadNetwork(@NonNull final MeshNetworkDao meshNetworkDao,
@@ -187,14 +179,6 @@ abstract class MeshNetworkDb extends RoomDatabase {
             }
             listener.onNetworkLoadedFromDb(meshNetwork);
         });
-        /*new LoadNetworkAsyncTask(dao,
-                netKeysDao,
-                appKeysDao,
-                provisionersDao,
-                nodesDao,
-                groupsDao,
-                scenesDao,
-                listener).execute();*/
     }
 
     void update(@NonNull final MeshNetworkDao dao, @NonNull final MeshNetwork meshNetwork) {
@@ -233,7 +217,7 @@ abstract class MeshNetworkDb extends RoomDatabase {
     }
 
     void delete(@NonNull final NetworkKeyDao dao, @NonNull final NetworkKey networkKey) {
-        databaseWriteExecutor.execute(() -> dao.delete(networkKey));
+        databaseWriteExecutor.execute(() -> dao.delete(networkKey.getKeyIndex()));
     }
 
     void insert(@NonNull final ApplicationKeyDao dao, @NonNull final ApplicationKey applicationKey) {
@@ -293,7 +277,7 @@ abstract class MeshNetworkDb extends RoomDatabase {
     }
 
     void delete(@NonNull final GroupDao dao, @NonNull final Group group) {
-        databaseWriteExecutor.execute(() -> dao.delete(group));
+        databaseWriteExecutor.execute(() -> dao.delete(group.getAddress()));
     }
 
     void insert(@NonNull final SceneDao dao, @NonNull final Scene scene) {
@@ -305,7 +289,7 @@ abstract class MeshNetworkDb extends RoomDatabase {
     }
 
     void delete(@NonNull final SceneDao dao, @NonNull final Scene scene) {
-        databaseWriteExecutor.execute(() -> dao.delete(scene));
+        databaseWriteExecutor.execute(() -> dao.delete(scene.getNumber()));
     }
 
     private static final Migration MIGRATION_1_2 = new Migration(1, 2) {

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/NetworkKey.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/NetworkKey.java
@@ -9,6 +9,7 @@ import java.lang.annotation.RetentionPolicy;
 
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.annotation.RestrictTo;
 import androidx.room.ColumnInfo;
 import androidx.room.Entity;
@@ -76,6 +77,7 @@ public final class NetworkKey extends MeshKey {
         phase = in.readInt();
         minSecurity = in.readByte() != 0;
         oldKey = in.createByteArray();
+        identityKey = in.createByteArray();
         timestamp = in.readLong();
     }
 
@@ -100,6 +102,7 @@ public final class NetworkKey extends MeshKey {
         dest.writeInt(phase);
         dest.writeByte((byte) (minSecurity ? 1 : 0));
         dest.writeByteArray(oldKey);
+        dest.writeByteArray(identityKey);
         dest.writeLong(timestamp);
     }
 
@@ -246,5 +249,14 @@ public final class NetworkKey extends MeshKey {
             return true;
         }
         return false;
+    }
+
+    protected byte[] getNetworkId() {
+        return SecureUtils.calculateK3(key);
+    }
+
+    @Nullable
+    protected byte[] getOldNetworkId() {
+        return SecureUtils.calculateK3(oldKey);
     }
 }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/NetworkKey.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/NetworkKey.java
@@ -130,6 +130,21 @@ public final class NetworkKey extends MeshKey {
     }
 
     /**
+     * Returns the NetworkKey based on the key refresh procedure phase.
+     *
+     * @return key
+     */
+    public byte[] getTxNetworkKey() {
+        switch (phase) {
+            case PHASE_1:
+                return oldKey;
+            case PHASE_2:
+            default:
+                return key;
+        }
+    }
+
+    /**
      * Uses min security
      *
      * @return true if minimum security or false otherwise
@@ -196,7 +211,7 @@ public final class NetworkKey extends MeshKey {
             if (phase == 0 || phase == 1) {
                 phase = 1;
                 timestamp = System.currentTimeMillis();
-                return super.distributeKey(newKey);
+                super.distributeKey(newKey);
             } else {
                 throw new IllegalArgumentException("A NetworkKey can only be updated once during a Key Refresh Procedure.");
             }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/NetworkKey.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/NetworkKey.java
@@ -204,14 +204,15 @@ public final class NetworkKey extends MeshKey {
      *
      * @param newKey New NetworkKey value
      * @return true if successful or false otherwise
-     * @throws IllegalArgumentException if a NetworkKey update is attempted twice
+     * @throws IllegalArgumentException if a NetworkKey distribution is attempted twice with different key
+     *                                  values during a single Key refresh procedure
      */
     protected boolean distributeKey(@NonNull final byte[] newKey) throws IllegalArgumentException {
         if (valid(newKey)) {
             if (phase == 0 || phase == 1) {
                 phase = 1;
                 timestamp = System.currentTimeMillis();
-                super.distributeKey(newKey);
+                return super.distributeKey(newKey);
             } else {
                 throw new IllegalArgumentException("A NetworkKey can only be updated once during a Key Refresh Procedure.");
             }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/data/ApplicationKeyDao.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/data/ApplicationKeyDao.java
@@ -1,16 +1,14 @@
 package no.nordicsemi.android.mesh.data;
 
+import androidx.annotation.RestrictTo;
 import androidx.room.Dao;
 import androidx.room.Delete;
 import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
 import androidx.room.Update;
-import androidx.annotation.RestrictTo;
-
 import no.nordicsemi.android.mesh.ApplicationKey;
 
 @RestrictTo(RestrictTo.Scope.LIBRARY)
-@SuppressWarnings("unused")
 @Dao
 public interface ApplicationKeyDao {
 

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/data/GroupDao.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/data/GroupDao.java
@@ -1,15 +1,13 @@
 package no.nordicsemi.android.mesh.data;
 
+import androidx.annotation.RestrictTo;
 import androidx.room.Dao;
-import androidx.room.Delete;
 import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
 import androidx.room.Update;
-import androidx.annotation.RestrictTo;
-
 import no.nordicsemi.android.mesh.Group;
 
-@SuppressWarnings("unused")
 @Dao
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public interface GroupDao {
@@ -20,6 +18,6 @@ public interface GroupDao {
     @Update(onConflict = OnConflictStrategy.REPLACE)
     void update(final Group group);
 
-    @Delete
-    void delete(final Group group);
+    @Query("DELETE FROM groups WHERE `group_address` = :groupAddress")
+    void delete(final int groupAddress);
 }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/data/NetworkKeyDao.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/data/NetworkKeyDao.java
@@ -1,23 +1,21 @@
 package no.nordicsemi.android.mesh.data;
 
 import androidx.room.Dao;
-import androidx.room.Delete;
 import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
 import androidx.room.Update;
-
 import no.nordicsemi.android.mesh.NetworkKey;
 
-@SuppressWarnings("unused")
 @Dao
 public interface NetworkKeyDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     void insert(final NetworkKey networkKey);
 
-    @Update(onConflict = OnConflictStrategy.REPLACE)
-    void update(final NetworkKey networkKey);
+    @Update
+    int update(final NetworkKey networkKey);
 
-    @Delete
-    void delete(final NetworkKey networkKey);
+    @Query("DELETE FROM network_key WHERE `index` = :index")
+    int delete(final int index);
 }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/data/SceneDao.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/data/SceneDao.java
@@ -1,15 +1,13 @@
 package no.nordicsemi.android.mesh.data;
 
+import androidx.annotation.RestrictTo;
 import androidx.room.Dao;
-import androidx.room.Delete;
 import androidx.room.Insert;
 import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
 import androidx.room.Update;
-import androidx.annotation.RestrictTo;
-
 import no.nordicsemi.android.mesh.Scene;
 
-@SuppressWarnings("unused")
 @Dao
 @RestrictTo(RestrictTo.Scope.LIBRARY)
 public interface SceneDao {
@@ -20,6 +18,6 @@ public interface SceneDao {
     @Update(onConflict = OnConflictStrategy.REPLACE)
     void update(final Scene scene);
 
-    @Delete
-    void delete(final Scene scene);
+    @Query("DELETE FROM scene WHERE `number` = :number")
+    void delete(final int number);
 }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ConfigKeyRefreshPhaseSet.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ConfigKeyRefreshPhaseSet.java
@@ -32,9 +32,8 @@ import no.nordicsemi.android.mesh.utils.MeshParserUtils;
 import static no.nordicsemi.android.mesh.opcodes.ConfigMessageOpCodes.CONFIG_KEY_REFRESH_PHASE_SET;
 
 /**
- * Createe the ConfigKeyRefreshPhaseSet message.
+ * Creates the ConfigKeyRefreshPhaseSet message.
  */
-@SuppressWarnings("unused")
 public class ConfigKeyRefreshPhaseSet extends ConfigMessage {
 
     private static final String TAG = ConfigKeyRefreshPhaseSet.class.getSimpleName();
@@ -43,7 +42,7 @@ public class ConfigKeyRefreshPhaseSet extends ConfigMessage {
     private final @KeyRefreshPhase int phase;
 
     /**
-     * Constructs ConfigKeyRefreshPhaseGet message.
+     * Constructs ConfigKeyRefreshPhaseSet message.
      *
      * @param networkKey {@link NetworkKey}
      */

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ConfigKeyRefreshPhaseStatus.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ConfigKeyRefreshPhaseStatus.java
@@ -76,7 +76,7 @@ public class ConfigKeyRefreshPhaseStatus extends ConfigStatusMessage implements 
 
         final ArrayList<Integer> keyIndexes = decode(mParameters.length, 1);
         mNetKeyIndex = keyIndexes.get(0);
-        phase = mParameters[2];
+        phase = mParameters[3];
 
         Log.v(TAG, "Status code: " + mStatusCode);
         Log.v(TAG, "Status message: " + mStatusCodeName);

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/DefaultNoOperationMessageState.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/DefaultNoOperationMessageState.java
@@ -11,7 +11,6 @@ import androidx.annotation.Nullable;
 import no.nordicsemi.android.mesh.Group;
 import no.nordicsemi.android.mesh.MeshManagerApi;
 import no.nordicsemi.android.mesh.MeshNetwork;
-import no.nordicsemi.android.mesh.NetworkKey;
 import no.nordicsemi.android.mesh.control.BlockAcknowledgementMessage;
 import no.nordicsemi.android.mesh.control.TransportControlMessage;
 import no.nordicsemi.android.mesh.models.ConfigurationServerModel;
@@ -327,13 +326,6 @@ class DefaultNoOperationMessageState extends MeshMessageState {
                     mMeshStatusCallbacks.onMeshMessageReceived(message.getSrc(), status);
                 } else if (message.getOpCode() == ConfigMessageOpCodes.CONFIG_KEY_REFRESH_PHASE_STATUS) {
                     final ConfigKeyRefreshPhaseStatus status = new ConfigKeyRefreshPhaseStatus(message);
-                    if (!isReceivedViaProxyFilter(message)) {
-                        final int index = status.getNetKeyIndex();
-                        final NetworkKey key = mInternalTransportCallbacks.getMeshNetwork().getNetKey(index);
-                        if (key != null) {
-                            key.setPhase(status.getPhase());
-                        }
-                    }
                     mInternalTransportCallbacks.updateMeshNetwork(status);
                     mMeshStatusCallbacks.onMeshMessageReceived(message.getSrc(), status);
                 } else if (message.getOpCode() == ConfigMessageOpCodes.CONFIG_GATT_PROXY_STATUS) {

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/DefaultNoOperationMessageState.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/DefaultNoOperationMessageState.java
@@ -160,7 +160,7 @@ class DefaultNoOperationMessageState extends MeshMessageState {
                             if (mMeshMessage instanceof ConfigAppKeyAdd) {
                                 node.setAddedAppKeyIndex(status.getAppKeyIndex());
                             } else if (mMeshMessage instanceof ConfigAppKeyUpdate) {
-                                node.updateAddedNetKey(status.getAppKeyIndex());
+                                node.updateAddedAppKey(status.getAppKeyIndex());
                             } else if (mMeshMessage instanceof ConfigAppKeyDelete) {
                                 node.removeAddedAppKeyIndex(status.getAppKeyIndex());
                             }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/NetworkLayer.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/NetworkLayer.java
@@ -24,10 +24,6 @@ package no.nordicsemi.android.mesh.transport;
 import android.util.Log;
 import android.util.SparseArray;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.annotation.VisibleForTesting;
-
 import org.spongycastle.crypto.InvalidCipherTextException;
 
 import java.nio.ByteBuffer;
@@ -35,6 +31,9 @@ import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import no.nordicsemi.android.mesh.MeshManagerApi;
 import no.nordicsemi.android.mesh.NetworkKey;
 import no.nordicsemi.android.mesh.Provisioner;
@@ -498,7 +497,7 @@ abstract class NetworkLayer extends LowerTransportLayer {
             final int netKeyIndex = message.getApplicationKey().getBoundNetKeyIndex();
             networkKey = mNetworkLayerCallbacks.getNetworkKey(netKeyIndex);
         }
-        return SecureUtils.calculateK2(networkKey.getKey(), SecureUtils.K2_MASTER_INPUT);
+        return SecureUtils.calculateK2(networkKey.getTxNetworkKey(), SecureUtils.K2_MASTER_INPUT);
     }
 
     /**

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ProvisionedBaseMeshNode.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ProvisionedBaseMeshNode.java
@@ -45,6 +45,7 @@ import androidx.room.Ignore;
 import androidx.room.PrimaryKey;
 import androidx.room.TypeConverters;
 import no.nordicsemi.android.mesh.Features;
+import no.nordicsemi.android.mesh.MeshNetwork;
 import no.nordicsemi.android.mesh.MeshTypeConverters;
 import no.nordicsemi.android.mesh.NodeKey;
 import no.nordicsemi.android.mesh.SecureNetworkBeacon;
@@ -52,7 +53,7 @@ import no.nordicsemi.android.mesh.utils.NetworkTransmitSettings;
 import no.nordicsemi.android.mesh.utils.RelaySettings;
 import no.nordicsemi.android.mesh.utils.SparseIntArrayParcelable;
 
-@SuppressWarnings({"unused", "WeakerAccess"})
+@SuppressWarnings({"WeakerAccess"})
 abstract class ProvisionedBaseMeshNode implements Parcelable {
 
     public static final int LOW = 0; //Low security
@@ -274,7 +275,7 @@ abstract class ProvisionedBaseMeshNode implements Parcelable {
      * Blacklist a node.
      *
      * @param blackListed true if blacklisted
-     * @deprecated Use {@link no.nordicsemi.android.mesh.MeshNetwork#excludeNode(ProvisionedMeshNode)} instead
+     * @deprecated Use {@link #setExcluded(boolean)} instead
      */
     @Deprecated
     @RestrictTo(RestrictTo.Scope.LIBRARY)
@@ -332,16 +333,21 @@ abstract class ProvisionedBaseMeshNode implements Parcelable {
     public @interface SecurityState {
     }
 
+    /**
+     * Returns true if the node is marked as excluded.
+     *
+     * @return true if marked as excluded or false otherwise.
+     */
     public boolean isExcluded() {
         return excluded;
     }
 
     /**
-     * Excludes a node and is meant to be used internally by the Room DB.
+     * Marks a node as excluded. Note that to exclude a node from a network, users must call
+     * {@link MeshNetwork#excludeNode(ProvisionedMeshNode)}
      *
-     * @param excluded True if the node is to be excluded
+     * @param excluded true if the node is to be excluded or false otherwise
      */
-    @RestrictTo(RestrictTo.Scope.LIBRARY)
     public void setExcluded(final boolean excluded) {
         this.excluded = excluded;
     }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/utils/SecureUtils.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/utils/SecureUtils.java
@@ -26,8 +26,6 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.util.Log;
 
-import androidx.annotation.NonNull;
-
 import com.google.gson.annotations.Expose;
 
 import org.spongycastle.crypto.BlockCipher;
@@ -45,6 +43,7 @@ import java.nio.ByteOrder;
 import java.nio.charset.Charset;
 import java.security.SecureRandom;
 
+import androidx.annotation.NonNull;
 import no.nordicsemi.android.mesh.SecureNetworkBeacon;
 
 @SuppressWarnings({"WeakerAccess", "CharsetObjectCanBeUsed"})
@@ -235,6 +234,9 @@ public class SecureUtils {
      * @param p    master input
      */
     public static K2Output calculateK2(final byte[] data, final byte[] p) {
+        if(data == null || p == null)
+            return null;
+
         final byte[] salt = calculateSalt(SMK2);
         final byte[] t = calculateCMAC(data, salt);
 
@@ -267,6 +269,8 @@ public class SecureUtils {
      * @param n network key
      */
     public static byte[] calculateK3(final byte[] n) {
+        if(n == null)
+            return null;
 
         final byte[] salt = calculateSalt(SMK3);
 

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/utils/SecureUtils.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/utils/SecureUtils.java
@@ -234,7 +234,7 @@ public class SecureUtils {
      * @param p    master input
      */
     public static K2Output calculateK2(final byte[] data, final byte[] p) {
-        if(data == null || p == null)
+        if (data == null || p == null)
             return null;
 
         final byte[] salt = calculateSalt(SMK2);
@@ -269,7 +269,7 @@ public class SecureUtils {
      * @param n network key
      */
     public static byte[] calculateK3(final byte[] n) {
-        if(n == null)
+        if (n == null)
             return null;
 
         final byte[] salt = calculateSalt(SMK3);
@@ -320,6 +320,8 @@ public class SecureUtils {
      * @return hash value
      */
     public static byte[] calculateIdentityKey(final byte[] n) {
+        if (n == null)
+            return null;
         final byte[] salt = calculateSalt(NKIK);
         ByteBuffer buffer = ByteBuffer.allocate(ID128.length + 1);
         buffer.put(ID128);


### PR DESCRIPTION
This PR implements the Key Refresh Procedure.

Basic workflow is complete. There is no UI for this feature in the Sample app, but required messages are supported in the library.. Android library does not support Configuration Server therefore, use the following API to update a Network Key and optionally bound Application Keys:

1. Initially, assume number of devices in the network, including the phone acting as Provisioner.
2. All Nodes know Primary Network Key with 2 bound Application Keys.
3. One of the devices was disposed, and to make it the proper way, all other devices need to update the Network Key to a different one, so the disposed one can no longer send or receive messages. The disposed device will be excluded from the Key Refresh Procedure.
4. Mark the required device "Excluded" (former Blacklisted).
https://github.com/NordicSemiconductor/Android-nRF-Mesh-Library/blob/8375851d803db5a8556240a7f340c04a98956f9e/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ProvisionedBaseMeshNode.java#L345-L353
5. Generate a new 16-byte key.
6.  Distribute the key to the provisioner https://github.com/NordicSemiconductor/Android-nRF-Mesh-Library/blob/8375851d803db5a8556240a7f340c04a98956f9e/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java#L276-L319
7. Send `ConfigNetKeyUpdate` message to all non-excluded Nodes. This step will distribute the new key to all Nodes. They will all go to Phase 1 of Key Refresh Procedure, also called Key Distribution.
6. In that phase they will continue to send messages using the old key, but will decode messages secured using the old or the new Network Key.
7. You may optionally update the app key by calling https://github.com/NordicSemiconductor/Android-nRF-Mesh-Library/blob/8375851d803db5a8556240a7f340c04a98956f9e/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java#L552-L585 
and send `ConfigAppKeyUpdate` to the same set of Nodes to update the Application Key(s). Mind, that updating Application Keys is only possible if the bound Network Key is in Phase 1.
8. When all Nodes, including low-power Nodes received the new Network Key (and optionally Application Key) (which may take some time if low-power Nodes turn on rarely), send `ConfigKeyRefreshPhaseSet` with phase set to Phase 2 of Key Refresh Procedure. In that phase they will start encrypting message using the new keys, and continue to receive messages (other than Secure Network beacons) using both old or new keys.
   > Note: Sending Secure Network beacon is currently not supported and may be added in the future releases. 
9. Next we must switch to using the new network key on the provisioner https://github.com/NordicSemiconductor/Android-nRF-Mesh-Library/blob/8375851d803db5a8556240a7f340c04a98956f9e/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java#L321-L338
10. When all Nodes are in Phase 2, the old keys can be revoked, Revoke the provisioners old key by calling https://github.com/NordicSemiconductor/Android-nRF-Mesh-Library/blob/8375851d803db5a8556240a7f340c04a98956f9e/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java#L340-L356

And revoke the rest of the nodes in Phase 2 by sending Do this by sending `ConfigKeyRefreshPhaseSet` with `phase` set to `PHASE_3`. This will make them forget the old keys and transition to the Phase 0 (Normal Operation).