### PR TITLE
Migrates to activity result contract

### DIFF
--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/GroupControlsActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/GroupControlsActivity.java
@@ -22,7 +22,6 @@
 
 package no.nordicsemi.android.nrfmesh;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -59,14 +58,12 @@ import no.nordicsemi.android.mesh.transport.VendorModelMessageUnacked;
 import no.nordicsemi.android.mesh.utils.MeshAddress;
 import no.nordicsemi.android.mesh.utils.MeshParserUtils;
 import no.nordicsemi.android.nrfmesh.adapter.SubGroupAdapter;
-import no.nordicsemi.android.nrfmesh.ble.ScannerActivity;
 import no.nordicsemi.android.nrfmesh.databinding.ActivityConfigGroupsBinding;
 import no.nordicsemi.android.nrfmesh.dialog.DialogFragmentError;
 import no.nordicsemi.android.nrfmesh.node.dialog.BottomSheetDetailsDialogFragment;
 import no.nordicsemi.android.nrfmesh.node.dialog.BottomSheetLevelDialogFragment;
 import no.nordicsemi.android.nrfmesh.node.dialog.BottomSheetOnOffDialogFragment;
 import no.nordicsemi.android.nrfmesh.node.dialog.BottomSheetVendorDialogFragment;
-import no.nordicsemi.android.nrfmesh.utils.Utils;
 import no.nordicsemi.android.nrfmesh.viewmodels.GroupControlsViewModel;
 
 @AndroidEntryPoint
@@ -183,9 +180,7 @@ public class GroupControlsActivity extends AppCompatActivity implements
             editGroup();
             return true;
         } else if (id == R.id.action_connect){
-            final Intent intent = new Intent(this, ScannerActivity.class);
-            intent.putExtra(Utils.EXTRA_DATA_PROVISIONING_SERVICE, false);
-            startActivityForResult(intent, Utils.CONNECT_TO_NETWORK);
+            mViewModel.navigateToScannerActivity(this, false);
             return true;
         } else if (id == R.id.action_disconnect){
             mViewModel.disconnect();

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/MainActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/MainActivity.java
@@ -40,7 +40,6 @@ import androidx.fragment.app.FragmentTransaction;
 import androidx.lifecycle.ViewModelProvider;
 import dagger.hilt.android.AndroidEntryPoint;
 import no.nordicsemi.android.nrfmesh.databinding.ActivityMainBinding;
-import no.nordicsemi.android.nrfmesh.utils.Utils;
 import no.nordicsemi.android.nrfmesh.viewmodels.SharedViewModel;
 
 @AndroidEntryPoint
@@ -136,7 +135,7 @@ public class MainActivity extends AppCompatActivity implements
     public boolean onOptionsItemSelected(final MenuItem item) {
         final int id = item.getItemId();
         if (id == R.id.action_connect) {
-            mViewModel.navigateToScannerActivity(this, false, Utils.CONNECT_TO_NETWORK, false);
+            mViewModel.navigateToScannerActivity(this, false);
             return true;
         } else if (id == R.id.action_disconnect) {
             mViewModel.disconnect();

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/MainActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/MainActivity.java
@@ -22,7 +22,6 @@
 
 package no.nordicsemi.android.nrfmesh;
 
-import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.view.Menu;
@@ -102,7 +101,8 @@ public class MainActivity extends AppCompatActivity implements
         setContentView(binding.getRoot());
 
         setSupportActionBar(binding.toolbar);
-        getSupportActionBar().setTitle(R.string.app_name);
+        if (getSupportActionBar() != null)
+            getSupportActionBar().setTitle(R.string.app_name);
 
         mNetworkFragment = (NetworkFragment) getSupportFragmentManager().findFragmentById(R.id.fragment_network);
         mGroupsFragment = (GroupsFragment) getSupportFragmentManager().findFragmentById(R.id.fragment_groups);
@@ -147,11 +147,6 @@ public class MainActivity extends AppCompatActivity implements
     @Override
     public void onBackPressed() {
         super.onBackPressed();
-    }
-
-    @Override
-    public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
     }
 
     @Override

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/ProvisioningActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/ProvisioningActivity.java
@@ -32,6 +32,8 @@ import com.google.android.material.snackbar.Snackbar;
 
 import java.util.Locale;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.content.ContextCompat;
@@ -81,6 +83,16 @@ public class ProvisioningActivity extends AppCompatActivity implements
 
     private ActivityMeshProvisionerBinding binding;
     private ProvisioningViewModel mViewModel;
+
+
+    private final ActivityResultLauncher<Intent> appKeySelector = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
+        if (result.getResultCode() == RESULT_OK && result.getData() != null) {
+            final ApplicationKey appKey = result.getData().getParcelableExtra(RESULT_KEY);
+            if (appKey != null) {
+                mViewModel.getNetworkLiveData().setSelectedAppKey(appKey);
+            }
+        }
+    });
 
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
@@ -132,7 +144,7 @@ public class ProvisioningActivity extends AppCompatActivity implements
         binding.containerAppKeys.getRoot().setOnClickListener(v -> {
             final Intent manageAppKeys = new Intent(ProvisioningActivity.this, AppKeysActivity.class);
             manageAppKeys.putExtra(Utils.EXTRA_DATA, Utils.ADD_APP_KEY);
-            startActivityForResult(manageAppKeys, Utils.SELECT_KEY);
+            appKeySelector.launch(manageAppKeys);
         });
 
         mViewModel.getConnectionState().observe(this, binding.connectionState::setText);

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/ProvisioningActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/ProvisioningActivity.java
@@ -335,19 +335,7 @@ public class ProvisioningActivity extends AppCompatActivity implements
                             }
                             break;
                         case PROVISIONING_AUTHENTICATION_STATIC_OOB_WAITING:
