### PR TITLE
fix: initial iv index transition date set to null

### DIFF
--- a/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/BaseMeshNetwork.java
@@ -86,7 +86,7 @@ abstract class BaseMeshNetwork {
     @TypeConverters(MeshTypeConverters.class)
     @Expose
     @NonNull
-    IvIndex ivIndex = new IvIndex(0, false, Calendar.getInstance());
+    IvIndex ivIndex = new IvIndex(0, false, null);
     //Properties with Ignore are stored in their own table with the network's UUID as the foreign key
     @Ignore
     @SerializedName("netKeys")

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/IvIndex.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/IvIndex.java
@@ -6,6 +6,7 @@ import android.os.Parcelable;
 import java.util.Calendar;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 /**
  * Class containing the current IV Index State of the network.
@@ -18,6 +19,7 @@ public class IvIndex implements Parcelable {
     private final int ivIndex;
     private final boolean isIvUpdateActive; // False: Normal Operation, True: IV Update in progress
     private boolean ivRecoveryFlag = false;
+    @Nullable
     private Calendar transitionDate;
 
     /**
@@ -27,7 +29,7 @@ public class IvIndex implements Parcelable {
      * @param isIvUpdateActive If true IV Update is in progress and false the network is in Normal operation.
      * @param transitionDate   Time when the last IV Update happened
      */
-    public IvIndex(final int ivIndex, final boolean isIvUpdateActive, final Calendar transitionDate) {
+    public IvIndex(final int ivIndex, final boolean isIvUpdateActive, @Nullable final Calendar transitionDate) {
         this.ivIndex = ivIndex;
         this.isIvUpdateActive = isIvUpdateActive;
         this.transitionDate = transitionDate;
@@ -86,6 +88,7 @@ public class IvIndex implements Parcelable {
         this.ivRecoveryFlag = ivRecoveryFlag;
     }
 
+    @Nullable
     public Calendar getTransitionDate() {
         return transitionDate;
     }
@@ -110,6 +113,9 @@ public class IvIndex implements Parcelable {
         return ivIndex == ivIndex1.ivIndex &&
                 isIvUpdateActive == ivIndex1.isIvUpdateActive &&
                 ivRecoveryFlag == ivIndex1.ivRecoveryFlag &&
-                (transitionDate.getTimeInMillis() == ivIndex1.transitionDate.getTimeInMillis());
+                ((transitionDate == ivIndex1.transitionDate) ||
+                        ((transitionDate != null && ivIndex1.transitionDate != null) &&
+                                (transitionDate.getTimeInMillis() == ivIndex1.transitionDate.getTimeInMillis()))
+                );
     }
 }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/MeshManagerApi.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/MeshManagerApi.java
@@ -323,7 +323,7 @@ public class MeshManagerApi implements MeshMngrApi {
                             final boolean flag = allowIvIndexRecoveryOver42;
                             if (!receivedBeacon.canOverwrite(lastIvIndex, lastTransitionDate, isIvRecoveryActive, isIvTestModeActive, flag)) {
                                 String numberOfHoursSinceDate = ((Calendar.getInstance().getTimeInMillis() -
-                                        lastTransitionDate.getTimeInMillis()) / (3600 * 1000)) + "h";
+                                        (lastTransitionDate != null ? lastTransitionDate.getTimeInMillis() : 0)) / (3600 * 1000)) + "h";
                                 MeshLogger.warn(TAG, "Discarding beacon " + receivedBeacon.getIvIndex() +
                                         ", last " + lastIvIndex.getIvIndex() + ", changed: "
                                         + numberOfHoursSinceDate + " ago, test mode: " + ivUpdateTestModeActive);

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/MeshNetworkDb.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/MeshNetworkDb.java
@@ -910,7 +910,7 @@ abstract class MeshNetworkDb extends RoomDatabase {
                 values.put("mesh_uuid", uuid);
                 values.put("mesh_name", meshName);
                 values.put("timestamp", timestamp);
-                values.put("iv_index", MeshTypeConverters.ivIndexToJson(new IvIndex(ivIndex, ivUpdateState == MeshNetwork.IV_UPDATE_ACTIVE, Calendar.getInstance())));
+                values.put("iv_index", MeshTypeConverters.ivIndexToJson(new IvIndex(ivIndex, ivUpdateState == MeshNetwork.IV_UPDATE_ACTIVE, null)));
                 values.put("sequence_numbers", sequenceNumbers);
                 values.put("last_selected", lastSelected);
                 database.insert("mesh_network_temp", SQLiteDatabase.CONFLICT_REPLACE, values);

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/SecureNetworkBeacon.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/SecureNetworkBeacon.java
@@ -171,6 +171,9 @@ public class SecureNetworkBeacon extends MeshBeacon {
                                                       final Calendar updatedAt,
                                                       final boolean isIvRecoveryActive,
                                                       final boolean isTestMode) {
+        if (updatedAt == null) {
+            return true;
+        }
         // Let's define a "state" as a pair of IV and IV Update Active flag.
         // "States" change as follows:
         // 1. IV = X,   IVUA = false (Normal Operation)


### PR DESCRIPTION
This PR partially fixes #523.

It sets the default transition date to null and thus accepts an iv index update if it's receiving a beacon with higher ivindex in the network for the very first time