### PR TITLE
Fixes on Generic transition time and scheduler

### DIFF
--- a/mesh/src/test/java/no/nordicsemi/android/mesh/data/GenericTransitionTimeTest.java
+++ b/mesh/src/test/java/no/nordicsemi/android/mesh/data/GenericTransitionTimeTest.java
@@ -1,0 +1,108 @@
+package no.nordicsemi.android.mesh.data;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class GenericTransitionTimeTest {
+
+    @Test
+    public void testResolutionSecondsGivesExpectedValueWithinRange() {
+        GenericTransitionTime timeStart = new GenericTransitionTime(
+                GenericTransitionTime.TransitionResolution.SECOND,
+                GenericTransitionTime.TransitionStep.Specific(0)
+        );
+
+        assertEquals(64, timeStart.getValue());
+
+        GenericTransitionTime timeHigh = new GenericTransitionTime(
+                GenericTransitionTime.TransitionResolution.SECOND,
+                GenericTransitionTime.TransitionStep.Specific(62)
+        );
+
+        assertEquals(126, timeHigh.getValue());
+    }
+
+    @Test
+    public void testResolutionHundredMillisecondsGivesExpectedValueWithinRange() {
+        GenericTransitionTime timeStart = new GenericTransitionTime(
+                GenericTransitionTime.TransitionResolution.HUNDRED_MILLISECONDS,
+                GenericTransitionTime.TransitionStep.Specific(0)
+        );
+
+        assertEquals(0, timeStart.getValue());
+
+        GenericTransitionTime timeHigh = new GenericTransitionTime(
+                GenericTransitionTime.TransitionResolution.HUNDRED_MILLISECONDS,
+                GenericTransitionTime.TransitionStep.Specific(62)
+        );
+
+        assertEquals(62, timeHigh.getValue());
+    }
+
+    @Test
+    public void testResolutionTenSecondsGivesExpectedValueWithinRange() {
+        GenericTransitionTime timeStart = new GenericTransitionTime(
+                GenericTransitionTime.TransitionResolution.TEN_SECONDS,
+                GenericTransitionTime.TransitionStep.Specific(0)
+        );
+
+        assertEquals(128, timeStart.getValue());
+
+        GenericTransitionTime timeHigh = new GenericTransitionTime(
+                GenericTransitionTime.TransitionResolution.TEN_SECONDS,
+                GenericTransitionTime.TransitionStep.Specific(62)
+        );
+
+        assertEquals(190, timeHigh.getValue());
+    }
+
+    @Test
+    public void testResolutionTenMinutesGivesExpectedValueWithinRange() {
+        GenericTransitionTime timeStart = new GenericTransitionTime(
+                GenericTransitionTime.TransitionResolution.TEN_MINUTES,
+                GenericTransitionTime.TransitionStep.Specific(0)
+        );
+
+        assertEquals(192, timeStart.getValue());
+
+        GenericTransitionTime timeHigh = new GenericTransitionTime(
+                GenericTransitionTime.TransitionResolution.TEN_MINUTES,
+                GenericTransitionTime.TransitionStep.Specific(62)
+        );
+
+        assertEquals(254, timeHigh.getValue());
+    }
+
+    @Test
+    public void testGivenValueGivesExpectedTransitionTimeSecond() {
+        GenericTransitionTime time = new GenericTransitionTime(72);
+
+        assertEquals(GenericTransitionTime.TransitionResolution.SECOND, time.resolution);
+        assertEquals(GenericTransitionTime.TransitionStep.Specific(8), time.transitionStep);
+    }
+
+    @Test
+    public void testGivenValueGivesExpectedTransitionTimeHundredMilliseconds() {
+        GenericTransitionTime time = new GenericTransitionTime(8);
+
+        assertEquals(GenericTransitionTime.TransitionResolution.HUNDRED_MILLISECONDS, time.resolution);
+        assertEquals(GenericTransitionTime.TransitionStep.Specific(8), time.transitionStep);
+    }
+
+    @Test
+    public void testGivenValueGivesExpectedTransitionTimeHundredTenSeconds() {
+        GenericTransitionTime time = new GenericTransitionTime(136);
+
+        assertEquals(GenericTransitionTime.TransitionResolution.TEN_SECONDS, time.resolution);
+        assertEquals(GenericTransitionTime.TransitionStep.Specific(8), time.transitionStep);
+    }
+
+    @Test
+    public void testGivenValueGivesExpectedTransitionTimeHundredTenMinutes() {
+        GenericTransitionTime time = new GenericTransitionTime(200);
+
+        assertEquals(GenericTransitionTime.TransitionResolution.TEN_MINUTES, time.resolution);
+        assertEquals(GenericTransitionTime.TransitionStep.Specific(8), time.transitionStep);
+    }
+}

--- a/mesh/src/test/java/no/nordicsemi/android/mesh/transport/SchedulerActionGetTest.java
+++ b/mesh/src/test/java/no/nordicsemi/android/mesh/transport/SchedulerActionGetTest.java
@@ -1,16 +1,11 @@
 package no.nordicsemi.android.mesh.transport;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
 import no.nordicsemi.android.mesh.ApplicationKey;