-                            if (getSupportFragmentManager().findFragmentByTag(DIALOG_FRAGMENT_AUTH_INPUT_TAG) == null) {
-                                DialogFragmentAuthenticationInput dialogFragmentAuthenticationInput = DialogFragmentAuthenticationInput.
-                                        newInstance(mViewModel.getUnprovisionedMeshNode().getValue());
-                                dialogFragmentAuthenticationInput.show(getSupportFragmentManager(), DIALOG_FRAGMENT_AUTH_INPUT_TAG);
-                            }
-                            break;
                         case PROVISIONING_AUTHENTICATION_OUTPUT_OOB_WAITING:
-                            if (getSupportFragmentManager().findFragmentByTag(DIALOG_FRAGMENT_AUTH_INPUT_TAG) == null) {
-                                DialogFragmentAuthenticationInput dialogFragmentAuthenticationInput = DialogFragmentAuthenticationInput.
-                                        newInstance(mViewModel.getUnprovisionedMeshNode().getValue());
-                                dialogFragmentAuthenticationInput.show(getSupportFragmentManager(), DIALOG_FRAGMENT_AUTH_INPUT_TAG);
-                            }
-                            break;
                         case PROVISIONING_AUTHENTICATION_INPUT_OOB_WAITING:
                             if (getSupportFragmentManager().findFragmentByTag(DIALOG_FRAGMENT_AUTH_INPUT_TAG) == null) {
                                 DialogFragmentAuthenticationInput dialogFragmentAuthenticationInput = DialogFragmentAuthenticationInput.

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/ProvisioningActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/ProvisioningActivity.java
@@ -84,7 +84,6 @@ public class ProvisioningActivity extends AppCompatActivity implements
     private ActivityMeshProvisionerBinding binding;
     private ProvisioningViewModel mViewModel;
 
-
     private final ActivityResultLauncher<Intent> appKeySelector = registerForActivityResult(new ActivityResultContracts.StartActivityForResult(), result -> {
         if (result.getResultCode() == RESULT_OK && result.getData() != null) {
             final ApplicationKey appKey = result.getData().getParcelableExtra(RESULT_KEY);
@@ -107,9 +106,11 @@ public class ProvisioningActivity extends AppCompatActivity implements
         final String deviceAddress = device.getAddress();
 
         setSupportActionBar(binding.toolbar);
-        getSupportActionBar().setTitle(deviceName);
-        getSupportActionBar().setSubtitle(deviceAddress);
-        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        if(getSupportActionBar() != null){
+            getSupportActionBar().setTitle(deviceName);
+            getSupportActionBar().setSubtitle(deviceAddress);
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+        }
 
         if (savedInstanceState == null)
             mViewModel.connect(this, device, false);

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/ProvisioningActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/ProvisioningActivity.java
@@ -267,19 +267,6 @@ public class ProvisioningActivity extends AppCompatActivity implements
     }
 
     @Override
-    protected void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        if (requestCode == Utils.SELECT_KEY) {
-            if (resultCode == RESULT_OK) {
-                final ApplicationKey appKey = data.getParcelableExtra(RESULT_KEY);
-                if (appKey != null) {
-                    mViewModel.getNetworkLiveData().setSelectedAppKey(appKey);
-                }
-            }
-        }
-    }
-
-    @Override
     public void onPinInputComplete(final String pin) {
         mViewModel.getMeshManagerApi().setProvisioningAuthentication(pin);
     }

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/SettingsFragment.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/SettingsFragment.java
@@ -24,9 +24,7 @@ package no.nordicsemi.android.nrfmesh;
 
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.net.Uri;
 import android.os.Bundle;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -35,9 +33,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-import java.io.FileNotFoundException;
-import java.io.OutputStream;
-
+import androidx.activity.result.ActivityResultLauncher;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.content.ContextCompat;
@@ -61,7 +57,7 @@ import no.nordicsemi.android.nrfmesh.scenes.ScenesActivity;
 import no.nordicsemi.android.nrfmesh.utils.Utils;
 import no.nordicsemi.android.nrfmesh.viewmodels.SharedViewModel;
 
-import static android.app.Activity.RESULT_OK;
+import static androidx.activity.result.contract.ActivityResultContracts.GetContent;
 
 @AndroidEntryPoint
 public class SettingsFragment extends Fragment implements
@@ -72,6 +68,14 @@ public class SettingsFragment extends Fragment implements
     private static final String TAG = SettingsFragment.class.getSimpleName();
     private static final int READ_FILE_REQUEST_CODE = 42;
     private SharedViewModel mViewModel;
+
+    private final ActivityResultLauncher<String> fileSelector = registerForActivityResult(
+            new GetContent(), result -> {
+                if(result != null) {
+                    mViewModel.disconnect();
+                    mViewModel.getMeshManagerApi().importMeshNetwork(result);
+                }
+            });
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -190,7 +194,6 @@ public class SettingsFragment extends Fragment implements
         });
 
         return binding.getRoot();
