### PR TITLE
Use shallow copy of lists in more places during db operations.

### DIFF
--- a/mesh/src/main/java/no/nordicsemi/android/mesh/MeshNetworkDb.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/MeshNetworkDb.java
@@ -146,17 +146,17 @@ abstract class MeshNetworkDb extends RoomDatabase {
         databaseWriteExecutor.execute(() -> {
 
             meshNetworkDao.insert(meshNetwork);
-            netKeysDao.insert(meshNetwork.getNetKeys());
-            appKeysDao.insert(meshNetwork.getAppKeys());
-            provisionersDao.insert(meshNetwork.getProvisioners());
+            netKeysDao.insert(new ArrayList<>(meshNetwork.netKeys));
+            appKeysDao.insert(new ArrayList<>(meshNetwork.appKeys));
+            provisionersDao.insert(new ArrayList<>(meshNetwork.provisioners));
             if (!meshNetwork.nodes.isEmpty()) {
-                nodesDao.insert(new ArrayList<>(meshNetwork.getNodes()));
+                nodesDao.insert(new ArrayList<>(meshNetwork.nodes));
             }
             if (meshNetwork.groups != null) {
-                groupsDao.insert(new ArrayList<>(meshNetwork.getGroups()));
+                groupsDao.insert(new ArrayList<>(meshNetwork.groups));
             }
             if (meshNetwork.scenes != null) {
-                scenesDao.insert(new ArrayList<>(meshNetwork.getScenes()));
+                scenesDao.insert(new ArrayList<>(meshNetwork.scenes));
             }
         });
     }
@@ -219,12 +219,12 @@ abstract class MeshNetworkDb extends RoomDatabase {
                     network.partial, MeshTypeConverters.ivIndexToJson(network.ivIndex),
                     network.lastSelected,
                     MeshTypeConverters.networkExclusionsToJson(network.getNetworkExclusions()));
-            netKeyDao.update(network.getNetKeys());
-            appKeyDao.update(network.getAppKeys());
-            provisionersDao.update(network.getProvisioners());
+            netKeyDao.update(new ArrayList<>(network.netKeys));
+            appKeyDao.update(new ArrayList<>(network.appKeys));
+            provisionersDao.update(new ArrayList<>(network.provisioners));
             nodesDao.update(new ArrayList<>(network.nodes));
-            groupsDao.update(network.getGroups());
-            sceneDao.update(network.getScenes());
+            groupsDao.update(new ArrayList<>(network.groups));
+            sceneDao.update(new ArrayList<>(network.scenes));
         });
     }
 


### PR DESCRIPTION
Noted that the list of provisioners also could get concurrent modifications. Figured I'd add the wrapping to the keys as well just for safety.