### PR TITLE
Adding support for Health Status messages

### DIFF
--- a/mesh/src/main/java/no/nordicsemi/android/mesh/opcodes/ApplicationMessageOpCodes.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/opcodes/ApplicationMessageOpCodes.java
@@ -487,4 +487,15 @@ public class ApplicationMessageOpCodes {
      * Opcode for the "Time Status" message
      */
     public static final int TIME_STATUS = 0x5D;
+
+
+    /**
+     * Opcode for the "Health Current Status" message
+     */
+    public static final int HEALTH_CURRENT_STATUS = 0x04;
+
+    /**
+     * Opcode for the "Health Fault Status" message
+     */
+    public static final int HEALTH_FAULT_STATUS = 0x05;
 }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/DefaultNoOperationMessageState.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/DefaultNoOperationMessageState.java
@@ -500,6 +500,14 @@ class DefaultNoOperationMessageState extends MeshMessageState {
                     final TimeZoneStatus timeZoneStatus = new TimeZoneStatus(message);
                     mInternalTransportCallbacks.updateMeshNetwork(timeZoneStatus);
                     mMeshStatusCallbacks.onMeshMessageReceived(message.getSrc(), timeZoneStatus);
+                } else if (message.getOpCode() == ApplicationMessageOpCodes.HEALTH_CURRENT_STATUS) {
+                    final HealthCurrentStatus healthCurrentStatus = new HealthCurrentStatus(message);
+                    mInternalTransportCallbacks.updateMeshNetwork(healthCurrentStatus);
+                    mMeshStatusCallbacks.onMeshMessageReceived(message.getSrc(), healthCurrentStatus);
+                } else if (message.getOpCode() == ApplicationMessageOpCodes.HEALTH_FAULT_STATUS) {
+                    final HealthFaultStatus healthFaultStatus = new HealthFaultStatus(message);
+                    mInternalTransportCallbacks.updateMeshNetwork(healthFaultStatus);
+                    mMeshStatusCallbacks.onMeshMessageReceived(message.getSrc(), healthFaultStatus);
                 } else if (message.getOpCode() == ApplicationMessageOpCodes.GENERIC_DEFAULT_TRANSITION_TIME_STATUS) {
                     final GenericDefaultTransitionTimeStatus genericDefaultTransitionTimeStatus = new GenericDefaultTransitionTimeStatus(message);
                     mInternalTransportCallbacks.updateMeshNetwork(genericDefaultTransitionTimeStatus);

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/HealthCurrentStatus.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/HealthCurrentStatus.java
@@ -1,0 +1,75 @@
+package no.nordicsemi.android.mesh.transport;
+
+import androidx.annotation.NonNull;
+
+import no.nordicsemi.android.mesh.logger.MeshLogger;
+import no.nordicsemi.android.mesh.opcodes.ApplicationMessageOpCodes;
+import no.nordicsemi.android.mesh.utils.MeshAddress;
+
+public class HealthCurrentStatus extends ApplicationStatusMessage {
+
+    private static final String TAG = HealthCurrentStatus.class.getSimpleName();
+    private static final int HEALTH_CURRENT_STATUS_MANDATORY_LENGTH = 3;
+    private static final int OP_CODE = ApplicationMessageOpCodes.HEALTH_CURRENT_STATUS;
+
+    private int mTestId;
+    private int mCompanyId;
+    private byte[] mFaultArray;
+
+
+    /**
+     * Constructs HealthCurrentStatus message
+     * @param message access message
+     */
+    public HealthCurrentStatus(@NonNull AccessMessage message) {
+        super(message);
+        this.mMessage = message;
+        this.mParameters = message.getParameters();
+        parseStatusParameters();
+    }
+
+    @Override
+    void parseStatusParameters() {
+        MeshLogger.verbose(TAG, "Received health current status from: " + MeshAddress.formatAddress(mMessage.getSrc(), true));
+        mTestId = mParameters[0] & 0xFF;
+        mCompanyId = mParameters[1] & 0xFF  | ((mParameters[2] & 0xFF) << 8);
+        MeshLogger.verbose(TAG, "Test ID: " + mTestId);
+        MeshLogger.verbose(TAG, "Company ID: " + mCompanyId);
+        if (mParameters.length > HEALTH_CURRENT_STATUS_MANDATORY_LENGTH) {
+            mFaultArray = new byte[mParameters.length - HEALTH_CURRENT_STATUS_MANDATORY_LENGTH];
+            System.arraycopy(mParameters, HEALTH_CURRENT_STATUS_MANDATORY_LENGTH, mFaultArray, 0, mParameters.length - 3);
+        }
+    }
+
+    @Override
+    public int getOpCode() {
+        return OP_CODE;
+    }
+
+    /**
+     * Returns the test id of the health status
+     *
+     * @return test id
+     */
+    public int getTestId() {
+        return mTestId;
+    }
+
+    /**
+     * Returns the company id of the health status
+     *
+     * @return company id
+     */
+    public int getCompanyId() {
+        return mCompanyId;
+    }
+
+    /**
+     * Returns the fault array of the health status
+     *
+     * @return fault array
+     */
+    public byte[] getFaultArray() {
+        return mFaultArray;
+    }
+}

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/HealthFaultStatus.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/HealthFaultStatus.java
@@ -18,7 +18,7 @@ public class HealthFaultStatus extends ApplicationStatusMessage {
 
 
     /**
-     * Constructs HealthCurrentStatus message
+     * Constructs HealthFaultStatus message
      * @param message access message
      */
     public HealthFaultStatus(@NonNull AccessMessage message) {
@@ -30,7 +30,7 @@ public class HealthFaultStatus extends ApplicationStatusMessage {
 
     @Override
     void parseStatusParameters() {
-        MeshLogger.verbose(TAG, "Received health current status from: " + MeshAddress.formatAddress(mMessage.getSrc(), true));
+        MeshLogger.verbose(TAG, "Received health fault status from: " + MeshAddress.formatAddress(mMessage.getSrc(), true));
         mTestId = mParameters[0] & 0xFF;
         mCompanyId = mParameters[1] & 0xFF  | ((mParameters[2] & 0xFF) << 8);
         MeshLogger.verbose(TAG, "Test ID: " + mTestId);

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/HealthFaultStatus.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/HealthFaultStatus.java
@@ -1,0 +1,75 @@
+package no.nordicsemi.android.mesh.transport;
+
+import androidx.annotation.NonNull;
+
+import no.nordicsemi.android.mesh.logger.MeshLogger;
+import no.nordicsemi.android.mesh.opcodes.ApplicationMessageOpCodes;
+import no.nordicsemi.android.mesh.utils.MeshAddress;
+
+public class HealthFaultStatus extends ApplicationStatusMessage {
+
+    private static final String TAG = HealthFaultStatus.class.getSimpleName();
+    private static final int HEALTH_CURRENT_STATUS_MANDATORY_LENGTH = 3;
+    private static final int OP_CODE = ApplicationMessageOpCodes.HEALTH_FAULT_STATUS;
+
+    private int mTestId;
+    private int mCompanyId;
+    private byte[] mFaultArray;
+
+
+    /**
+     * Constructs HealthCurrentStatus message
+     * @param message access message
+     */
+    public HealthFaultStatus(@NonNull AccessMessage message) {
+        super(message);
+        this.mMessage = message;
+        this.mParameters = message.getParameters();
+        parseStatusParameters();
+    }
+
+    @Override
+    void parseStatusParameters() {
+        MeshLogger.verbose(TAG, "Received health current status from: " + MeshAddress.formatAddress(mMessage.getSrc(), true));
+        mTestId = mParameters[0] & 0xFF;
+        mCompanyId = mParameters[1] & 0xFF  | ((mParameters[2] & 0xFF) << 8);
+        MeshLogger.verbose(TAG, "Test ID: " + mTestId);
+        MeshLogger.verbose(TAG, "Company ID: " + mCompanyId);
+        if (mParameters.length > HEALTH_CURRENT_STATUS_MANDATORY_LENGTH) {
+            mFaultArray = new byte[mParameters.length - HEALTH_CURRENT_STATUS_MANDATORY_LENGTH];
+            System.arraycopy(mParameters, HEALTH_CURRENT_STATUS_MANDATORY_LENGTH, mFaultArray, 0, mParameters.length - 3);
+        }
+    }
+
+    @Override
+    public int getOpCode() {
+        return OP_CODE;
+    }
+
+    /**
+     * Returns the test id of the health status
+     *
+     * @return test id
+     */
+    public int getTestId() {
+        return mTestId;
+    }
+
+    /**
+     * Returns the company id of the health status
+     *
+     * @return company id
+     */
+    public int getCompanyId() {
+        return mCompanyId;
+    }
+
+    /**
+     * Returns the fault array of the health status
+     *
+     * @return fault array
+     */
+    public byte[] getFaultArray() {
+        return mFaultArray;
+    }
+}


### PR DESCRIPTION
### HealthCurrentStatus and HealthFaultStatus implementation

In order to be able to parse and get information from products with the Health Status, I implemented both HealthCurrentStatus and HealthFaultStatus that can be sent by products after configuring publication on a Health server model. 