-
     }
 
     @Override
@@ -220,35 +223,6 @@ public class SettingsFragment extends Fragment implements
     }
 
     @Override
-    public void onActivityResult(final int requestCode, final int resultCode, final Intent data) {
-        super.onActivityResult(requestCode, resultCode, data);
-        if (requestCode == READ_FILE_REQUEST_CODE) {
-            if (resultCode == RESULT_OK) {
-                if (data != null && data.getData() != null) {
-                    //Disconnect from network before importing
-                    mViewModel.disconnect();
-                    final Uri uri = data.getData();
-                    mViewModel.getMeshManagerApi().importMeshNetwork(uri);
-                }
-            } else {
-                Log.e(TAG, "Error while opening file browser");
-            }
-        } else if (requestCode == 2011) {
-            if (resultCode == RESULT_OK) {
-                if (data != null && data.getData() != null) {
-                    final Uri uri = data.getData();
-                    try {
-                        final OutputStream stream = requireContext().getContentResolver().openOutputStream(uri);
-                        mViewModel.exportMeshNetwork(stream);
-                    } catch (FileNotFoundException e) {
-                        e.printStackTrace();
-                    }
-                }
-            }
-        }
-    }
-
-    @Override
     public void onNetworkNameEntered(@NonNull final String name) {
         mViewModel.getNetworkLiveData().setNetworkName(name);
     }
