### PR TITLE
Create HealthFaultClear message and fix heartbeat parsing

### DIFF
--- a/mesh/src/main/java/no/nordicsemi/android/mesh/opcodes/ApplicationMessageOpCodes.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/opcodes/ApplicationMessageOpCodes.java
@@ -616,6 +616,11 @@ public class ApplicationMessageOpCodes {
     public static final int HEALTH_FAULT_STATUS = 0x05;
 
     /**
+     * Opcode for the "Health Fault Clear" message
+     */
+    public static final int HEALTH_FAULT_CLEAR = 0x802F;
+
+    /**
      * Opcode for the "Health Fault Get" message
      */
     public static final int HEALTH_FAULT_GET = 0x8031;

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/DefaultNoOperationMessageState.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/DefaultNoOperationMessageState.java
@@ -573,11 +573,11 @@ class DefaultNoOperationMessageState extends MeshMessageState {
      * @param controlMessage control message received by the transport layer
      */
     private void parseControlMessage(final ControlMessage controlMessage) {
-        //Get the segment count count of the access message
-        final int segmentCount = message.getNetworkLayerPdu().size();
         if (controlMessage.getPduType() == MeshManagerApi.PDU_TYPE_NETWORK) {
             final TransportControlMessage transportControlMessage = controlMessage.getTransportControlMessage();
             if (transportControlMessage.getState() == TransportControlMessage.TransportControlMessageState.LOWER_TRANSPORT_BLOCK_ACKNOWLEDGEMENT) {
+                /* Get the segment count of the access message */
+                final int segmentCount = message.getNetworkLayerPdu().size();
                 MeshLogger.verbose(TAG, "Acknowledgement payload: " + MeshParserUtils.bytesToHex(controlMessage.getTransportControlPdu(), false));
                 final ArrayList<Integer> retransmitPduIndexes = BlockAcknowledgementMessage.getSegmentsToBeRetransmitted(controlMessage.getTransportControlPdu(), segmentCount);
                 mMeshStatusCallbacks.onBlockAcknowledgementReceived(controlMessage.getSrc(), controlMessage);

--- a/mesh/src/main/java/no/nordicsemi/android/mesh/transport/HealthFaultClear.java
+++ b/mesh/src/main/java/no/nordicsemi/android/mesh/transport/HealthFaultClear.java
@@ -1,0 +1,36 @@
+package no.nordicsemi.android.mesh.transport;
+
+import androidx.annotation.NonNull;
+
+import no.nordicsemi.android.mesh.ApplicationKey;
+import no.nordicsemi.android.mesh.logger.MeshLogger;
+import no.nordicsemi.android.mesh.opcodes.ApplicationMessageOpCodes;
+import no.nordicsemi.android.mesh.utils.SecureUtils;
+
+public class HealthFaultClear extends ApplicationMessage {
+
+    private static final String TAG = HealthFaultGet.class.getSimpleName();
+    private static final int OP_CODE = ApplicationMessageOpCodes.HEALTH_FAULT_CLEAR;
+    private final int mCompanyId;
+
+    /**
+     * Constructs HealthFaultClear message
+     */
+    public HealthFaultClear(@NonNull final ApplicationKey appKey, final int companyId) {
+        super(appKey);
+        this.mCompanyId = companyId;
+        assembleMessageParameters();
+    }
+
+    @Override
+    public int getOpCode() {
+        return OP_CODE;
+    }
+
+    @Override
+    void assembleMessageParameters() {
+        MeshLogger.verbose(TAG, "Company ID: " + mCompanyId);
+        mAid = SecureUtils.calculateK4(mAppKey.getKey());
+        mParameters = new byte[]{(byte) mCompanyId, (byte) (mCompanyId >> 8)};
+    }
+}


### PR DESCRIPTION
**Feature Additions:**

* Added support for the "Health Fault Clear" message by introducing the `HealthFaultClear` class and its associated opcode in `ApplicationMessageOpCodes`, enabling the mesh health model to clear registered faults. [[1]](diffhunk://#diff-2a197d17f191368bca446ed10ad712317ec6b880e71d4d67f648447813162014R1-R36) [[2]](diffhunk://#diff-b42ac80f5efcfdf9633dc2e7243277b440f2a98d1f2913bd1d60c8307c329da5R618-R622)

**Bug Fixes and Minor Improvements:**

* Fixed the scope of the segment count calculation in `DefaultNoOperationMessageState.java` to ensure it is only accessed when appropriate.