### PR TITLE
Additions for "Health Fault Get" message

### DIFF
--- a/mesh/src/main/java/no/nordicsemi/android/mesh/opcodes/ApplicationMessageOpCodes.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/opcodes/ApplicationMessageOpCodes.java
@@ -543,4 +543,9 @@ public class ApplicationMessageOpCodes {
      * Opcode for the "Health Fault Status" message
      */
     public static final int HEALTH_FAULT_STATUS = 0x05;
+
+    /**
+     * Opcode for the "Health Fault Get" message
+     */
+    public static final int HEALTH_FAULT_GET = 0x8031;
 }

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/HealthFaultGet.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/HealthFaultGet.java
@@ -1,0 +1,36 @@
+package no.nordicsemi.android.mesh.transport;
+
+import androidx.annotation.NonNull;
+
+import no.nordicsemi.android.mesh.ApplicationKey;
+import no.nordicsemi.android.mesh.logger.MeshLogger;
+import no.nordicsemi.android.mesh.opcodes.ApplicationMessageOpCodes;
+import no.nordicsemi.android.mesh.utils.SecureUtils;
+
+public class HealthFaultGet extends ApplicationMessage {
+
+    private static final String TAG = HealthFaultGet.class.getSimpleName();
+    private static final int OP_CODE = ApplicationMessageOpCodes.HEALTH_FAULT_GET;
+    private final int mCompanyId;
+
+    /**
+     * Constructs HealthFaultGet message
+     */
+    public HealthFaultGet(@NonNull final ApplicationKey appKey, final int companyId) {
+        super(appKey);
+        this.mCompanyId = companyId;
+        assembleMessageParameters();
+    }
+
+    @Override
+    public int getOpCode() {
+        return OP_CODE;
+    }
+
+    @Override
+    void assembleMessageParameters() {
+        MeshLogger.verbose(TAG, "Company ID: " + mCompanyId);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
+        mParameters = new byte[]{(byte) mCompanyId, (byte) (mCompanyId >> 8)};
+    }
+}


### PR DESCRIPTION
This pull request introduces support for the "Health Fault Get" message in the Bluetooth Mesh stack. The changes include defining a new opcode and implementing a corresponding transport class to handle the message.

### Additions for "Health Fault Get" message:

* [`mesh/src/main/java/no/nordicsemi/android/mesh/opcodes/ApplicationMessageOpCodes.java`](diffhunk://#diff-b42ac80f5efcfdf9633dc2e7243277b440f2a98d1f2913bd1d60c8307c329da5R546-R550): Added a new opcode constant `HEALTH_FAULT_GET` with the value `0x8031`.
* [`mesh/src/main/java/no/nordicsemi/android/mesh/transport/HealthFaultGet.java`](diffhunk://#diff-fa3812a5b52b62c6ae9d4a39334b68ab07bc2dd461dbb5a72bcbecfd2b5c71e2R1-R36): Implemented the `HealthFaultGet` class, which extends `ApplicationMessage`. This class constructs and assembles the parameters for the "Health Fault Get" message, including logging the company ID.