@@ -267,14 +241,6 @@ public class SettingsFragment extends Fragment implements
      * Fires an intent to spin up the "file chooser" UI to select a file
      */
     private void performFileSearch() {
-        final Intent intent;
-        if (Utils.isKitkatOrAbove()) {
-            intent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
-        } else {
-            intent = new Intent(Intent.ACTION_GET_CONTENT);
-        }
-        intent.addCategory(Intent.CATEGORY_OPENABLE);
-        intent.setType("*/*");
-        startActivityForResult(intent, READ_FILE_REQUEST_CODE);
+        fileSelector.launch("application/json");
     }
 }

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/ble/ScannerActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/ble/ScannerActivity.java
@@ -142,13 +142,13 @@ public class ScannerActivity extends AppCompatActivity implements
             if (resultCode == RESULT_OK) {
                 setResultIntent(data);
             }
-        } else if (requestCode == Utils.CONNECT_TO_NETWORK) {
-            if (resultCode == RESULT_OK) {
-                finish();
-            }
         } else if (requestCode == REQUEST_ENABLE_BLUETOOTH) {
             if (resultCode == RESULT_OK) {
                 startScan(mViewModel.getScannerRepository().getScannerState());
+            }
+        } else {
+            if (resultCode == RESULT_OK) {
+                finish();
             }
         }
     }

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/node/ConfigurationServerActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/node/ConfigurationServerActivity.java
@@ -10,6 +10,8 @@ import android.widget.TextView;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.android.material.switchmaterial.SwitchMaterial;
 
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
 import androidx.cardview.widget.CardView;
 import dagger.hilt.android.AndroidEntryPoint;
@@ -43,7 +45,6 @@ import no.nordicsemi.android.nrfmesh.R;
 import no.nordicsemi.android.nrfmesh.databinding.LayoutConfigServerModelBinding;
 import no.nordicsemi.android.nrfmesh.node.dialog.DialogFragmentNetworkTransmitSettings;
 import no.nordicsemi.android.nrfmesh.node.dialog.DialogRelayRetransmitSettings;
-import no.nordicsemi.android.nrfmesh.utils.Utils;
 import no.nordicsemi.android.nrfmesh.viewmodels.ModelConfigurationViewModel;
 
 import static android.view.View.GONE;
@@ -101,6 +102,12 @@ public class ConfigurationServerActivity extends BaseModelConfigurationActivity 
     private int mNetworkTransmitCount = NETWORK_TRANSMIT_SETTING_UNKNOWN;
     private int mNetworkTransmitIntervalSteps = NETWORK_TRANSMIT_SETTING_UNKNOWN;
 
+    private final ActivityResultLauncher<Intent> heartbeatConfigurationLauncher = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(), result -> {
+                if (result.getResultCode() == RESULT_OK && result.getData() != null) {
+                    showProgressBar();
+                }
+            });
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -163,10 +170,7 @@ public class ConfigurationServerActivity extends BaseModelConfigurationActivity 
                     sendMessage(new ConfigHeartbeatPublicationSet()));
 
             mSetPublication = nodeControlsContainerBinding.actionSetHeartbeatPublication;
-            mSetPublication.setOnClickListener(v -> {
-                final Intent heartbeatPublication = new Intent(this, HeartbeatPublicationActivity.class);
-                startActivityForResult(heartbeatPublication, Utils.HEARTBEAT_SETTINGS_SET);
-            });
+            mSetPublication.setOnClickListener(v -> heartbeatConfigurationLauncher.launch(new Intent(this, HeartbeatPublicationActivity.class)));
 
             mRefreshSubscription = nodeControlsContainerBinding.actionRefreshHeartbeatSubscription;
             mRefreshSubscription.setOnClickListener(v -> sendMessage(new ConfigHeartbeatSubscriptionGet()));
@@ -175,10 +179,7 @@ public class ConfigurationServerActivity extends BaseModelConfigurationActivity 
             mClearSubscription.setOnClickListener(v -> sendMessage(new ConfigHeartbeatPublicationSet()));
 
             mSetSubscription = nodeControlsContainerBinding.actionSetHeartbeatSubscription;
