### PR TITLE
Add the Global part of the Generic Location Client to the SDK

### DIFF
--- a/mesh/src/main/java/no/nordicsemi/android/mesh/data/GlobalAltitude.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/data/GlobalAltitude.java
@@ -1,0 +1,146 @@
+package no.nordicsemi.android.mesh.data;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+
+/**
+ * GlobalAltitude is an object representing the Global Altitude field of the Generic Location model.
+ * It is an abstract class with three concrete implementations:
+ * <ul>
+ *     <li>Coordinate: A altitude position in the World Geodetic System (WGS84) coordinate system.</li>
+ *     <li>GreaterThanOrEqualTo32766: Altitude is greater than or equal to 32766 meters.</li>
+ *     <li>NotConfigured: Altitude is not configured.</li>
+ * </ul>
+ */
+public abstract class GlobalAltitude {
+    private static final short ENCODED_VALUE_NOT_CONFIGURED = 0x7FFF;
+    private static final short ENCODED_VALUE_GREATER_THAN_OR_EQUAL_TO_32766 = 0x7FFE;
+
+    private GlobalAltitude() {
+    }
+
+    public abstract short getEncodedValue();
+
+    /**
+     * Creates a GlobalAltitude from an encoded value.
+     *
+     * @param encodedValue a value encoded according to the Global Altitude field of the Generic Location model
+     * @return either a Coordinate or NotConfigured instance representing the encodedValue
+     */
+    @NonNull
+    public static GlobalAltitude of(short encodedValue) {
+        if (encodedValue == ENCODED_VALUE_NOT_CONFIGURED) {
+            return new NotConfigured();
+        }
+        if (encodedValue == ENCODED_VALUE_GREATER_THAN_OR_EQUAL_TO_32766) {
+            return new GreaterThanOrEqualTo32766();
+        }
+        return new Coordinate(encodedValue);
+    }
+
+    /**
+     * Encodes a altitude position in the World Geodetic System (WGS84) coordinate system.
+     *
+     * @param position a position in the range of -32768 to 32765 meters inclusive
+     * @return a Coordinate instance encoding the position
+     * @throws IllegalArgumentException if position is out of range
+     */
+    @NonNull
+    public static Coordinate encode(int position) {
+        return new Coordinate(position);
+    }
+
+    /**
+     * Creates a NotConfigured instance representing that global altitude is not configured.
+     *
+     * @return a NotConfigured instance
+     */
+    @NonNull
+    public static NotConfigured notConfigured() {
+        return new NotConfigured();
+    }
+
+    /**
+     * Get the decoded altitude position in the World Geodetic System (WGS84) coordinate system.
+     *
+     * @return the position or null if `not configured` or `greater than or equal to 32766 meters`
+     */
+    @Nullable
+    public Integer getDecodedPosition() {
+        if (this instanceof Coordinate) {
+            return ((Coordinate) this).getPosition();
+        }
+        return null;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GlobalAltitude that = (GlobalAltitude) o;
+        return getEncodedValue() == that.getEncodedValue();
+    }
+
+    @Override
+    public final int hashCode() {
+        return Integer.valueOf(getEncodedValue()).hashCode();
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "GlobalAltitude." + this.getClass().getSimpleName() + " encodedValue: " + Integer.toHexString(this.getEncodedValue()) + " position: " + this.getDecodedPosition();
+    }
+
+    public final static class Coordinate extends GlobalAltitude {
+
+        private final short encodedValue;
+
+        private Coordinate(short encodedValue) {
+            if (encodedValue == ENCODED_VALUE_NOT_CONFIGURED) {
+                throw new IllegalArgumentException("Encoded value can't be ´NOT_CONFIGURED´ (0x7FFF)");
+            }
+            if (encodedValue == ENCODED_VALUE_GREATER_THAN_OR_EQUAL_TO_32766) {
+                throw new IllegalArgumentException("Encoded value can't be ´GREATER_THAN_OR_EQUAL_TO_32766´ (0x7FFE)");
+            }
+            this.encodedValue = encodedValue;
+        }
+
+        private Coordinate(int value) {
+            if (value < -32768 || value > 32765) {
+                throw new IllegalArgumentException("Altitude coordinate must be between -32768 and 32765 meters inclusive");
+            }
+            this.encodedValue = (short) value;
+        }
+
+        @Override
+        public short getEncodedValue() {
+            return encodedValue;
+        }
+
+        public int getPosition() {
+            return (int) encodedValue;
+        }
+    }
+
+    public final static class NotConfigured extends GlobalAltitude {
+        private NotConfigured() {
+        }
+
+        @Override
+        public short getEncodedValue() {
+            return ENCODED_VALUE_NOT_CONFIGURED;
+        }
+    }
+
+    public final static class GreaterThanOrEqualTo32766 extends GlobalAltitude {
+        private GreaterThanOrEqualTo32766() {
+        }
+
+        @Override
+        public short getEncodedValue() {
+            return ENCODED_VALUE_GREATER_THAN_OR_EQUAL_TO_32766;
+        }
+    }
+}

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/data/GlobalLatitude.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/data/GlobalLatitude.java
@@ -1,0 +1,133 @@
+package no.nordicsemi.android.mesh.data;
+
+import static java.lang.Math.floor;
+import static java.lang.Math.max;
+import static java.lang.Math.pow;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+
+/**
+ * GlobalLatitude is an object representing the Global Latitude field of the Generic Location model.
+ * It is an abstract class with two concrete implementations:
+ * <ul>
+ *     <li>Coordinate: A latitude position in the World Geodetic System (WGS84) coordinate system.</li>
+ *     <li>NotConfigured: Latitude is not configured.</li>
+ * </ul>
+ */
+public abstract class GlobalLatitude {
+    private static final int ENCODED_VALUE_NOT_CONFIGURED = 0x80000000;
+
+    private GlobalLatitude() {
+    }
+
+    public abstract int getEncodedValue();
+
+    /**
+     * Creates a GlobalLatitude from an encoded value.
+     *
+     * @param encodedValue a value encoded according to the Global Latitude field of the Generic Location model
+     * @return either a Coordinate or NotConfigured instance representing the encodedValue
+     */
+    @NonNull
+    public static GlobalLatitude of(int encodedValue) {
+        if (encodedValue == ENCODED_VALUE_NOT_CONFIGURED) {
+            return new NotConfigured();
+        }
+        return new Coordinate(encodedValue);
+    }
+
+    /**
+     * Encodes a latitude position in the World Geodetic System (WGS84) coordinate system.
+     *
+     * @param position a position in the range of -90° to 90° inclusive
+     * @return a Coordinate instance encoding the position
+     * @throws IllegalArgumentException if position is out of range
+     */
+    @NonNull
+    public static Coordinate encode(double position) {
+        return new Coordinate(position);
+    }
+
+    /**
+     * Creates a NotConfigured instance representing that global latitude is not configured.
+     *
+     * @return a NotConfigured instance
+     */
+    @NonNull
+    public static NotConfigured notConfigured() {
+        return new NotConfigured();
+    }
+
+    /**
+     * Get the decoded latitude position in the World Geodetic System (WGS84) coordinate system.
+     *
+     * @return the position or null if `not configured`
+     */
+    @Nullable
+    public Double getDecodedPosition() {
+        if (this instanceof Coordinate) {
+            return ((Coordinate) this).getPosition();
+        }
+        return null;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GlobalLatitude that = (GlobalLatitude) o;
+        return getEncodedValue() == that.getEncodedValue();
+    }
+
+    @Override
+    public final int hashCode() {
+        return Integer.valueOf(getEncodedValue()).hashCode();
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "GlobalLatitude." + this.getClass().getSimpleName() + " encodedValue: " + Integer.toHexString(this.getEncodedValue()) + " position: " + this.getDecodedPosition();
+    }
+
+    public final static class Coordinate extends GlobalLatitude {
+
+        private final int encodedValue;
+
+        private Coordinate(int encodedValue) {
+            if (encodedValue == ENCODED_VALUE_NOT_CONFIGURED) {
+                throw new IllegalArgumentException("Encoded value can't be ´NOT CONFIGURED´ (0x80000000)");
+            }
+            this.encodedValue = encodedValue;
+        }
+
+        private Coordinate(double value) {
+            if (value < -90 || value > 90) {
+                throw new IllegalArgumentException("Latitude coordinate must be between -90 and 90 degrees inclusive");
+            }
+            int n = (int) floor((value / 90) * (pow(2, 31) - 1));
+            this.encodedValue = max(0x80000001, n);
+        }
+
+        @Override
+        public int getEncodedValue() {
+            return encodedValue;
+        }
+
+        public double getPosition() {
+            return ((double) this.encodedValue) / (pow(2, 31) - 1) * 90;
+        }
+    }
+
+    public final static class NotConfigured extends GlobalLatitude {
+        private NotConfigured() {
+        }
+
+        @Override
+        public int getEncodedValue() {
+            return ENCODED_VALUE_NOT_CONFIGURED;
+        }
+    }
+}

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/data/GlobalLongitude.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/data/GlobalLongitude.java
@@ -1,0 +1,133 @@
+package no.nordicsemi.android.mesh.data;
+
+import static java.lang.Math.floor;
+import static java.lang.Math.max;
+import static java.lang.Math.pow;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+
+/**
+ * GlobalLongitude is an object representing the Global Longitude field of the Generic Location model.
+ * It is an abstract class with two concrete implementations:
+ * <ul>
+ *     <li>Coordinate: A Longitude position in the World Geodetic System (WGS84) coordinate system.</li>
+ *     <li>NotConfigured: Longitude is not configured.</li>
+ * </ul>
+ */
+public abstract class GlobalLongitude {
+    private static final int ENCODED_VALUE_NOT_CONFIGURED = 0x80000000;
+
+    private GlobalLongitude() {
+    }
+
+    public abstract int getEncodedValue();
+
+    /**
+     * Creates a GlobalLongitude from an encoded value.
+     *
+     * @param encodedValue a value encoded according to the Global Longitude field of the Generic Location model
+     * @return either a Coordinate or NotConfigured instance representing the encodedValue
+     */
+    @NonNull
+    public static GlobalLongitude of(int encodedValue) {
+        if (encodedValue == ENCODED_VALUE_NOT_CONFIGURED) {
+            return new NotConfigured();
+        }
+        return new Coordinate(encodedValue);
+    }
+
+    /**
+     * Encodes a Longitude position in the World Geodetic System (WGS84) coordinate system.
+     *
+     * @param position a position in the range of -180° to 180° inclusive
+     * @return a Coordinate instance encoding the position
+     * @throws IllegalArgumentException if position is out of range
+     */
+    @NonNull
+    public static Coordinate encode(double position) {
+        return new Coordinate(position);
+    }
+
+    /**
+     * Creates a NotConfigured instance representing that global longitude is not configured.
+     *
+     * @return a NotConfigured instance
+     */
+    @NonNull
+    public static NotConfigured notConfigured() {
+        return new NotConfigured();
+    }
+
+    /**
+     * Get the decoded longitude position in the World Geodetic System (WGS84) coordinate system.
+     *
+     * @return the position or null if `not configured`
+     */
+    @Nullable
+    public Double getDecodedPosition() {
+        if (this instanceof Coordinate) {
+            return ((Coordinate) this).getPosition();
+        }
+        return null;
+    }
+
+    @Override
+    public final boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        GlobalLongitude that = (GlobalLongitude) o;
+        return getEncodedValue() == that.getEncodedValue();
+    }
+
+    @Override
+    public final int hashCode() {
+        return Integer.valueOf(getEncodedValue()).hashCode();
+    }
+
+    @NonNull
+    @Override
+    public String toString() {
+        return "GlobalLongitude." + this.getClass().getSimpleName() + " encodedValue: " + Integer.toHexString(this.getEncodedValue()) + " position: " + this.getDecodedPosition();
+    }
+
+    public final static class Coordinate extends GlobalLongitude {
+
+        private final int encodedValue;
+
+        private Coordinate(int encodedValue) {
+            if (encodedValue == ENCODED_VALUE_NOT_CONFIGURED) {
+                throw new IllegalArgumentException("Encoded value can't be ´NOT CONFIGURED´ (0x80000000)");
+            }
+            this.encodedValue = encodedValue;
+        }
+
+        private Coordinate(double value) {
+            if (value < -180 || value > 180) {
+                throw new IllegalArgumentException("Longitude coordinate must be between -180 and 180 degrees inclusive");
+            }
+            int n = (int) floor((value / 180) * (pow(2, 31) - 1));
+            this.encodedValue = max(0x80000001, n);
+        }
+
+        @Override
+        public int getEncodedValue() {
+            return encodedValue;
+        }
+
+        public double getPosition() {
+            return ((double) this.encodedValue) / (pow(2, 31) - 1) * 180;
+        }
+    }
+
+    public final static class NotConfigured extends GlobalLongitude {
+        private NotConfigured() {
+        }
+
+        @Override
+        public int getEncodedValue() {
+            return ENCODED_VALUE_NOT_CONFIGURED;
+        }
+    }
+}

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/opcodes/ApplicationMessageOpCodes.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/opcodes/ApplicationMessageOpCodes.java
@@ -55,6 +55,26 @@ public class ApplicationMessageOpCodes {
     public static final int GENERIC_LEVEL_SET = 0x8206;
 
     /**
+     * Opcode for the "Generic Location Global Get" message
+     */
+    public static final int GENERIC_LOCATION_GLOBAL_GET = 0x8225;
+
+    /**
+     * Opcode for the "Generic Location Global Status" message
+     */
+    public static final int GENERIC_LOCATION_GLOBAL_STATUS = 0x40;
+
+    /**
+     * Opcode for the "Generic Location Global Set" message
+     */
+    public static final int GENERIC_LOCATION_GLOBAL_SET = 0x41;
+
+    /**
+     * Opcode for the "Generic Location Global Set Unacknowledged" message
+     */
+    public static final int GENERIC_LOCATION_GLOBAL_SET_UNACKNOWLEDGED = 0x42;
+
+    /**
      * Opcode for the "Generic Level Set Unacknowledged" message.
      */
     public static final int GENERIC_LEVEL_SET_UNACKNOWLEDGED = 0x8207;

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/DefaultNoOperationMessageState.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/DefaultNoOperationMessageState.java
@@ -122,6 +122,10 @@ class DefaultNoOperationMessageState extends MeshMessageState {
                     }
                     mInternalTransportCallbacks.updateMeshNetwork(status);
                     mMeshStatusCallbacks.onMeshMessageReceived(message.getSrc(), status);
+                } else if (message.getOpCode() == ApplicationMessageOpCodes.GENERIC_LOCATION_GLOBAL_STATUS) {
+                    final GenericLocationGlobalStatus genericLocationGlobalStatus = new GenericLocationGlobalStatus(message);
+                    mInternalTransportCallbacks.updateMeshNetwork(genericLocationGlobalStatus);
+                    mMeshStatusCallbacks.onMeshMessageReceived(message.getSrc(), genericLocationGlobalStatus);
                 } else if (message.getOpCode() == ApplicationMessageOpCodes.SENSOR_DESCRIPTOR_STATUS) {
                     final SensorDescriptorStatus status = new SensorDescriptorStatus(message);
                     mInternalTransportCallbacks.updateMeshNetwork(status);

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/GenericLocationGlobalGet.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/GenericLocationGlobalGet.java
@@ -1,0 +1,41 @@
+package no.nordicsemi.android.mesh.transport;
+
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import no.nordicsemi.android.mesh.ApplicationKey;
+import no.nordicsemi.android.mesh.opcodes.ApplicationMessageOpCodes;
+import no.nordicsemi.android.mesh.utils.SecureUtils;
+
+/**
+ * To be used as a wrapper class when creating a GenericLocationGlobalGet message.
+ */
+public class GenericLocationGlobalGet extends ApplicationMessage {
+
+    private static final String TAG = GenericLocationGlobalGet.class.getSimpleName();
+    private static final int OP_CODE = ApplicationMessageOpCodes.GENERIC_LOCATION_GLOBAL_GET;
+
+    /**
+     * Constructs GenericLocationGlobalGet message.
+     *
+     * @param appKey application key for this message
+     * @throws IllegalArgumentException if any illegal arguments are passed
+     */
+    public GenericLocationGlobalGet(@NonNull final ApplicationKey appKey) throws IllegalArgumentException {
+        super(appKey);
+        assembleMessageParameters();
+    }
+
+    @Override
+    public int getOpCode() {
+        return OP_CODE;
+    }
+
+    @Override
+    void assembleMessageParameters() {
+        Log.v(TAG, "Creating message");
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
+    }
+}

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/GenericLocationGlobalSet.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/GenericLocationGlobalSet.java
@@ -1,0 +1,97 @@
+package no.nordicsemi.android.mesh.transport;
+
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import no.nordicsemi.android.mesh.ApplicationKey;
+import no.nordicsemi.android.mesh.data.GlobalAltitude;
+import no.nordicsemi.android.mesh.data.GlobalLatitude;
+import no.nordicsemi.android.mesh.data.GlobalLongitude;
+import no.nordicsemi.android.mesh.opcodes.ApplicationMessageOpCodes;
+import no.nordicsemi.android.mesh.utils.SecureUtils;
+
+/**
+ * To be used as a wrapper class for when creating the GenericLocationGlobalSet message.
+ */
+public final class GenericLocationGlobalSet extends ApplicationMessage {
+    private static final String TAG = GenericLocationGlobalSet.class.getSimpleName();
+    private static final int OP_CODE = ApplicationMessageOpCodes.GENERIC_LOCATION_GLOBAL_SET;
+    private static final int GENERIC_LOCATION_GLOBAL_SET_LENGTH = 10;
+    private GlobalLatitude latitude;
+    private GlobalLongitude longitude;
+    private GlobalAltitude altitude;
+
+    /**
+     * Constructs GenericLocationGlobalSet message.
+     *
+     * @param appKey    {@link ApplicationKey} key for this message
+     * @param latitude  {@link GlobalLatitude} global latitude
+     * @param longitude {@link GlobalLongitude} global longitude
+     * @param altitude  {@link GlobalAltitude} global altitude
+     */
+    public GenericLocationGlobalSet(
+            @NonNull final ApplicationKey appKey,
+            @NonNull final GlobalLatitude latitude,
+            @NonNull final GlobalLongitude longitude,
+            @NonNull final GlobalAltitude altitude) {
+        super(appKey);
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.altitude = altitude;
+        assembleMessageParameters();
+    }
+
+    @Override
+    void assembleMessageParameters() {
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
+        final ByteBuffer buffer = ByteBuffer.allocate(GENERIC_LOCATION_GLOBAL_SET_LENGTH).order(ByteOrder.LITTLE_ENDIAN);
+        Log.v(TAG, "Creating message");
+        Log.v(TAG, latitude.toString());
+        Log.v(TAG, longitude.toString());
+        Log.v(TAG, altitude.toString());
+        buffer.putInt(latitude.getEncodedValue());
+        buffer.putInt(longitude.getEncodedValue());
+        buffer.putShort(altitude.getEncodedValue());
+        mParameters = buffer.array();
+    }
+
+    @Override
+    public int getOpCode() {
+        return OP_CODE;
+    }
+
+    /**
+     * Returns the Global Latitude
+     *
+     * @return a GlobalLatitude instance
+     */
+    @NonNull
+    public GlobalLatitude getLatitude() {
+        return latitude;
+    }
+
+    /**
+     * Returns the Global Longitude
+     *
+     * @return a GlobalLongitude instance
+     */
+    @NonNull
+    public GlobalLongitude getLongitude() {
+        return longitude;
+    }
+
+    /**
+     * Returns the Global Altitude
+     *
+     * @return a GlobalAltitude instance
+     */
+    @NonNull
+    public GlobalAltitude getAltitude() {
+        return altitude;
+    }
+}

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/GenericLocationGlobalSetUnacknowledged.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/GenericLocationGlobalSetUnacknowledged.java
@@ -1,0 +1,97 @@
+package no.nordicsemi.android.mesh.transport;
+
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import no.nordicsemi.android.mesh.ApplicationKey;
+import no.nordicsemi.android.mesh.data.GlobalAltitude;
+import no.nordicsemi.android.mesh.data.GlobalLatitude;
+import no.nordicsemi.android.mesh.data.GlobalLongitude;
+import no.nordicsemi.android.mesh.opcodes.ApplicationMessageOpCodes;
+import no.nordicsemi.android.mesh.utils.SecureUtils;
+
+/**
+ * To be used as a wrapper class for when creating the GenericLocationGlobalSetUnacknowledged message.
+ */
+public final class GenericLocationGlobalSetUnacknowledged extends ApplicationMessage {
+    private static final String TAG = GenericLocationGlobalSetUnacknowledged.class.getSimpleName();
+    private static final int OP_CODE = ApplicationMessageOpCodes.GENERIC_LOCATION_GLOBAL_SET_UNACKNOWLEDGED;
+    private static final int GENERIC_LOCATION_GLOBAL_SET_LENGTH = 10;
+    private GlobalLatitude latitude;
+    private GlobalLongitude longitude;
+    private GlobalAltitude altitude;
+
+    /**
+     * Constructs GenericLocationGlobalSetUnacknowledged message.
+     *
+     * @param appKey    {@link ApplicationKey} key for this message
+     * @param latitude  {@link GlobalLatitude} global latitude
+     * @param longitude {@link GlobalLongitude} global longitude
+     * @param altitude  {@link GlobalAltitude} global altitude
+     */
+    public GenericLocationGlobalSetUnacknowledged(
+            @NonNull final ApplicationKey appKey,
+            @NonNull final GlobalLatitude latitude,
+            @NonNull final GlobalLongitude longitude,
+            @NonNull final GlobalAltitude altitude) {
+        super(appKey);
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.altitude = altitude;
+        assembleMessageParameters();
+    }
+
+    @Override
+    void assembleMessageParameters() {
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
+        final ByteBuffer buffer = ByteBuffer.allocate(GENERIC_LOCATION_GLOBAL_SET_LENGTH).order(ByteOrder.LITTLE_ENDIAN);
+        Log.v(TAG, "Creating message");
+        Log.v(TAG, latitude.toString());
+        Log.v(TAG, longitude.toString());
+        Log.v(TAG, altitude.toString());
+        buffer.putInt(latitude.getEncodedValue());
+        buffer.putInt(longitude.getEncodedValue());
+        buffer.putShort(altitude.getEncodedValue());
+        mParameters = buffer.array();
+    }
+
+    @Override
+    public int getOpCode() {
+        return OP_CODE;
+    }
+
+    /**
+     * Returns the Global Latitude
+     *
+     * @return a GlobalLatitude instance
+     */
+    @NonNull
+    public GlobalLatitude getLatitude() {
+        return latitude;
+    }
+
+    /**
+     * Returns the Global Longitude
+     *
+     * @return a GlobalLongitude instance
+     */
+    @NonNull
+    public GlobalLongitude getLongitude() {
+        return longitude;
+    }
+
+    /**
+     * Returns the Global Altitude
+     *
+     * @return a GlobalAltitude instance
+     */
+    @NonNull
+    public GlobalAltitude getAltitude() {
+        return altitude;
+    }
+}

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/GenericLocationGlobalStatus.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/GenericLocationGlobalStatus.java
@@ -1,0 +1,113 @@
+package no.nordicsemi.android.mesh.transport;
+
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import no.nordicsemi.android.mesh.data.GlobalAltitude;
+import no.nordicsemi.android.mesh.data.GlobalLatitude;
+import no.nordicsemi.android.mesh.data.GlobalLongitude;
+import no.nordicsemi.android.mesh.opcodes.ApplicationMessageOpCodes;
+import no.nordicsemi.android.mesh.utils.MeshAddress;
+
+/**
+ * To be used as a wrapper class for when creating the GenericLocationGlobalStatus Message.
+ */
+public final class GenericLocationGlobalStatus extends ApplicationStatusMessage implements Parcelable {
+    private static final String TAG = GenericLocationGlobalStatus.class.getSimpleName();
+    private static final int OP_CODE = ApplicationMessageOpCodes.GENERIC_LOCATION_GLOBAL_STATUS;
+    private static final int GENERIC_LOCATION_GLOBAL_STATUS_LENGTH = 10;
+    private GlobalLatitude latitude = GlobalLatitude.notConfigured();
+    private GlobalLongitude longitude = GlobalLongitude.notConfigured();
+    private GlobalAltitude altitude = GlobalAltitude.notConfigured();
+
+    private static final Parcelable.Creator<GenericLocationGlobalStatus> CREATOR = new Parcelable.Creator<GenericLocationGlobalStatus>() {
+        @Override
+        public GenericLocationGlobalStatus createFromParcel(Parcel in) {
+            final AccessMessage message = in.readParcelable(AccessMessage.class.getClassLoader());
+            return new GenericLocationGlobalStatus(message);
+        }
+
+        @Override
+        public GenericLocationGlobalStatus[] newArray(int size) {
+            return new GenericLocationGlobalStatus[size];
+        }
+    };
+
+    /**
+     * Constructs the GenericLocationGlobalStatus message.
+     *
+     * @param message Access Message
+     */
+    public GenericLocationGlobalStatus(@NonNull final AccessMessage message) {
+        super(message);
+        this.mParameters = message.getParameters();
+        parseStatusParameters();
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        final AccessMessage message = (AccessMessage) mMessage;
+        dest.writeParcelable(message, flags);
+    }
+
+    @Override
+    void parseStatusParameters() {
+        Log.v(TAG, "Received generic location global status from: " + MeshAddress.formatAddress(mMessage.getSrc(), true));
+        if (mParameters.length == GENERIC_LOCATION_GLOBAL_STATUS_LENGTH) {
+            final ByteBuffer buffer = ByteBuffer.wrap(mParameters).order(ByteOrder.LITTLE_ENDIAN);
+            latitude = GlobalLatitude.of(buffer.getInt());
+            longitude = GlobalLongitude.of(buffer.getInt());
+            altitude = GlobalAltitude.of(buffer.getShort());
+            Log.v(TAG, latitude.toString());
+            Log.v(TAG, longitude.toString());
+            Log.v(TAG, altitude.toString());
+        }
+    }
+
+    @Override
+    public int getOpCode() {
+        return OP_CODE;
+    }
+
+    /**
+     * Returns the Global Latitude
+     *
+     * @return a GlobalLatitude instance
+     */
+    @NonNull
+    public GlobalLatitude getLatitude() {
+        return latitude;
+    }
+
+    /**
+     * Returns the Global Longitude
+     *
+     * @return a GlobalLongitude instance
+     */
+    @NonNull
+    public GlobalLongitude getLongitude() {
+        return longitude;
+    }
+
+    /**
+     * Returns the Global Altitude
+     *
+     * @return a GlobalAltitude instance
+     */
+    @NonNull
+    public GlobalAltitude getAltitude() {
+        return altitude;
+    }
+}

--- a/mesh/src/test/java/no/nordicsemi/android/mesh/transport/GenericLocationClientTests.java
+++ b/mesh/src/test/java/no/nordicsemi/android/mesh/transport/GenericLocationClientTests.java
@@ -1,0 +1,214 @@
+package no.nordicsemi.android.mesh.transport;
+
+import org.junit.Test;
+
+import no.nordicsemi.android.mesh.ApplicationKey;
+import no.nordicsemi.android.mesh.data.GlobalAltitude;
+import no.nordicsemi.android.mesh.data.GlobalLatitude;
+import no.nordicsemi.android.mesh.data.GlobalLongitude;
+import no.nordicsemi.android.mesh.utils.MeshParserUtils;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import java.util.ArrayList;
+
+public class GenericLocationClientTests {
+
+    final ApplicationKey applicationKey = new ApplicationKey(
+            0,
+            MeshParserUtils.toByteArray("DEADBEEFDEADBEEFDEADBEEFDEADBEEF"));
+
+    @Test
+    public void testGlobalLatitude() {
+        int[] encodedValues = {0, 0x80000001, 0x7FFFFFFF};
+        double[] values = {0, -90, 90};
+
+        for (int n = 0; n < encodedValues.length; n++) {
+            assertEquals(
+                    GlobalLatitude.of(encodedValues[n]),
+                    GlobalLatitude.encode(values[n]));
+            assertEquals(
+                    GlobalLatitude.of(encodedValues[n]).getDecodedPosition(),
+                    Double.valueOf(values[n]));
+            assertEquals(
+                    GlobalLatitude.of(encodedValues[n]).getClass(),
+                    GlobalLatitude.Coordinate.class);
+        }
+
+        assertEquals(
+                GlobalLatitude.of(0x80000000).getClass(),
+                GlobalLatitude.NotConfigured.class);
+
+
+        assertNull(GlobalLatitude.of(0x80000000).getDecodedPosition());
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> GlobalLatitude.encode(Math.nextDown(-90)));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> GlobalLatitude.encode(Math.nextUp(90)));
+    }
+
+    @Test
+    public void testGlobalLongitude() {
+        int[] encodedValues = {0, 0x80000001, 0x7FFFFFFF};
+        double[] values = {0, -180, 180};
+
+        for (int n = 0; n < encodedValues.length; n++) {
+            assertEquals(
+                    GlobalLongitude.of(encodedValues[n]),
+                    GlobalLongitude.encode(values[n]));
+            assertEquals(
+                    GlobalLongitude.of(encodedValues[n]).getDecodedPosition(),
+                    Double.valueOf(values[n]));
+            assertEquals(
+                    GlobalLongitude.of(encodedValues[n]).getClass(),
+                    GlobalLongitude.Coordinate.class);
+        }
+
+        assertEquals(
+                GlobalLongitude.of(0x80000000).getClass(),
+                GlobalLongitude.NotConfigured.class);
+
+
+        assertNull(GlobalLongitude.of(0x80000000).getDecodedPosition());
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> GlobalLongitude.encode(Math.nextDown(-180)));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> GlobalLongitude.encode(Math.nextUp(180)));
+    }
+
+    @Test
+    public void testGlobalAltitude() {
+        short[] encodedValues = {0, (short) 0x8000, 0x7FFD};
+        int[] values = {0, -32768, 32765};
+
+        for (int n = 0; n < encodedValues.length; n++) {
+            assertEquals(
+                    GlobalAltitude.encode(values[n]),
+                    GlobalAltitude.of(encodedValues[n]));
+            assertEquals(
+                    Integer.valueOf(values[n]),
+                    GlobalAltitude.of(encodedValues[n]).getDecodedPosition());
+            assertEquals(
+                    GlobalAltitude.Coordinate.class,
+                    GlobalAltitude.of(encodedValues[n]).getClass());
+        }
+
+        assertEquals(
+                GlobalAltitude.of((short) 0x7FFF).getClass(),
+                GlobalAltitude.NotConfigured.class);
+        assertNull(GlobalAltitude.of((short) 0x7FFF).getDecodedPosition());
+
+        assertEquals(
+                GlobalAltitude.of((short) 0x7FFE).getClass(),
+                GlobalAltitude.GreaterThanOrEqualTo32766.class);
+        assertNull(GlobalAltitude.of((short) 0x7FFE).getDecodedPosition());
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> GlobalAltitude.encode(-32769));
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> GlobalAltitude.encode(32766));
+    }
+
+    @Test
+    public void testGlobalGet() {
+        GenericLocationGlobalGet message = new GenericLocationGlobalGet(applicationKey);
+        assertNull(message.mParameters);
+    }
+
+    @Test
+    public void testGlobalStatus() {
+        ArrayList<byte[]> encodedValues = new ArrayList<>();
+        encodedValues.add(new byte[]{});
+
+        encodedValues.add(new byte[]{
+                (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+                (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+                (byte) 0x00, (byte) 0x00});
+
+        encodedValues.add(new byte[]{
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0x7F,
+                (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x80,
+                (byte) 0x01, (byte) 0x00});
+
+        ArrayList<Double> latitudes = new ArrayList<>();
+        latitudes.add(null);
+        latitudes.add(0.0);
+        latitudes.add(90.0);
+
+        ArrayList<Double> longitudes = new ArrayList<>();
+        longitudes.add(null);
+        longitudes.add(0.0);
+        longitudes.add(-180.0);
+
+        ArrayList<Integer> altitudes = new ArrayList<>();
+        altitudes.add(null);
+        altitudes.add(0);
+        altitudes.add(1);
+
+        for (int n = 0; n < encodedValues.size(); n++) {
+            AccessMessage accessMessage = new AccessMessage();
+            accessMessage.setParameters(encodedValues.get(n));
+            GenericLocationGlobalStatus message = new GenericLocationGlobalStatus(accessMessage);
+            assertEquals(latitudes.get(n), message.getLatitude().getDecodedPosition());
+            assertEquals(longitudes.get(n), message.getLongitude().getDecodedPosition());
+            assertEquals(altitudes.get(n), message.getAltitude().getDecodedPosition());
+        }
+    }
+
+    @Test
+    public void testGlobalSet() {
+        ArrayList<Double> latitudes = new ArrayList<>();
+        latitudes.add(0.0);
+        latitudes.add(90.0);
+
+        ArrayList<Double> longitudes = new ArrayList<>();
+        longitudes.add(0.0);
+        longitudes.add(-180.0);
+
+        ArrayList<Integer> altitudes = new ArrayList<>();
+        altitudes.add(0);
+        altitudes.add(1);
+
+        ArrayList<byte[]> encodedValues = new ArrayList<>();
+        encodedValues.add(new byte[]{
+                (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+                (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+                (byte) 0x00, (byte) 0x00});
+
+        encodedValues.add(new byte[]{
+                (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0x7F,
+                (byte) 0x01, (byte) 0x00, (byte) 0x00, (byte) 0x80,
+                (byte) 0x01, (byte) 0x00});
+
+
+        for (int n = 0; n < encodedValues.size(); n++) {
+            GenericLocationGlobalSet message = new GenericLocationGlobalSet(
+                    applicationKey,
+                    GlobalLatitude.encode(latitudes.get(n)),
+                    GlobalLongitude.encode(longitudes.get(n)),
+                    GlobalAltitude.encode(altitudes.get(n)));
+            assertArrayEquals(encodedValues.get(n), message.mParameters);
+            GenericLocationGlobalSetUnacknowledged messageUnacknowledged =
+                    new GenericLocationGlobalSetUnacknowledged(
+                            applicationKey,
+                            GlobalLatitude.encode(latitudes.get(n)),
+                            GlobalLongitude.encode(longitudes.get(n)),
+                            GlobalAltitude.encode(altitudes.get(n)));
+            assertArrayEquals(encodedValues.get(n), messageUnacknowledged.mParameters);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the `Global` part of the `Generic Location Client` to the SDK.

Supported messages:
- `Generic Location Global Get`
- `Generic Location Global Set`
- `Generic Location Global Set Unacknowledged`
- `Generic Location Global Status`