### PR TITLE
Exclude spongycastle on proguard

### DIFF
--- a/mesh/mesh-proguard-rules.pro
+++ b/mesh/mesh-proguard-rules.pro
@@ -20,3 +20,4 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 -keep class no.nordicsemi.android.mesh.** { *; }
+-keep class org.spongycastle.** { *; }


### PR DESCRIPTION
* This was causing provisioning to halt because public key generation was failing on version 3.1.9