-            mSetSubscription.setOnClickListener(v -> {
-                final Intent subscription = new Intent(this, HeartbeatSubscriptionActivity.class);
-                startActivityForResult(subscription, Utils.HEARTBEAT_SETTINGS_SET);
-            });
+            mSetSubscription.setOnClickListener(v -> heartbeatConfigurationLauncher.launch(new Intent(this, HeartbeatSubscriptionActivity.class)));
 
             mNetworkTransmitCountText = nodeControlsContainerBinding.networkTransmitCount;
             mNetworkTransmitIntervalStepsText = nodeControlsContainerBinding.networkTransmitIntervalSteps;

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/node/ConfigurationServerActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/node/ConfigurationServerActivity.java
@@ -26,6 +26,7 @@ import no.nordicsemi.android.mesh.transport.ConfigHeartbeatPublicationGet;
 import no.nordicsemi.android.mesh.transport.ConfigHeartbeatPublicationSet;
 import no.nordicsemi.android.mesh.transport.ConfigHeartbeatPublicationStatus;
 import no.nordicsemi.android.mesh.transport.ConfigHeartbeatSubscriptionGet;
+import no.nordicsemi.android.mesh.transport.ConfigHeartbeatSubscriptionSet;
 import no.nordicsemi.android.mesh.transport.ConfigHeartbeatSubscriptionStatus;
 import no.nordicsemi.android.mesh.transport.ConfigNetworkTransmitSet;
 import no.nordicsemi.android.mesh.transport.ConfigNetworkTransmitStatus;
@@ -176,7 +177,7 @@ public class ConfigurationServerActivity extends BaseModelConfigurationActivity 
             mRefreshSubscription.setOnClickListener(v -> sendMessage(new ConfigHeartbeatSubscriptionGet()));
 
             mClearSubscription = nodeControlsContainerBinding.actionClearHeartbeatSubscription;
-            mClearSubscription.setOnClickListener(v -> sendMessage(new ConfigHeartbeatPublicationSet()));
+            mClearSubscription.setOnClickListener(v -> sendMessage(new ConfigHeartbeatSubscriptionSet()));
 
             mSetSubscription = nodeControlsContainerBinding.actionSetHeartbeatSubscription;
             mSetSubscription.setOnClickListener(v -> heartbeatConfigurationLauncher.launch(new Intent(this, HeartbeatSubscriptionActivity.class)));

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/node/HeartbeatPublicationActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/node/HeartbeatPublicationActivity.java
@@ -50,7 +50,6 @@ import static no.nordicsemi.android.mesh.utils.Heartbeat.PERIOD_LOG_MIN;
 import static no.nordicsemi.android.mesh.utils.Heartbeat.calculateHeartbeatCount;
 import static no.nordicsemi.android.mesh.utils.Heartbeat.calculateHeartbeatPeriod;
 import static no.nordicsemi.android.mesh.utils.Heartbeat.periodToTime;
-import static no.nordicsemi.android.nrfmesh.utils.Utils.CONNECT_TO_NETWORK;
 import static no.nordicsemi.android.nrfmesh.utils.Utils.EXTRA_DATA;
 import static no.nordicsemi.android.nrfmesh.utils.Utils.HEARTBEAT_PUBLICATION_NET_KEY;
 import static no.nordicsemi.android.nrfmesh.utils.Utils.RESULT_KEY;