-import no.nordicsemi.android.mesh.utils.BitReader;
 import no.nordicsemi.android.mesh.utils.MeshParserUtils;
-
-import static org.junit.Assert.assertEquals;
-
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.BitSet;
 
 public class SchedulerActionGetTest {
 

--- a/mesh/src/test/java/no/nordicsemi/android/mesh/transport/SchedulerActionStatusTest.java
+++ b/mesh/src/test/java/no/nordicsemi/android/mesh/transport/SchedulerActionStatusTest.java
@@ -1,51 +1,47 @@
 package no.nordicsemi.android.mesh.transport;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnit;
-import org.mockito.junit.MockitoRule;
+import static org.junit.Assert.assertEquals;
 
-import java.util.ArrayList;
+import org.junit.Test;
+
 import java.util.Arrays;
 
 import no.nordicsemi.android.mesh.data.GenericTransitionTime;
 import no.nordicsemi.android.mesh.data.ScheduleEntry;
-
-import static org.junit.Assert.assertEquals;
+import no.nordicsemi.android.mesh.utils.MeshParserUtils;
 
 public class SchedulerActionStatusTest {
-
-    @Rule
-    public MockitoRule rule = MockitoJUnit.rule();
-
-    byte[] schedulerData = new byte[]{(byte)0x33,(byte) 0x33,(byte) 0x48,(byte) 0x1C,(byte) 0x16, (byte) 0xBC, (byte) 0xC4, (byte)0x50,(byte) 0x11,(byte) 0x40};
-
-    @Mock
-    AccessMessage accessMessage;
 
     @Test
     public void test_reading_data() {
         ScheduleEntry expectedEntry = new ScheduleEntry()
-                .setYear(ScheduleEntry.Year.Specific(20))
-                .setMonth(ScheduleEntry.Month.Any(
-                        Arrays.asList(ScheduleEntry.Month.FEBRUARY, ScheduleEntry.Month.OCTOBER, ScheduleEntry.Month.DECEMBER)))
-                .setDay(ScheduleEntry.Day.Value(8))
-                .setHour(ScheduleEntry.Hour.Value(12))
+                .setYear(ScheduleEntry.Year.Any)
+                .setMonth(ScheduleEntry.Month.Any(Arrays.asList(
+                        ScheduleEntry.Month.JANUARY,
+                        ScheduleEntry.Month.FEBRUARY,
+                        ScheduleEntry.Month.MARCH,
+                        ScheduleEntry.Month.APRIL,
+                        ScheduleEntry.Month.MAY,
+                        ScheduleEntry.Month.JUNE,
+                        ScheduleEntry.Month.JULY,
+                        ScheduleEntry.Month.AUGUST,
+                        ScheduleEntry.Month.SEPTEMBER,
+                        ScheduleEntry.Month.OCTOBER,
+                        ScheduleEntry.Month.NOVEMBER,
+                        ScheduleEntry.Month.DECEMBER)))
+                .setDayOfWeek(ScheduleEntry.DayOfWeek.Any(Arrays.asList(ScheduleEntry.DayOfWeek.WEDNESDAY, ScheduleEntry.DayOfWeek.THURSDAY, ScheduleEntry.DayOfWeek.FRIDAY)))
+                .setHour(ScheduleEntry.Hour.Value(11))
                 .setMinute(ScheduleEntry.Minute.Value(30))
-                .setSecond(ScheduleEntry.Second.Value(45))
-                .setDayOfWeek(ScheduleEntry.DayOfWeek.Any(new ArrayList<>(
-                        Arrays.asList(ScheduleEntry.DayOfWeek.SATURDAY, ScheduleEntry.DayOfWeek.SUNDAY))))
-                .setAction(ScheduleEntry.Action.TurnOn)
-                .setGenericTransitionTime(new GenericTransitionTime(GenericTransitionTime.TransitionResolution.SECOND, GenericTransitionTime.TransitionStep.Specific(8)))
-                .setScene(ScheduleEntry.Scene.Address(0x3333));
+                .setSecond(ScheduleEntry.Second.Value(0))
+                .setAction(ScheduleEntry.Action.TurnOff)
+                .setGenericTransitionTime(new GenericTransitionTime(GenericTransitionTime.TransitionResolution.TEN_SECONDS, GenericTransitionTime.TransitionStep.Specific(17)));
 
-        Mockito.when(accessMessage.getParameters()).thenReturn(schedulerData);
+        AccessMessage am = new AccessMessage();
+        am.setParameters(MeshParserUtils.toByteArray("45FE7FB03C8003910000"));
 
-        SchedulerActionStatus sut = new SchedulerActionStatus(accessMessage);
+        SchedulerActionStatus sut = new SchedulerActionStatus(am);
 
-        assertEquals(0, sut.getIndex());
+        assertEquals(5, sut.getIndex());
         assertEquals(expectedEntry, sut.getEntry());
 
     }


### PR DESCRIPTION
- Fix error in parsing values for Generic Transition Time (MshMDLv1.0.1)
- Expose millis for transition time.
- Fix scheduler action status test.