### PR TITLE
Fixes release confugration

### DIFF
--- a/gradle/publish-module.gradle
+++ b/gradle/publish-module.gradle
@@ -5,21 +5,15 @@ apply from: rootProject.file("gradle/git-tag-version.gradle")
 group = GROUP
 version = getVersionNameFromTags()
 
-task androidSourcesJar(type: Jar) {
-    archiveClassifier.set('sources')
+tasks.register('androidSourcesJar', Jar) {
     from android.sourceSets.main.java.srcDirs
-    // from android.sourceSets.main.kotlin.srcDirs
-}
-
-artifacts {
-    archives androidSourcesJar
 }
 
 afterEvaluate {
     publishing {
         publications {
             release(MavenPublication) {
-                from components.findByName('release')
+                from components.release
 
                 artifact androidSourcesJar
 

--- a/mesh/build.gradle
+++ b/mesh/build.gradle
@@ -43,6 +43,14 @@ android {
             consumerProguardFiles 'mesh-proguard-rules.pro'
         }
     }
+    // Upgrading to gradle 8 requires the following configuration
+    // https://stackoverflow.com/questions/67253670/could-not-get-unknown-property-release-for-softwarecomponentinternal-maven-p/77141507#77141507
+    publishing {
+        singleVariant('release') {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 
     testOptions {
         unitTests.returnDefaultValues = true


### PR DESCRIPTION
This pull request includes changes to update Gradle configurations, primarily to support Gradle 8 and improve publication handling. The most important changes involve refactoring the `androidSourcesJar` task and modifying the publication configuration in the `mesh/build.gradle` file and fixes #608.

### Gradle configuration updates:

* [`gradle/publish-module.gradle`](diffhunk://#diff-fd713abb89717cdf3f2ffcd53e924cc7100d8533de79c0b914704659772c2360L8-R16): Refactored the `androidSourcesJar` task to use `tasks.register` instead of the older `task` syntax, improving compatibility with newer Gradle versions. Removed redundant code related to Kotlin source sets and artifacts.
* [`mesh/build.gradle`](diffhunk://#diff-56a11e6eccde5997f0a8f16845470fc91528ada6eb3dec0582d69630ca6fca5cR46-R53): Added a `publishing` block to configure single-variant publication for the `release` variant, including source and Javadoc jars, to address compatibility issues with Gradle 8.