### PR TITLE
Fixes segmentation and reassembly of single-segment segmented messages.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,14 +24,14 @@
 
 buildscript {
 
-    ext.hilt_version = '2.46.1'
+    ext.hilt_version = '2.55'
     repositories {
         google()
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.1.4'
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
         classpath 'io.github.gradle-nexus:publish-plugin:1.3.0'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Oct 18 21:42:22 CEST 2020
+#Wed Jan 29 20:32:48 CET 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/LowerTransportLayer.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/LowerTransportLayer.java
@@ -493,8 +493,9 @@ abstract class LowerTransportLayer extends UpperTransportLayer {
             }
 
             // We need to ensure there could be an unsegmented message that could be sent as a
-            // segmented message i.e. segO = 0 and segN = 0
-            if (segO == segN) {
+            // segmented message i.e. segO = 0 and segN = 0. This will ensure the multi-segmented
+            // messages that may not arrive in order will be reassembled correctly or rather ignored.
+            if (segO == 0 && segN == 0) {
                 if (MeshAddress.isValidUnicastAddress(dst)) {
                     mSegmentedAccessBlockAck = BlockAcknowledgementMessage.calculateBlockAcknowledgement(mSegmentedAccessBlockAck, segO);
                     handleImmediateBlockAcks(seqZero, ttl, blockAckSrc, blockAckDst, segN);


### PR DESCRIPTION
This PR Fixes the following issue

- The library was starting the incomplete timer and waiting for more segments when both Seg 0 and Seg N were 0. The lncomplete timer in the lower transport layer was started upon receiving a message with its `seqAuth > lastSeqAuth, but was ignoring the case where both Seg N and Seg 0 can be zero.