### PR TITLE
Refactored setup of MeshMessageState callbacks

### DIFF
--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ApplicationMessageState.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ApplicationMessageState.java
@@ -5,6 +5,8 @@ import java.util.UUID;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import no.nordicsemi.android.mesh.ApplicationKey;
+import no.nordicsemi.android.mesh.InternalTransportCallbacks;
+import no.nordicsemi.android.mesh.MeshStatusCallbacks;
 import no.nordicsemi.android.mesh.utils.MeshAddress;
 
 /**
@@ -17,30 +19,36 @@ class ApplicationMessageState extends MeshMessageState {
     /**
      * Constructs the application message state
      *
-     * @param src           Source address
-     * @param dst           Destination address
-     * @param meshMessage   {@link MeshMessage} to be sent
-     * @param meshTransport {@link MeshTransport} transport
-     * @param callbacks     {@link InternalMeshMsgHandlerCallbacks} callbacks
+     * @param src                Source address
+     * @param dst                Destination address
+     * @param meshMessage        {@link MeshMessage} to be sent
+     * @param meshTransport      {@link MeshTransport} transport
+     * @param handlerCallbacks   {@link InternalMeshMsgHandlerCallbacks} callbacks
+     * @param transportCallbacks {@link InternalTransportCallbacks} callbacks
+     * @param statusCallbacks    {@link MeshStatusCallbacks} callbacks
      * @throws IllegalArgumentException if src or dst address is invalid
      */
     ApplicationMessageState(final int src,
                             final int dst,
                             @NonNull final MeshMessage meshMessage,
                             @NonNull final MeshTransport meshTransport,
-                            @NonNull final InternalMeshMsgHandlerCallbacks callbacks) throws IllegalArgumentException {
-        this(src, dst, null, meshMessage, meshTransport, callbacks);
+                            @NonNull final InternalMeshMsgHandlerCallbacks handlerCallbacks,
+                            @NonNull final InternalTransportCallbacks transportCallbacks,
+                            @NonNull  final MeshStatusCallbacks statusCallbacks) throws IllegalArgumentException {
+        this(src, dst, null, meshMessage, meshTransport, handlerCallbacks, transportCallbacks, statusCallbacks);
     }
 
     /**
      * Constructs the application message state
      *
-     * @param src           Source address
-     * @param dst           Destination address
-     * @param label         Label UUID of destination address
-     * @param meshMessage   {@link MeshMessage} to be sent
-     * @param meshTransport {@link MeshTransport} transport
-     * @param callbacks     {@link InternalMeshMsgHandlerCallbacks} callbacks
+     * @param src                Source address
+     * @param dst                Destination address
+     * @param label              Label UUID of destination address
+     * @param meshMessage        {@link MeshMessage} to be sent
+     * @param meshTransport      {@link MeshTransport} transport
+     * @param handlerCallbacks   {@link InternalMeshMsgHandlerCallbacks} callbacks
+     * @param transportCallbacks {@link InternalTransportCallbacks} callbacks
+     * @param statusCallbacks    {@link MeshStatusCallbacks} callbacks
      * @throws IllegalArgumentException if src or dst address is invalid
      */
     ApplicationMessageState(final int src,
@@ -48,8 +56,10 @@ class ApplicationMessageState extends MeshMessageState {
                             @Nullable final UUID label,
                             @NonNull final MeshMessage meshMessage,
                             @NonNull final MeshTransport meshTransport,
-                            @NonNull final InternalMeshMsgHandlerCallbacks callbacks) throws IllegalArgumentException {
-        super(meshMessage, meshTransport, callbacks);
+                            @NonNull final InternalMeshMsgHandlerCallbacks handlerCallbacks,
+                            @NonNull final InternalTransportCallbacks transportCallbacks,
+                            @NonNull  final MeshStatusCallbacks statusCallbacks) throws IllegalArgumentException {
+        super(meshMessage, meshTransport, handlerCallbacks, transportCallbacks, statusCallbacks);
         this.mSrc = src;
         if (!MeshAddress.isAddressInRange(src)) {
             throw new IllegalArgumentException("Invalid address, a source address must be a valid 16-bit value!");

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/BaseMeshMessageHandler.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/BaseMeshMessageHandler.java
@@ -192,10 +192,7 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
      * @param meshMessage Mesh message
      */
     private DefaultNoOperationMessageState toggleState(@NonNull final MeshTransport transport, @Nullable final MeshMessage meshMessage) {
-        final DefaultNoOperationMessageState state = new DefaultNoOperationMessageState(meshMessage, transport, this);
-        state.setTransportCallbacks(mInternalTransportCallbacks);
-        state.setStatusCallbacks(mStatusCallbacks);
-        return state;
+        return new DefaultNoOperationMessageState(meshMessage, transport, this, mInternalTransportCallbacks, mStatusCallbacks);
     }
 
     /**
@@ -206,9 +203,7 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
     protected MeshMessageState getState(final int address) {
         MeshMessageState state = stateSparseArray.get(address);
         if (state == null) {
-            state = new DefaultNoOperationMessageState(null, getTransport(address), this);
-            state.setTransportCallbacks(mInternalTransportCallbacks);
-            state.setStatusCallbacks(mStatusCallbacks);
+            state = new DefaultNoOperationMessageState(null, getTransport(address), this, mInternalTransportCallbacks, mStatusCallbacks);
             stateSparseArray.put(address, state);
         }
         return state;
@@ -261,9 +256,7 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
      * @param configurationMessage {@link ProxyConfigMessage} Mesh message containing the message opcode and message parameters
      */
     private void createProxyConfigMeshMessage(final int src, final int dst, @NonNull final ProxyConfigMessage configurationMessage) {
-        final ProxyConfigMessageState currentState = new ProxyConfigMessageState(src, dst, configurationMessage, getTransport(dst), this);
-        currentState.setTransportCallbacks(mInternalTransportCallbacks);
-        currentState.setStatusCallbacks(mStatusCallbacks);
+        final ProxyConfigMessageState currentState = new ProxyConfigMessageState(src, dst, configurationMessage, getTransport(dst), this, mInternalTransportCallbacks, mStatusCallbacks);
         stateSparseArray.put(dst, toggleState(currentState.getMeshTransport(), configurationMessage));
         currentState.executeSend();
     }
@@ -279,9 +272,7 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
             return;
         }
 
-        final ConfigMessageState currentState = new ConfigMessageState(src, dst, node.getDeviceKey(), configurationMessage, getTransport(dst), this);
-        currentState.setTransportCallbacks(mInternalTransportCallbacks);
-        currentState.setStatusCallbacks(mStatusCallbacks);
+        final ConfigMessageState currentState = new ConfigMessageState(src, dst, node.getDeviceKey(), configurationMessage, getTransport(dst), this, mInternalTransportCallbacks, mStatusCallbacks);
         if (MeshAddress.isValidUnicastAddress(dst)) {
             stateSparseArray.put(dst, toggleState(getTransport(dst), configurationMessage));
         }
@@ -302,14 +293,12 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
     private void createAppMeshMessage(final int src, final int dst, @NonNull final ApplicationMessage applicationMessage) {
         final ApplicationMessageState currentState;
         if (applicationMessage instanceof VendorModelMessageAcked) {
-            currentState = new VendorModelMessageAckedState(src, dst, (VendorModelMessageAcked) applicationMessage, getTransport(dst), this);
+            currentState = new VendorModelMessageAckedState(src, dst, (VendorModelMessageAcked) applicationMessage, getTransport(dst), this, mInternalTransportCallbacks, mStatusCallbacks);
         } else if (applicationMessage instanceof VendorModelMessageUnacked) {
-            currentState = new VendorModelMessageUnackedState(src, dst, (VendorModelMessageUnacked) applicationMessage, getTransport(dst), this);
+            currentState = new VendorModelMessageUnackedState(src, dst, (VendorModelMessageUnacked) applicationMessage, getTransport(dst), this, mInternalTransportCallbacks, mStatusCallbacks);
         } else {
-            currentState = new ApplicationMessageState(src, dst, applicationMessage, getTransport(dst), this);
+            currentState = new ApplicationMessageState(src, dst, applicationMessage, getTransport(dst), this, mInternalTransportCallbacks, mStatusCallbacks);
         }
-        currentState.setTransportCallbacks(mInternalTransportCallbacks);
-        currentState.setStatusCallbacks(mStatusCallbacks);
         if (MeshAddress.isValidUnicastAddress(dst)) {
             stateSparseArray.put(dst, toggleState(getTransport(dst), applicationMessage));
         }
@@ -332,14 +321,12 @@ public abstract class BaseMeshMessageHandler implements MeshMessageHandlerApi, I
     private void createAppMeshMessage(final int src, final int dst, @NonNull UUID label, @NonNull final ApplicationMessage applicationMessage) {
         final ApplicationMessageState currentState;
         if (applicationMessage instanceof VendorModelMessageAcked) {
-            currentState = new VendorModelMessageAckedState(src, dst, label, (VendorModelMessageAcked) applicationMessage, getTransport(dst), this);
+            currentState = new VendorModelMessageAckedState(src, dst, label, (VendorModelMessageAcked) applicationMessage, getTransport(dst), this, mInternalTransportCallbacks, mStatusCallbacks);
         } else if (applicationMessage instanceof VendorModelMessageUnacked) {
-            currentState = new VendorModelMessageUnackedState(src, dst, label, (VendorModelMessageUnacked) applicationMessage, getTransport(dst), this);
+            currentState = new VendorModelMessageUnackedState(src, dst, label, (VendorModelMessageUnacked) applicationMessage, getTransport(dst), this, mInternalTransportCallbacks, mStatusCallbacks);
         } else {
-            currentState = new ApplicationMessageState(src, dst, label, applicationMessage, getTransport(dst), this);
+            currentState = new ApplicationMessageState(src, dst, label, applicationMessage, getTransport(dst), this, mInternalTransportCallbacks, mStatusCallbacks);
         }
-        currentState.setTransportCallbacks(mInternalTransportCallbacks);
-        currentState.setStatusCallbacks(mStatusCallbacks);
         if (MeshAddress.isValidUnicastAddress(dst)) {
             stateSparseArray.put(dst, toggleState(getTransport(dst), applicationMessage));
         }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ConfigMessageState.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ConfigMessageState.java
@@ -24,6 +24,9 @@ package no.nordicsemi.android.mesh.transport;
 
 import androidx.annotation.NonNull;
 
+import no.nordicsemi.android.mesh.InternalTransportCallbacks;
+import no.nordicsemi.android.mesh.MeshStatusCallbacks;
+
 /**
  * ConfigMessageState class that handles configuration message state.
  */
@@ -34,20 +37,24 @@ class ConfigMessageState extends MeshMessageState {
     /**
      * Constructs the ConfigMessageState
      *
-     * @param src           Source address
-     * @param dst           Destination address
-     * @param deviceKey     Device key
-     * @param meshMessage   {@link MeshMessage} Mesh message to be sent
-     * @param meshTransport {@link MeshTransport} Mesh transport
-     * @param callbacks     {@link InternalMeshMsgHandlerCallbacks} callbacks
+     * @param src                Source address
+     * @param dst                Destination address
+     * @param deviceKey          Device key
+     * @param meshMessage        {@link MeshMessage} Mesh message to be sent
+     * @param meshTransport      {@link MeshTransport} Mesh transport
+     * @param handlerCallbacks   {@link InternalMeshMsgHandlerCallbacks} callbacks
+     * @param transportCallbacks {@link InternalTransportCallbacks} callbacks
+     * @param statusCallbacks    {@link MeshStatusCallbacks} callbacks
      */
     ConfigMessageState(final int src,
                        final int dst,
                        @NonNull final byte[] deviceKey,
                        @NonNull final MeshMessage meshMessage,
                        @NonNull final MeshTransport meshTransport,
-                       @NonNull final InternalMeshMsgHandlerCallbacks callbacks) {
-        super(meshMessage, meshTransport, callbacks);
+                       @NonNull final InternalMeshMsgHandlerCallbacks handlerCallbacks,
+                       @NonNull final InternalTransportCallbacks transportCallbacks,
+                       @NonNull  final MeshStatusCallbacks statusCallbacks) {
+        super(meshMessage, meshTransport, handlerCallbacks, transportCallbacks, statusCallbacks);
         this.mSrc = src;
         this.mDst = dst;
         this.mDeviceKey = deviceKey;

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/DefaultNoOperationMessageState.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/DefaultNoOperationMessageState.java
@@ -10,8 +10,10 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import no.nordicsemi.android.mesh.Features;
 import no.nordicsemi.android.mesh.Group;
+import no.nordicsemi.android.mesh.InternalTransportCallbacks;
 import no.nordicsemi.android.mesh.MeshManagerApi;
 import no.nordicsemi.android.mesh.MeshNetwork;
+import no.nordicsemi.android.mesh.MeshStatusCallbacks;
 import no.nordicsemi.android.mesh.NetworkKey;
 import no.nordicsemi.android.mesh.control.BlockAcknowledgementMessage;
 import no.nordicsemi.android.mesh.control.TransportControlMessage;
@@ -39,14 +41,18 @@ class DefaultNoOperationMessageState extends MeshMessageState {
     /**
      * Constructs the DefaultNoOperationMessageState
      *
-     * @param meshMessage   {@link MeshMessage} Mesh message to be sent
-     * @param meshTransport {@link MeshTransport} Mesh transport
-     * @param callbacks     {@link InternalMeshMsgHandlerCallbacks} callbacks
+     * @param meshMessage        {@link MeshMessage} Mesh message to be sent
+     * @param meshTransport      {@link MeshTransport} Mesh transport
+     * @param handlerCallbacks   {@link InternalMeshMsgHandlerCallbacks} callbacks
+     * @param transportCallbacks {@link InternalTransportCallbacks} callbacks
+     * @param statusCallbacks    {@link MeshStatusCallbacks} callbacks
      */
     DefaultNoOperationMessageState(@Nullable final MeshMessage meshMessage,
                                    @NonNull final MeshTransport meshTransport,
-                                   @NonNull final InternalMeshMsgHandlerCallbacks callbacks) {
-        super(meshMessage, meshTransport, callbacks);
+                                   @NonNull final InternalMeshMsgHandlerCallbacks handlerCallbacks,
+                                   @NonNull final InternalTransportCallbacks transportCallbacks,
+                                   @NonNull  final MeshStatusCallbacks statusCallbacks) {
+        super(meshMessage, meshTransport, handlerCallbacks, transportCallbacks, statusCallbacks);
     }
 
     @Override

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/MeshMessageState.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/MeshMessageState.java
@@ -34,38 +34,26 @@ abstract class MeshMessageState implements LowerTransportLayerCallbacks {
     /**
      * Constructs the base mesh message state class
      *
-     * @param meshMessage   {@link MeshMessage} Mesh message
-     * @param meshTransport {@link MeshTransport} Mesh transport
-     * @param callbacks     {@link InternalMeshMsgHandlerCallbacks} Internal mesh message handler callbacks
+     * @param meshMessage        {@link MeshMessage} Mesh message
+     * @param meshTransport      {@link MeshTransport} Mesh transport
+     * @param handlerCallbacks   {@link InternalMeshMsgHandlerCallbacks} callbacks
+     * @param transportCallbacks {@link InternalTransportCallbacks} callbacks
+     * @param statusCallbacks    {@link MeshStatusCallbacks} callbacks
      */
     MeshMessageState(@Nullable final MeshMessage meshMessage,
                      @NonNull final MeshTransport meshTransport,
-                     @NonNull final InternalMeshMsgHandlerCallbacks callbacks) {
+                     @NonNull final InternalMeshMsgHandlerCallbacks handlerCallbacks,
+                     @NonNull final InternalTransportCallbacks transportCallbacks,
+                     @NonNull  final MeshStatusCallbacks statusCallbacks) {
         this.mMeshMessage = meshMessage;
         if (meshMessage != null) {
             this.message = meshMessage.getMessage();
         }
-        this.meshMessageHandlerCallbacks = callbacks;
+        this.meshMessageHandlerCallbacks = handlerCallbacks;
+        this.mInternalTransportCallbacks = transportCallbacks;
+        this.mMeshStatusCallbacks = statusCallbacks;
         this.mMeshTransport = meshTransport;
         this.mMeshTransport.setLowerTransportLayerCallbacks(this);
-    }
-
-    /**
-     * Set transport callbacks
-     *
-     * @param callbacks callbacks
-     */
-    void setTransportCallbacks(final InternalTransportCallbacks callbacks) {
-        this.mInternalTransportCallbacks = callbacks;
-    }
-
-    /**
-     * Set mesh status call backs
-     *
-     * @param callbacks callbacks
-     */
-    void setStatusCallbacks(final MeshStatusCallbacks callbacks) {
-        this.mMeshStatusCallbacks = callbacks;
     }
 
     /**

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ProxyConfigMessageState.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/ProxyConfigMessageState.java
@@ -24,6 +24,9 @@ package no.nordicsemi.android.mesh.transport;
 
 import androidx.annotation.NonNull;
 
+import no.nordicsemi.android.mesh.InternalTransportCallbacks;
+import no.nordicsemi.android.mesh.MeshStatusCallbacks;
+
 /**
  * This generic state class handles the proxy configuration messages received or sent.
  * <p>
@@ -38,18 +41,22 @@ class ProxyConfigMessageState extends MeshMessageState {
     /**
      * Constructs the ProxyConfigMessageState for sending/receiving proxy configuration messages
      *
-     * @param src           Source address
-     * @param dst           Destination address
-     * @param meshMessage   {@link MeshMessage} Mesh proxy config message
-     * @param meshTransport {@link MeshTransport} Mesh transport
-     * @param callbacks     {@link InternalMeshMsgHandlerCallbacks} Internal callbacks
+     * @param src                Source address
+     * @param dst                Destination address
+     * @param meshMessage        {@link MeshMessage} Mesh proxy config message
+     * @param meshTransport      {@link MeshTransport} Mesh transport
+     * @param handlerCallbacks   {@link InternalMeshMsgHandlerCallbacks} callbacks
+     * @param transportCallbacks {@link InternalTransportCallbacks} callbacks
+     * @param statusCallbacks    {@link MeshStatusCallbacks} callbacks
      */
     ProxyConfigMessageState(final int src,
                             final int dst,
                             @NonNull final MeshMessage meshMessage,
                             @NonNull final MeshTransport meshTransport,
-                            @NonNull final InternalMeshMsgHandlerCallbacks callbacks) {
-        super(meshMessage, meshTransport, callbacks);
+                            @NonNull final InternalMeshMsgHandlerCallbacks handlerCallbacks,
+                            @NonNull final InternalTransportCallbacks transportCallbacks,
+                            @NonNull  final MeshStatusCallbacks statusCallbacks) {
+        super(meshMessage, meshTransport, handlerCallbacks, transportCallbacks, statusCallbacks);
         this.mSrc = src;
         this.mDst = dst;
         createControlMessage();

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/VendorModelMessageAckedState.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/VendorModelMessageAckedState.java
@@ -7,6 +7,8 @@ import java.util.UUID;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import no.nordicsemi.android.mesh.ApplicationKey;
+import no.nordicsemi.android.mesh.InternalTransportCallbacks;
+import no.nordicsemi.android.mesh.MeshStatusCallbacks;
 
 /**
  * State class for handling VendorModelMessageAckedState messages.
@@ -22,15 +24,19 @@ class VendorModelMessageAckedState extends ApplicationMessageState {
      * @param dst                     Destination address to which the message must be sent to
      * @param vendorModelMessageAcked Wrapper class {@link VendorModelMessageStatus} containing the
      *                                opcode and parameters for {@link VendorModelMessageStatus} message
-     * @param callbacks               {@link InternalMeshMsgHandlerCallbacks} for internal callbacks
+     * @param handlerCallbacks          {@link InternalMeshMsgHandlerCallbacks} for internal callbacks
+     * @param transportCallbacks        {@link InternalTransportCallbacks} callbacks
+     * @param statusCallbacks           {@link MeshStatusCallbacks} callbacks
      * @throws IllegalArgumentException exception for invalid arguments
      */
     VendorModelMessageAckedState(final int src,
                                  final int dst,
                                  @NonNull final VendorModelMessageAcked vendorModelMessageAcked,
                                  @NonNull final MeshTransport meshTransport,
-                                 @NonNull final InternalMeshMsgHandlerCallbacks callbacks) throws IllegalArgumentException {
-        this(src, dst, null, vendorModelMessageAcked, meshTransport, callbacks);
+                                 @NonNull final InternalMeshMsgHandlerCallbacks handlerCallbacks,
+                                 @NonNull final InternalTransportCallbacks transportCallbacks,
+                                 @NonNull  final MeshStatusCallbacks statusCallbacks) throws IllegalArgumentException {
+        this(src, dst, null, vendorModelMessageAcked, meshTransport, handlerCallbacks, transportCallbacks, statusCallbacks);
     }
 
     /**
@@ -41,7 +47,9 @@ class VendorModelMessageAckedState extends ApplicationMessageState {
      * @param label                   Label UUID of destination address
      * @param vendorModelMessageAcked Wrapper class {@link VendorModelMessageStatus} containing the
      *                                opcode and parameters for {@link VendorModelMessageStatus} message
-     * @param callbacks               {@link InternalMeshMsgHandlerCallbacks} for internal callbacks
+     * @param handlerCallbacks          {@link InternalMeshMsgHandlerCallbacks} for internal callbacks
+     * @param transportCallbacks        {@link InternalTransportCallbacks} callbacks
+     * @param statusCallbacks           {@link MeshStatusCallbacks} callbacks
      * @throws IllegalArgumentException exception for invalid arguments
      */
     VendorModelMessageAckedState(final int src,
@@ -49,8 +57,10 @@ class VendorModelMessageAckedState extends ApplicationMessageState {
                                  @Nullable UUID label,
                                  @NonNull final VendorModelMessageAcked vendorModelMessageAcked,
                                  @NonNull final MeshTransport meshTransport,
-                                 @NonNull final InternalMeshMsgHandlerCallbacks callbacks) throws IllegalArgumentException {
-        super(src, dst, label, vendorModelMessageAcked, meshTransport, callbacks);
+                                 @NonNull final InternalMeshMsgHandlerCallbacks handlerCallbacks,
+                                 @NonNull final InternalTransportCallbacks transportCallbacks,
+                                 @NonNull  final MeshStatusCallbacks statusCallbacks) throws IllegalArgumentException {
+        super(src, dst, label, vendorModelMessageAcked, meshTransport, handlerCallbacks, transportCallbacks, statusCallbacks);
     }
 
     @Override

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/VendorModelMessageUnackedState.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/VendorModelMessageUnackedState.java
@@ -7,6 +7,8 @@ import java.util.UUID;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import no.nordicsemi.android.mesh.ApplicationKey;
+import no.nordicsemi.android.mesh.InternalTransportCallbacks;
+import no.nordicsemi.android.mesh.MeshStatusCallbacks;
 
 class VendorModelMessageUnackedState extends ApplicationMessageState {
 
@@ -19,15 +21,19 @@ class VendorModelMessageUnackedState extends ApplicationMessageState {
      * @param dst                       Destination address to which the message must be sent to
      * @param vendorModelMessageUnacked Wrapper class {@link VendorModelMessageStatus} containing the
      *                                  opcode and parameters for {@link VendorModelMessageStatus} message
-     * @param callbacks                 {@link InternalMeshMsgHandlerCallbacks} for internal callbacks
+     * @param handlerCallbacks          {@link InternalMeshMsgHandlerCallbacks} for internal callbacks
+     * @param transportCallbacks        {@link InternalTransportCallbacks} callbacks
+     * @param statusCallbacks           {@link MeshStatusCallbacks} callbacks
      * @throws IllegalArgumentException exception for invalid arguments
      */
     VendorModelMessageUnackedState(final int src,
                                    final int dst,
                                    @NonNull final VendorModelMessageUnacked vendorModelMessageUnacked,
                                    @NonNull final MeshTransport meshTransport,
-                                   @NonNull final InternalMeshMsgHandlerCallbacks callbacks) throws IllegalArgumentException {
-        this(src, dst, null, vendorModelMessageUnacked, meshTransport, callbacks);
+                                   @NonNull final InternalMeshMsgHandlerCallbacks handlerCallbacks,
+                                   @NonNull final InternalTransportCallbacks transportCallbacks,
+                                   @NonNull  final MeshStatusCallbacks statusCallbacks) throws IllegalArgumentException {
+        this(src, dst, null, vendorModelMessageUnacked, meshTransport, handlerCallbacks, transportCallbacks, statusCallbacks);
     }
 
     /**
@@ -38,7 +44,9 @@ class VendorModelMessageUnackedState extends ApplicationMessageState {
      * @param label                     Label UUID of destination address
      * @param vendorModelMessageUnacked Wrapper class {@link VendorModelMessageStatus} containing the
      *                                  opcode and parameters for {@link VendorModelMessageStatus} message
-     * @param callbacks                 {@link InternalMeshMsgHandlerCallbacks} for internal callbacks
+     * @param handlerCallbacks          {@link InternalMeshMsgHandlerCallbacks} for internal callbacks
+     * @param transportCallbacks        {@link InternalTransportCallbacks} callbacks
+     * @param statusCallbacks           {@link MeshStatusCallbacks} callbacks
      * @throws IllegalArgumentException exception for invalid arguments
      */
     VendorModelMessageUnackedState(final int src,
@@ -46,8 +54,10 @@ class VendorModelMessageUnackedState extends ApplicationMessageState {
                                    @Nullable UUID label,
                                    @NonNull final VendorModelMessageUnacked vendorModelMessageUnacked,
                                    @NonNull final MeshTransport meshTransport,
-                                   @NonNull final InternalMeshMsgHandlerCallbacks callbacks) throws IllegalArgumentException {
-        super(src, dst, vendorModelMessageUnacked, meshTransport, callbacks);
+                                   @NonNull final InternalMeshMsgHandlerCallbacks handlerCallbacks,
+                                   @NonNull final InternalTransportCallbacks transportCallbacks,
+                                   @NonNull  final MeshStatusCallbacks statusCallbacks) throws IllegalArgumentException {
+        super(src, dst, vendorModelMessageUnacked, meshTransport, handlerCallbacks, transportCallbacks, statusCallbacks);
     }
 
     @Override


### PR DESCRIPTION
Refactored setup of MeshMessageState to take all callbacks in constructor instead of setters.

Seems to fix #447