### PR TITLE
Fixes a possible concurrent modification exception when resetting a node.

### DIFF
--- a/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java
@@ -1358,10 +1358,6 @@ abstract class BaseMeshNetwork {
      * Returns the map of network exclusions
      */
     public Map<Integer, List<Integer>> getNetworkExclusions() {
-        final Map<Integer, List<Integer>> networkExclusions = new HashMap<>();
-        for (Map.Entry<Integer, List<Integer>> entry : this.networkExclusions.entrySet()) {
-            networkExclusions.put(entry.getKey(), Collections.unmodifiableList(entry.getValue()));
-        }
         return Collections.unmodifiableMap(networkExclusions);
     }
 

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/MeshNetworkDb.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/MeshNetworkDb.java
@@ -218,7 +218,7 @@ abstract class MeshNetworkDb extends RoomDatabase {
             networkDao.update(network.meshUUID, network.meshName, network.timestamp,
                     network.partial, MeshTypeConverters.ivIndexToJson(network.ivIndex),
                     network.lastSelected,
-                    MeshTypeConverters.networkExclusionsToJson(network.getNetworkExclusions()));
+                    MeshTypeConverters.networkExclusionsToJson(new HashMap<>(network.getNetworkExclusions())));
             netKeyDao.update(new ArrayList<>(network.netKeys));
             appKeyDao.update(new ArrayList<>(network.appKeys));
             provisionersDao.update(new ArrayList<>(network.provisioners));


### PR DESCRIPTION
* Make a copy of the network exclusions before updating the DB.