@@ -211,7 +210,7 @@ public class HeartbeatPublicationActivity extends AppCompatActivity implements
             onBackPressed();
             return true;
         } else if (id == R.id.action_connect) {
-            mViewModel.navigateToScannerActivity(this, false, CONNECT_TO_NETWORK, false);
+            mViewModel.navigateToScannerActivity(this, false);
             return true;
         } else if (id == R.id.action_disconnect) {
             mViewModel.disconnect();

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/node/HeartbeatSubscriptionActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/node/HeartbeatSubscriptionActivity.java
@@ -36,7 +36,6 @@ import no.nordicsemi.android.nrfmesh.node.dialog.DialogFragmentHeartbeatSource;
 import no.nordicsemi.android.nrfmesh.viewmodels.HeartbeatViewModel;
 
 import static no.nordicsemi.android.mesh.utils.Heartbeat.calculateHeartbeatPeriod;
-import static no.nordicsemi.android.nrfmesh.utils.Utils.CONNECT_TO_NETWORK;
 
 @AndroidEntryPoint
 public class HeartbeatSubscriptionActivity extends AppCompatActivity implements
@@ -140,7 +139,7 @@ public class HeartbeatSubscriptionActivity extends AppCompatActivity implements
             onBackPressed();
             return true;
         } else if (itemId == R.id.action_connect) {
-            mViewModel.navigateToScannerActivity(this, false, CONNECT_TO_NETWORK, false);
+            mViewModel.navigateToScannerActivity(this, false);
             return true;
         } else if (itemId == R.id.action_disconnect) {
             mViewModel.disconnect();

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/utils/Utils.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/utils/Utils.java
@@ -100,7 +100,6 @@ public class Utils {
     public static final int SELECT_SCENE = 6;
 
     // Heartbeat publication key
-    public static final int HEARTBEAT_SETTINGS_SET = 2022;
     public static final int HEARTBEAT_PUBLICATION_NET_KEY = 6;
     public static final int SELECT_KEY = 2011; //Random number
 

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/viewmodels/BaseActivity.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/viewmodels/BaseActivity.java
@@ -11,7 +11,6 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout;
 import no.nordicsemi.android.mesh.transport.MeshMessage;
 import no.nordicsemi.android.nrfmesh.R;
 import no.nordicsemi.android.nrfmesh.dialog.DialogFragmentTransactionStatus;
-import no.nordicsemi.android.nrfmesh.utils.Utils;
 
 
 public abstract class BaseActivity extends AppCompatActivity {
@@ -72,7 +71,7 @@ public abstract class BaseActivity extends AppCompatActivity {
             onBackPressed();
             return true;
         } else if (id == R.id.action_connect) {
-            mViewModel.navigateToScannerActivity(this, false, Utils.CONNECT_TO_NETWORK, false);
+            mViewModel.navigateToScannerActivity(this, false);
             return true;
         } else if (id == R.id.action_disconnect) {
             mViewModel.disconnect();

--- a/app/src/main/java/no/nordicsemi/android/nrfmesh/viewmodels/BaseViewModel.java
+++ b/app/src/main/java/no/nordicsemi/android/nrfmesh/viewmodels/BaseViewModel.java
@@ -94,18 +94,12 @@ public abstract class BaseViewModel extends ViewModel {
      * Navigate to scanner activity
      *
      * @param context                 Activity context
-     * @param withResult              Start activity with result
-     * @param requestCode             Request code when using with result
      * @param withProvisioningService Scan with provisioning service
      */
-    public void navigateToScannerActivity(@NonNull final Activity context, final boolean withResult, final int requestCode, final boolean withProvisioningService) {
+    public void navigateToScannerActivity(@NonNull final Context context, final boolean withProvisioningService) {
         final Intent intent = new Intent(context, ScannerActivity.class);
         intent.putExtra(Utils.EXTRA_DATA_PROVISIONING_SERVICE, withProvisioningService);
-        if (withResult) {
-            context.startActivityForResult(intent, requestCode);
-        } else {
-            context.startActivity(intent);
-        }
+        context.startActivity(intent);
     }
 
     /**
@@ -300,7 +294,7 @@ public abstract class BaseViewModel extends ViewModel {
         Snackbar.make(container, context.getString(R.string.disconnected_network_rationale), Snackbar.LENGTH_LONG)
                 .setActionTextColor(context.getResources().getColor(R.color.colorSecondary))
                 .setAction(context.getString(R.string.action_connect), v ->
-                        navigateToScannerActivity(context, false, Utils.CONNECT_TO_NETWORK, false))
+                        navigateToScannerActivity(context, false))
                 .show();
     }
 


### PR DESCRIPTION
* Migrates deprecated `startActivityForResult` to `ActivityResultLauncher`.
* Fixes an issue in the app when clearing heartbeat subscription a `HeartbeatPublicationSet` with unassigned address was sent.